### PR TITLE
Bond Selection Without RPC

### DIFF
--- a/moldesign/viewer/bondclicker.py
+++ b/moldesign/viewer/bondclicker.py
@@ -39,29 +39,27 @@ class BondClicker(GeometryViewer):
         self.bond_callbacks = []
         self.click_callbacks = []
         self.vdw(radius=self.ATOMRADIUS, render=False)
-        self.draw_all_bonds(render=True)
+        self.draw_all_bonds()
 
     def set_positions(self, *args, **kwargs):
         render = kwargs.get('render',True)
-        kwargs['render'] = False
         super(BondClicker, self).set_positions(*args, **kwargs)
-        self.draw_all_bonds(render=render)
+        self.draw_all_bonds()
 
-    def draw_all_bonds(self, render=True, batch=True):
+    def draw_all_bonds(self, batch=True):
         # TODO: this should be written in javascript, for speed and consistency
         for bond in self.mol.bonds:
-            self.draw_bond(bond, batch=batch, render=False)
-        if render: self.render()
+            self.draw_bond(bond, batch=batch)
 
     def set_bond_color(self, color, bond, render=True):
         self._bond_colors[bond] = color
-        self.draw_bond(bond, render=render)
+        self.draw_bond(bond)
 
     def unset_bond_color(self, bond, render=True):
         self._bond_colors.pop(bond, None)
-        self.draw_bond(bond, render=render)
+        self.draw_bond(bond)
 
-    def draw_bond(self, bond, render=True, batch=False, **shape_args):
+    def draw_bond(self, bond, batch=False, **shape_args):
         atom = bond.a1
         nbr = bond.a2
         order = bond.order
@@ -73,8 +71,7 @@ class BondClicker(GeometryViewer):
 
         assert 'clickable' not in shape_args
         color = self._bond_colors.get(bond, self.BONDCOLOR)
-        kwargs = dict(render=False,
-                      clickable=True,
+        kwargs = dict(clickable=True,
                       color=color,
                       batch=batch)
         kwargs.update(shape_args)
@@ -111,7 +108,6 @@ class BondClicker(GeometryViewer):
         self._bond_shapes[bond] = shapes
         for x in shapes:
             self._bonds[x] = bond
-        if render: self.render()
 
     def handle_click(self, trait_name, old, new):
         if 'pyid' in new:

--- a/moldesign/viewer/bondclicker.py
+++ b/moldesign/viewer/bondclicker.py
@@ -38,7 +38,6 @@ class BondClicker(GeometryViewer):
         self.atom_callbacks = []
         self.bond_callbacks = []
         self.click_callbacks = []
-        self.vdw(radius=self.ATOMRADIUS, render=False)
         self.draw_all_bonds()
 
     def set_positions(self, *args, **kwargs):

--- a/moldesign/widgets/selection.py
+++ b/moldesign/widgets/selection.py
@@ -48,11 +48,7 @@ class BondSelector(SelBase):
 
         self.atom_list.observe(self.remove_bondlist_highlight, 'value')
 
-        self.select_all_bonds_button = ipy.Button(description='Select all bonds')
-        self.select_all_bonds_button.on_click(self.select_all_bonds)
-
         self.subtools.children = [ipy.HBox([self.select_all_atoms_button,
-                                            self.select_all_bonds_button,
                                             self.select_none])]
         self.toolpane.children = (self.atom_listname,
                                   self.atom_list,
@@ -60,12 +56,17 @@ class BondSelector(SelBase):
                                   self.bond_list)
 
     def _atoms_to_bonds(self, atomIndices):
+        return list(self.selected_bonds(atomIndices))
+
+    def selected_bonds(self, *args, **kwargs):
+        atomIndices = kwargs.get('atomIndices', self.viewer.selected_atoms);
         bonds = set()
+
         for bond in self.mol.bonds:
             if bond.a1.index in atomIndices and bond.a2.index in atomIndices:
                 bonds.add(bond)
 
-        return list(bonds)
+        return bonds
 
     def _redraw_selection_state(self):
         currentset = set(self._bondset)
@@ -87,11 +88,7 @@ class BondSelector(SelBase):
     def bondkey(bond):
         return bond.name
 
-    def select_all_bonds(self, *args):
-        self.viewer.selected_bonds = self.mol.bonds
-
     def clear_selections(self, *args):
-        self.viewer.selected_bonds = []
         super(BondSelector, self).clear_selections(*args)
 
 

--- a/moldesign/widgets/selection.py
+++ b/moldesign/widgets/selection.py
@@ -41,9 +41,9 @@ class BondSelector(SelBase):
                                             height=150)
 
         traitlets.directional_link(
-            (self.viewer, 'selected_bonds'),
+            (self.viewer, 'selected_atoms'),
             (self.bond_list, 'options'),
-            lambda selectedBonds: list(selectedBonds)
+            self._atoms_to_bonds
         )
 
         self.atom_list.observe(self.remove_bondlist_highlight, 'value')
@@ -58,6 +58,14 @@ class BondSelector(SelBase):
                                   self.atom_list,
                                   self.bond_listname,
                                   self.bond_list)
+
+    def _atoms_to_bonds(self, atomIndices):
+        bonds = set()
+        for bond in self.mol.bonds:
+            if bond.a1.index in atomIndices and bond.a2.index in atomIndices:
+                bonds.add(bond)
+
+        return list(bonds)
 
     def _redraw_selection_state(self):
         currentset = set(self._bondset)


### PR DESCRIPTION
~~This is branched off of https://github.com/Autodesk/molecular-design-toolkit/pull/87 and waiting on that.~~

![bond_selector](https://cloud.githubusercontent.com/assets/389558/18061315/2836ff1a-6dd7-11e6-916f-e54b466639fd.gif)

For now, this works by selecting the bonds that join selected atoms.  So there is no explicit way to click and select a bond, you have to click and select the two atoms it connects.  This makes things much simpler for now until we come up with a solid way we want to do this.