### PR TITLE
Openbabel forcefields

### DIFF
--- a/moldesign/_tests/test_mm.py
+++ b/moldesign/_tests/test_mm.py
@@ -25,10 +25,12 @@ def typedfixture(*types, **kwargs):
 
 @pytest.fixture
 def small_molecule():
-    return mdt.from_smiles('CNCOS(=O)C')
+    mol = mdt.from_smiles('CNCOS(=O)C')
+    mol.positions += 0.001*np.random.random(mol.positions.shape)*u.angstrom  # move out of minimum
+    return mol
 
 
-@typedfixture('mdready')
+@typedfixture('hasmodel')
 def parameterize_zeros(small_molecule):
     params = mdt.parameterize(small_molecule, charges='zero')
     mol = mdt.assign_forcefield(small_molecule, parameters=params)
@@ -36,7 +38,7 @@ def parameterize_zeros(small_molecule):
     return mol
 
 
-@typedfixture('mdready')
+@typedfixture('hasmodel')
 def parameterize_am1bcc(small_molecule):
     params = mdt.parameterize(small_molecule, charges='am1-bcc', ffname='gaff')
     mol = mdt.assign_forcefield(small_molecule, parameters=params)
@@ -44,7 +46,31 @@ def parameterize_am1bcc(small_molecule):
     return mol
 
 
-@typedfixture('mdready')
+@typedfixture('hasmodel')
+def openbabel_mmff94(small_molecule):
+    small_molecule.set_energy_model(mdt.models.OpenBabelPotential, forcefield='mmff94')
+    return small_molecule
+
+
+@typedfixture('hasmodel')
+def openbabel_mmff94s(small_molecule):
+    small_molecule.set_energy_model(mdt.models.OpenBabelPotential, forcefield='mmff94s')
+    return small_molecule
+
+
+@typedfixture('hasmodel')
+def openbabel_uff(small_molecule):
+    small_molecule.set_energy_model(mdt.models.OpenBabelPotential, forcefield='uff')
+    return small_molecule
+
+
+@typedfixture('hasmodel')
+def openbabel_ghemical(small_molecule):
+    small_molecule.set_energy_model(mdt.models.OpenBabelPotential, forcefield='ghemical')
+    return small_molecule
+
+
+@typedfixture('hasmodel')
 def protein_default_amber_forcefield():
     mol = mdt.from_pdb('1YU8')
     newmol = mdt.assign_forcefield(mol)
@@ -52,14 +78,14 @@ def protein_default_amber_forcefield():
     return newmol
 
 
-@typedfixture('mdready')
+@typedfixture('hasmodel')
 def gaff_model_gasteiger(small_molecule):
     small_molecule.set_energy_model(mdt.models.GAFF, charges='gasteiger')
     return small_molecule
 
 
-@pytest.mark.parametrize('objkey', registered_types['mdready'])
-def test_properties(objkey, request):
+@pytest.mark.parametrize('objkey', registered_types['hasmodel'])
+def test_forces_and_energy_were_calculated(objkey, request):
     mol = request.getfuncargvalue(objkey)
     energy = mol.calculate_potential_energy()
     forces = mol.calculate_forces()
@@ -69,20 +95,26 @@ def test_properties(objkey, request):
 @pytest.mark.skipif(mdt.interfaces.openmm.force_remote,
                     reason="Numerical derivatives need to be parallelized, "
                            "otherwise this takes too long")
-@pytest.mark.parametrize('objkey', registered_types['mdready'])
-def test_forces(objkey, request):
+@pytest.mark.parametrize('objkey', registered_types['hasmodel'])
+def test_analytical_vs_numerical_forces(objkey, request):
     mol = request.getfuncargvalue(objkey)
 
-    anagrad = -mol.calculate_forces().defunits_value()
+    if mol.num_atoms > 20:
+        atoms = random.sample(mol.atoms, 20)
+    else:
+        atoms = mol.atoms
+    atom_indices = [atom.index for atom in atoms]
+
+    anagrad = -mol.calculate_forces()#[atom_indices]
     numgrad = helpers.num_grad(mol,
                                mol.calculate_potential_energy,
-                               step=0.005*u.angstrom
-                               ).defunits_value()
-    assert np.sqrt(np.sum((anagrad-numgrad) ** 2))/(3.0*mol.num_atoms) <= 1.0e-4  # this isn't good
+                               #atoms=atoms,
+                               step=0.005*u.angstrom)
+    assert (anagrad-numgrad).norm()/(3.0*len(atoms)) <= 1.0e-4 * u.eV / u.angstrom
 
 
-@pytest.mark.parametrize('objkey', registered_types['mdready'])
-def test_minimize(objkey, request):
+@pytest.mark.parametrize('objkey', registered_types['hasmodel'])
+def test_minimization_reduces_energy(objkey, request):
     mol = request.getfuncargvalue(objkey)
     e1 = mol.calculate_potential_energy()
     mol = request.getfuncargvalue(objkey)

--- a/moldesign/_tests/test_mm.py
+++ b/moldesign/_tests/test_mm.py
@@ -105,10 +105,10 @@ def test_analytical_vs_numerical_forces(objkey, request):
         atoms = mol.atoms
     atom_indices = [atom.index for atom in atoms]
 
-    anagrad = -mol.calculate_forces()#[atom_indices]
+    anagrad = -mol.calculate_forces()[atom_indices]
     numgrad = helpers.num_grad(mol,
                                mol.calculate_potential_energy,
-                               #atoms=atoms,
+                               atoms=atoms,
                                step=0.005*u.angstrom)
     assert (anagrad-numgrad).norm()/(3.0*len(atoms)) <= 1.0e-4 * u.eV / u.angstrom
 

--- a/moldesign/models/__init__.py
+++ b/moldesign/models/__init__.py
@@ -3,4 +3,5 @@ from .pyscf import *
 from .models import *
 from .toys import *
 from .amber import *
+from .openbabel import *
 

--- a/moldesign/models/openbabel.py
+++ b/moldesign/models/openbabel.py
@@ -52,7 +52,7 @@ class OpenBabelPotential(EnergyModelBase):
 
         self._prepped = True
 
-    #@mdt.compute.runsremotely(enable=mdt.interfaces.openbabel.force_remote, is_imethod=True)
+    @mdt.compute.runsremotely(enable=mdt.interfaces.openbabel.force_remote, is_imethod=True)
     def calculate(self, requests):
         import openbabel as ob
 
@@ -75,8 +75,9 @@ class OpenBabelPotential(EnergyModelBase):
                                          forces=forces*self._units/u.angstrom)
         return result
 
-    # run the entire minimization remotely for speed
-    #@mdt.compute.runsremotely(enable=mdt.interfaces.openbabel.force_remote, is_imethod=True)
+
+    # if necessary, run the entire minimization remotely for speed
+    @mdt.compute.runsremotely(enable=mdt.interfaces.openbabel.force_remote, is_imethod=True)
     def minimize(self, **kwargs):
         super(OpenBabelPotential, self).minimize(**kwargs)
 

--- a/moldesign/models/openbabel.py
+++ b/moldesign/models/openbabel.py
@@ -1,0 +1,70 @@
+# Copyright 2016 Autodesk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+""" Energy models using OpenBabel's heuristic, highly approximate drug forcefields
+"""
+from __future__ import absolute_import
+
+import openbabel as ob
+
+import moldesign as mdt
+from moldesign import units as u
+from .base import EnergyModelBase
+
+
+class OpenBabelPotential(EnergyModelBase):
+    DEFAULT_PROPERTIES = ['potential_energy', 'forces']
+    ALL_PROPERTIES = DEFAULT_PROPERTIES
+    PARAMETERS = [mdt.parameters.Parameter(name='forcefield',
+                                           short_description='Forcefield selection',
+                                           type=str,
+                                           default='mmff94s',
+                                           choices=['ghemical', 'mmff94', 'mmff94s', 'uff'])]
+    FORCE_UNITS = u.hartree / u.bohr
+
+    FFNAMES = {n: n.capitalize() for n in ['ghemical', 'mmff94', 'mmff94s', 'uff']}
+
+    def prep(self):
+        if self._prepped:
+            return
+        self._pbmol = mdt.interfaces.openbabel.mol_to_pybel(self.mol)
+        self._ff = ob.OBForceField.FindForceField(self.FFNAMES[self.params.forcefield])
+        self._ff.Setup(self._pbmol.OBMol)
+
+        assert self._ff.GetUnit() == 'kcal/mol'
+        self._prepped = True
+
+    def calculate(self, requests):
+        self.prep()
+        for atom, pbatom in zip(self.mol.atoms, self._pbmol.atoms):
+            pbatom.OBAtom.SetVector(*atom.position.value_in(u.angstrom))
+        self._ff.UpdateCoordinates(self._pbmol.OBMol)
+
+        energy = self._ff.Energy(True)
+        data = ob.toConformerData(self._pbmol.OBMol.GetData(4))
+        forces = []
+
+        for iatom, f in enumerate(data.GetForces()[0]):
+            forces.append([f.GetX(), f.GetY(), f.GetZ()])
+
+        result = mdt.MolecularProperties(self.mol,
+                                         potential_energy=energy*u.kcalpermol,
+                                         forces=forces*u.kcalpermol/u.angstrom)
+
+        return result
+
+
+
+
+
+

--- a/moldesign/models/openbabel.py
+++ b/moldesign/models/openbabel.py
@@ -30,6 +30,7 @@ __all__ = []
 FFNAMES = {n: n.capitalize() for n in ['ghemical', 'mmff94', 'mmff94s', 'uff']}
 UNITNAMES = {'kcal/mol': u.kcalpermol, 'kJ/mol': u.kjpermol}
 
+
 @exports
 class OpenBabelPotential(EnergyModelBase):
     DEFAULT_PROPERTIES = ['potential_energy', 'forces']
@@ -58,12 +59,12 @@ class OpenBabelPotential(EnergyModelBase):
         self.prep()
         for atom, pbatom in zip(self.mol.atoms, self._pbmol.atoms):
             pbatom.OBAtom.SetVector(*atom.position.value_in(u.angstrom))
-        self._ff.UpdateCoordinates(self._pbmol.OBMol)
+        self._ff.SetCoordinates(self._pbmol.OBMol)
         energy = self._ff.Energy(True)
+        self._ff.GetCoordinates(self._pbmol.OBMol)
 
-        # these next two lines are a complete mystery to me. Comes from
         # http://forums.openbabel.org/Doing-an-energ-force-calculation-with-openbabel-td1590730.html
-        data = ob.toConformerData(self._pbmol.OBMol.GetData(4))
+        data = ob.toConformerData(self._pbmol.OBMol.GetData(4))  # 4 == OBConformerData constant
         force_iterator = data.GetForces()[0]
 
         forces = np.array([[f.GetX(), f.GetY(), f.GetZ()] for f in force_iterator])

--- a/moldesign/models/openbabel.py
+++ b/moldesign/models/openbabel.py
@@ -64,7 +64,7 @@ class OpenBabelPotential(EnergyModelBase):
         self._ff.GetCoordinates(self._pbmol.OBMol)
 
         # http://forums.openbabel.org/Doing-an-energ-force-calculation-with-openbabel-td1590730.html
-        data = ob.toConformerData(self._pbmol.OBMol.GetData(4))  # 4 == OBConformerData constant
+        data = ob.toConformerData(self._pbmol.OBMol.GetData(ob.ConformerData))
         force_iterator = data.GetForces()[0]
 
         forces = np.array([[f.GetX(), f.GetY(), f.GetZ()] for f in force_iterator])
@@ -80,7 +80,3 @@ class OpenBabelPotential(EnergyModelBase):
     @mdt.compute.runsremotely(enable=mdt.interfaces.openbabel.force_remote, is_imethod=True)
     def minimize(self, **kwargs):
         super(OpenBabelPotential, self).minimize(**kwargs)
-
-
-
-

--- a/moldesign/utils/callsigs.py
+++ b/moldesign/utils/callsigs.py
@@ -86,6 +86,7 @@ def args_from(original_function,
                                           default=default)
                 newparams.append(newp)
 
+        newparams.sort(key=lambda param: param._kind)
         sig = sig.replace(parameters=newparams)
 
     else:


### PR DESCRIPTION
This adds a set of new, very fast (but not particularly reliable) energy models implemented in OpenBabel. This specifically gives access to OB's drug docking / conformer generation forcefields: mmff94, mmff94s, uff, and ghemical.

~~This shouldn't be merged until I figure out why the (currently commented out) remote execution decorators `@mdt.compute.runsremotely` cause everything to fail at import~~ fixed
