### PR TITLE
Atom selection helpers

### DIFF
--- a/moldesign/_tests/test_atom_containers.py
+++ b/moldesign/_tests/test_atom_containers.py
@@ -217,3 +217,5 @@ def test_setlike_atomlist_methods(protein):
 
     assert l1 - l2 == protein.atoms[:5]
     assert l2 - l1 == protein.atoms[10:15]
+
+    assert (l1 + l2).unique() == protein.atoms[:15]

--- a/moldesign/_tests/test_atom_containers.py
+++ b/moldesign/_tests/test_atom_containers.py
@@ -201,3 +201,19 @@ def test_residues_within(fixturename, request):
             assert residue in within5
         else:
             assert residue not in within5
+
+
+def test_setlike_atomlist_methods(protein):
+    l1 = protein.atoms[:10]
+    assert isinstance(l1, mdt.AtomList)
+    l2 = protein.atoms[5:15]
+
+    assert l1.union(l2) == protein.atoms[:15]
+    assert l2.union(l1) == protein.atoms[5:15] + protein.atoms[:5]
+
+    interx = l1.intersection(l2)
+    assert interx == protein.atoms[5:10]
+    assert l2.intersection(l1) == interx
+
+    assert l1 - l2 == protein.atoms[:5]
+    assert l2 - l1 == protein.atoms[10:15]

--- a/moldesign/molecules/atomcollections.py
+++ b/moldesign/molecules/atomcollections.py
@@ -468,3 +468,9 @@ class AtomList(AtomContainer):
     def __repr__(self):
         return '<%s: %s>' % (type(self).__name__, self.atoms)
 
+    def intersection(self):
+        raise NotImplementedError()
+
+    def union(self):
+        raise NotImplementedError()
+

--- a/moldesign/molecules/atomcollections.py
+++ b/moldesign/molecules/atomcollections.py
@@ -15,6 +15,8 @@
 import copy
 
 import collections
+
+import itertools
 import numpy as np
 
 import moldesign as mdt
@@ -433,44 +435,86 @@ class AtomContainer(object):
 
 
 @toplevel
-class AtomList(AtomContainer):
-    """A list of atoms that allows attribute "slicing" - accessing an attribute of the
-    list will return a list of atom attributes.
+class AtomList(list, AtomContainer):
+    """ A list of atoms with various helpful methods for creating and manipulating atom selections
 
     Args:
         atomlist (List[AtomContainer]): list of objects that are either atoms or contain a list of
            atoms at ``atomlist.atoms``
     """
-
-    append = mdt.utils.Alias('atoms.append')
-    pop = mdt.utils.Alias('atoms.pop')
-    insert = mdt.utils.Alias('atoms.insert')
-    sort = mdt.utils.Alias('atoms.sort')
-
-    def __init__(self, atomlist):
-        self.atoms = []
+    def __init__(self, atomlist=()):
+        atoms = []
         for obj in atomlist:
             if hasattr(obj, 'atoms'):
-                self.atoms.extend(obj.atoms)
+                atoms.extend(obj.atoms)
             else:
-                self.atoms.append(obj)
-        super(AtomList, self).__init__()
-
-    def __iter__(self):
-        return iter(self.atoms)
+                atoms.append(obj)
+        super(AtomList, self).__init__(atoms)
 
     def __getitem__(self, item):
-        return self.atoms[item]
+        result = super(AtomList, self).__getitem__(item)
+        if isinstance(item, slice):
+            return type(self)(result)
+        else:
+            return result
+
+    def __getslice__(self, i, j):
+        result = super(AtomList, self).__getslice__(i, j)
+        return type(self)(result)
 
     def __str__(self):
-        return str(self.atoms)
+        return '[Atoms: %s]' % ', '.join(atom._shortstr() for atom in self)
 
     def __repr__(self):
-        return '<%s: %s>' % (type(self).__name__, self.atoms)
+        try:
+            return '<AtomList: [%s]>' % ', '.join(atom._shortstr() for atom in self)
+        except:
+            return '<AtomList at %x (__repr__ failed)>' % id(self)
 
-    def intersection(self):
-        raise NotImplementedError()
+    def intersection(self, *otherlists):
+        """ Return a list of atoms that appear in all lists (including this one).
 
-    def union(self):
-        raise NotImplementedError()
+        Args:
+            *otheriters (Iterable): one or more lists of atoms
 
+        Returns:
+            moldesign.AtomList: intersection of this lists with all passed lists. Preserves order
+              in this list
+        """
+        s = set(self).intersection(*otherlists)
+        return type(self)(o for o in self if o in s)
+
+    def union(self, *otherlists):
+        """ Return a list of atoms that appear in any lists (including this one).
+
+        Args:
+            *otherlists (Iterable): one or more lists of atoms
+
+        Returns:
+            moldesign.AtomList: union of this list of atoms with all passed lists of atoms.
+               Equivalent to concatenating all lists then removing duplicates
+        """
+        found = set()
+        newlist = type(self)()
+        for item in itertools.chain(self, *otherlists):
+            if item not in found:
+                found.add(item)
+                newlist.append(item)
+        return newlist
+
+    def unique(self):
+        """ Return only unique atoms from this list
+
+        Returns:
+            moldesign.AtomList: copy of this list without any duplicates. Preserves order.
+        """
+        return self.union()
+
+    def __sub__(self, other):
+        otherset = set(other)
+        return type(self)(atom for atom in self if atom not in otherset)
+
+    # alas for self so that this works with AtomContainer methods
+    @property
+    def atoms(self):
+        return self

--- a/moldesign/molecules/atoms.py
+++ b/moldesign/molecules/atoms.py
@@ -179,8 +179,17 @@ class AtomReprMixin(object):
                 molstring += ' (res %s chain %s)' % (self.residue.name, self.chain.name)
         return '%s%s' % (desc, molstring)
 
+    def _shortstr(self):
+        """ A shorter string representation for easier-to-read lists of atoms
+        """
+        fields = [self.name]
+        if self.molecule:
+            fields.append('#%d' % self.index)
+            if self.molecule.is_biomolecule:
+                fields.append('in %s.%s' % (self.chain.name, self.residue.name))
+        return ' '.join(fields)
+
     def __repr__(self):
-        # TODO: rename parent to "molecule"
         try:
             if self.molecule:
                 return '<%s in molecule %s>' % (self, self.molecule)

--- a/moldesign/molecules/atoms.py
+++ b/moldesign/molecules/atoms.py
@@ -96,6 +96,10 @@ class AtomGeometryMixin(object):
     def atoms_within(self, *args, **kwargs):
         return self._container.atoms_within(*args, **kwargs)
 
+    @utils.args_from(AtomContainer.residues_within)
+    def residues_within(self, *args, **kwargs):
+        return self._container.residues_within(*args, **kwargs)
+
     @utils.args_from(AtomContainer.calc_distance_array)
     def calc_distances(self, *args, **kwargs):
         array = self._container.calc_distance_array(*args, **kwargs)

--- a/moldesign/molecules/biounits.py
+++ b/moldesign/molecules/biounits.py
@@ -30,7 +30,7 @@ class ChildList(AtomContainer):
 
     def __repr__(self):
         try:
-            return '<Children of %s: %s>' % (self.parent, mdt.AtomList.__)
+            return '<Children of %s: %s>' % (self.parent, self)
         except:
             return '<ChildList @ %x (__repr__ failed)>' % id(self)
 

--- a/moldesign/molecules/biounits.py
+++ b/moldesign/molecules/biounits.py
@@ -30,7 +30,7 @@ class ChildList(AtomContainer):
 
     def __repr__(self):
         try:
-            return '<Children of %s: %s>' % (self.parent, self)
+            return '<Children of %s: %s>' % (self.parent, mdt.AtomList.__)
         except:
             return '<ChildList @ %x (__repr__ failed)>' % id(self)
 

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ class PostInstall(install):
         install.run(self)
         self.prompt_intro()
 
-    def prompt_intro(self):  # this doesn't actually display - print statements don't work?
+    def prompt_intro(self):
         print 'Thank you for installing the Molecular Design Toolkit!!!'
         print 'For help, documentation, and any questions, visit us at '
         print '    http://moldesign.bionano.autodesk.com/'


### PR DESCRIPTION
This PR collects and rationalizes various tools for selecting groups of atoms. Specifically:
- Adds `AtomContainer.residues_within` method (to select all residues within a certain radius, similar to `AtomContainer.atoms_within`
- Simplifies the `AtomList` class implementation
- Give `AtomLists` set-like methods `intersection`, `union`, `unique`, and allow subtraction
- `AtomLists` will automatically unroll lists of AtomContainers, so `AtomList([residue1, atom2, chain3])` will create a list of all the atoms in those objects 

Still to do (in a separate PR):
- [ ] viz methods will automatically unroll lists of lists
- [ ] `residue.atoms` should offer `AtomList` methods and functionality  
