### PR TITLE
Orbital Visualizer Without RPC

### DIFF
--- a/moldesign/molecules/molecule.py
+++ b/moldesign/molecules/molecule.py
@@ -530,11 +530,14 @@ class MolTopologyMixin(object):
     def to_json(self):
         js = mdt.chemjson.jsonify(self,
             ('name'
-            'properties energy_model integrator').split())
+            'properties integrator').split())
         js['atoms'] = []
         js['bonds'] = []
         js['residues'] = []
         js['chains'] = []
+
+        if self.energy_model:
+            js['energy_model'] = self.energy_model.to_json()
 
         for i, atom in enumerate(self.atoms):
             momenta = []

--- a/moldesign/viewer/viewer3d.py
+++ b/moldesign/viewer/viewer3d.py
@@ -220,10 +220,7 @@ class GeometryViewer(MolViz_3DMol, ColorMixin):
         coords = grid.xyzlist().reshape(3, grid.npoints ** 3).T
         values = orbital(coords)
         grid.fxyz = values.reshape(npts, npts, npts)
-        maxrange = max(r[1]-r[0] for r in (grid.xr, grid.yr, grid.zr))
 
-        # try not to clip the orbitals
-        self.viewer('adjustClipping', [0.6* maxrange.value_in(u.angstrom)])
         return grid
 
     def get_orbnames(self):

--- a/moldesign/widgets/orbitals.py
+++ b/moldesign/widgets/orbitals.py
@@ -111,6 +111,6 @@ class OrbitalUIPane(Selector, ipy.Box):
         viewer = self.viz.viewer
         viewer.orbital_spec['npts'] = int(self.orb_resolution.value)
         if viewer.current_orbital is not None:
-            viewer.draw_orbital(viewer.current_orbital, render=True, **viewer.orbital_spec)
+            viewer.draw_orbital(viewer.current_orbital, **viewer.orbital_spec)
 
 


### PR DESCRIPTION
![screen shot 2016-09-01 at 10 28 50 am](https://cloud.githubusercontent.com/assets/389558/18177402/e9c989fa-702e-11e6-83ca-391a794c643e.png)

This is a small PR; most of the work to get this working happened in notebook-molecular-visualization (https://github.com/Autodesk/notebook-molecular-visualization/pull/9).