### PR TITLE
Atom distance fix

### DIFF
--- a/moldesign/_tests/test_atom_containers.py
+++ b/moldesign/_tests/test_atom_containers.py
@@ -7,9 +7,45 @@ import numpy as np
 import moldesign as mdt
 from moldesign import units as u
 
-@pytest.fixture
+
+registered_types = {}
+
+
+def typedfixture(*types, **kwargs):
+    """This is a decorator that lets us associate fixtures with one or more arbitrary types.
+    We'll later use this type to determine what tests to run on the result"""
+
+    def fixture_wrapper(func):
+        for t in types:
+            registered_types.setdefault(t, []).append(func.__name__)
+        return pytest.fixture(**kwargs)(func)
+
+    return fixture_wrapper
+
+
+@typedfixture('container')
 def protein():
     return mdt.read('data/3AID.pdb')
+
+
+@typedfixture('container')
+def chain(protein):
+    return random.choice(protein.chains)
+
+
+@typedfixture('container')
+def residue(protein):
+    return random.choice(protein.residues)
+
+
+@typedfixture('container')
+def atomlist(protein):
+    return mdt.AtomList(random.sample(protein.atoms, 10))
+
+
+@typedfixture('container')
+def small_molecule():
+    return mdt.from_smiles('c1ccccc1')
 
 
 def test_self_distances_are_0(protein):
@@ -27,37 +63,76 @@ def test_distance_is_minimum_pairwise(protein):
     res2 = protein.residues[2]
 
     assert res1.distance(res2) == _get_minimum_pairwise(res1, res2)
-    assert res1.distance(res2.atoms[3]) == _get_minimum_pairwise(res1, mdt.AtomList(res2.atoms[3]))
+    assert res1.distance(res2.atoms[3]) == _get_minimum_pairwise(res1,
+                                                                 mdt.AtomList([res2.atoms[3]]))
 
 
-def test_center_of_mass_movement(protein):
-    res = protein.residues[0]
-    origpos = res.positions.copy()
+@pytest.mark.parametrize(['f1', 'f2'],
+                         itertools.product(registered_types['container'],
+                                           registered_types['container']))
+def test_pairwise_distance_arrays(f1, f2, request):
+    o1 = request.getfuncargvalue(f1)
+    o2 = request.getfuncargvalue(f2)
 
-    res.positions -= res.center_of_mass
-    np.testing.assert_allclose(res.center_of_mass,
-                               np.zeros(3))
+    array = o1.calc_distance_array(o2)
 
-    res.translate([1.0, 2.0, 3.0] * u.angstrom)
-    np.testing.assert_allclose(res.center_of_mass,
+    if o1.num_atoms * o2.num_atoms > 250:  # stochastically test larger matrices
+        pairs = ((random.randrange(0, o1.num_atoms), random.randrange(0, o2.num_atoms))
+                 for i in xrange(250))
+    else:
+        pairs = itertools.product(xrange(o1.num_atoms), xrange(o2.num_atoms))
+
+    for iatom, jatom in pairs:
+        assert o1.atoms[iatom].distance(o2.atoms[jatom]) == array[iatom, jatom]
+
+
+@pytest.mark.parametrize('fixturename', registered_types['container'])
+def test_center_of_mass_movement(fixturename, request):
+    obj = request.getfuncargvalue(fixturename)
+    origpos = obj.positions.copy()
+
+    obj.positions -= obj.center_of_mass
+    np.testing.assert_allclose(obj.center_of_mass,
+                               np.zeros(3),
+                               atol=1e-10)
+
+    obj.translate([1.0, 2.0, 3.0] * u.angstrom)
+    np.testing.assert_allclose(obj.center_of_mass,
                                [1.0, 2.0, 3.0]*u.angstrom)
 
-    res.rotate(90 * u.degrees, [0,0,1])
-    np.testing.assert_allclose(res.center_of_mass,
-                               [-2.0, -1.0, 3.0]*u.angstrom)
-    res.positions = origpos
+    obj.rotate(90 * u.degrees, [0,0,1])
+    np.testing.assert_allclose(obj.center_of_mass,
+                               [1.0, 2.0, 3.0]*u.angstrom)
+
+    obj.rotate(90 * u.degrees, [0,0,1], center=[0,0,0]*u.angstrom)
+    np.testing.assert_allclose(obj.center_of_mass,
+                               [-2.0, 1.0, 3.0]*u.angstrom)
+    obj.positions = origpos
 
 
-def test_container_properties(protein):
-    myres = random.choice(protein.residues)
-    assert myres.mass == sum([atom.mass for atom in myres.atoms])
-    assert myres.positions == u.array([atom.position for atom in myres.atoms])
+@pytest.mark.parametrize('fixturename', registered_types['container'])
+def test_container_properties(fixturename, request):
+    obj = request.getfuncargvalue(fixturename)
+    assert obj.mass == sum([atom.mass for atom in obj.atoms])
+    np.testing.assert_array_equal(obj.positions.defunits(),
+                                  u.array([atom.position for atom in obj.atoms]).defunits())
+    assert obj.num_atoms == len(obj.atoms)
 
+
+@pytest.mark.parametrize('fixturename', registered_types['container'])
+def test_position_links(fixturename, request):
+    obj = request.getfuncargvalue(fixturename)
+
+    np.testing.assert_array_equal(obj.positions[0, :],
+                                  obj.atoms[0].position)
+    obj.positions[0, :] *= 2.0
+    np.testing.assert_array_equal(obj.positions[0, :],
+                                  obj.atoms[0].position)
 
 def _get_minimum_pairwise(group1, group2):
-    mindist = np.inf
+    mindist = np.inf * u.angstrom
     for a1, a2 in itertools.product(group1.atoms, group2.atoms):
-        distance = np.sqrt(np.dot((a1.position-a2.position)**2))
+        distance = (a1.position-a2.position).norm()
         mindist = min(distance, mindist)
 
     return mindist

--- a/moldesign/_tests/test_atom_containers.py
+++ b/moldesign/_tests/test_atom_containers.py
@@ -1,0 +1,63 @@
+import itertools
+import random
+
+import pytest
+import numpy as np
+
+import moldesign as mdt
+from moldesign import units as u
+
+@pytest.fixture
+def protein():
+    return mdt.read('data/3AID.pdb')
+
+
+def test_self_distances_are_0(protein):
+    res = protein.residues[0]
+
+    assert protein.distance(protein.atoms[0]) == 0.0
+    assert protein.residues[0].distance(protein) == 0.0
+    assert protein.atoms[0].distance(protein.atoms[0]) == 0.0
+    assert res.distance(res) == 0.0
+    assert res.distance(res.chain) == 0.0
+
+
+def test_distance_is_minimum_pairwise(protein):
+    res1 = protein.residues[0]
+    res2 = protein.residues[2]
+
+    assert res1.distance(res2) == _get_minimum_pairwise(res1, res2)
+    assert res1.distance(res2.atoms[3]) == _get_minimum_pairwise(res1, mdt.AtomList(res2.atoms[3]))
+
+
+def test_center_of_mass_movement(protein):
+    res = protein.residues[0]
+    origpos = res.positions.copy()
+
+    res.positions -= res.center_of_mass
+    np.testing.assert_allclose(res.center_of_mass,
+                               np.zeros(3))
+
+    res.translate([1.0, 2.0, 3.0] * u.angstrom)
+    np.testing.assert_allclose(res.center_of_mass,
+                               [1.0, 2.0, 3.0]*u.angstrom)
+
+    res.rotate(90 * u.degrees, [0,0,1])
+    np.testing.assert_allclose(res.center_of_mass,
+                               [-2.0, -1.0, 3.0]*u.angstrom)
+    res.positions = origpos
+
+
+def test_container_properties(protein):
+    myres = random.choice(protein.residues)
+    assert myres.mass == sum([atom.mass for atom in myres.atoms])
+    assert myres.positions == u.array([atom.position for atom in myres.atoms])
+
+
+def _get_minimum_pairwise(group1, group2):
+    mindist = np.inf
+    for a1, a2 in itertools.product(group1.atoms, group2.atoms):
+        distance = np.sqrt(np.dot((a1.position-a2.position)**2))
+        mindist = min(distance, mindist)
+
+    return mindist

--- a/moldesign/_tests/test_qm.py
+++ b/moldesign/_tests/test_qm.py
@@ -53,7 +53,8 @@ def test_pyscf_rhf_sto3g_properties(objkey, request):
     assert 'wfn' in mol.properties
     assert 'canonical' in mol.wfn.orbitals
     assert 'atomic' in mol.wfn.orbitals
-    assert mol.wfn.num_electrons == sum(mol.atoms.atnum) - mol.charge.value_in(u.q_e)
+    assert mol.wfn.num_electrons == sum([atom.atnum for atom in mol.atoms]) \
+                                    - mol.charge.value_in(u.q_e)
 
 
 @pytest.mark.parametrize('objkey', registered_types['molecule'])

--- a/moldesign/interfaces/pyscf_interface.py
+++ b/moldesign/interfaces/pyscf_interface.py
@@ -36,7 +36,7 @@ def mol_to_pyscf(mol, basis, symmetry=None, charge=0, positions=None):
     from pyscf import gto
     pyscfmol = gto.Mole()
 
-    positions = if_not_none(positions, mol.atoms.position)
+    positions = if_not_none(positions, mol.positions)
     pyscfmol.atom = [[atom.elem, pos.value_in(u.angstrom)]
                      for atom, pos in zip(mol.atoms, positions)]
     pyscfmol.basis = basis

--- a/moldesign/molecules/molecule.py
+++ b/moldesign/molecules/molecule.py
@@ -504,8 +504,8 @@ class MolReprMixin(object):
             str
         """
         counts = {}
-        for symbol in self.atoms.symbol:
-            counts[symbol] = counts.get(symbol, 0) + 1
+        for atom in self.atoms:
+            counts[atom.symbol] = counts.get(atom.symbol, 0) + 1
 
         my_elements = sorted(counts.keys())
         if html: template = '%s<sub>%d</sub>'


### PR DESCRIPTION
@justinmc - for review, whenever you get a chance. These are bug fixes (and new test cases) centered around the `.distance` methods that most objects offer.

I ended up simplifying the `AtomList` class, which is used in a lot of different places. I don't *think* this broke anything -  all the tests are still passing.