### PR TITLE
Parmed PDB / mmCIF integration

### DIFF
--- a/moldesign/_tests/data/1KBU.cif
+++ b/moldesign/_tests/data/1KBU.cif
@@ -1,0 +1,9607 @@
+data_1KBU
+# 
+_entry.id   1KBU 
+# 
+_audit_conform.dict_name       mmcif_pdbx.dic 
+_audit_conform.dict_version    4.007 
+_audit_conform.dict_location   http://mmcif.pdb.org/dictionaries/ascii/mmcif_pdbx.dic 
+# 
+loop_
+_database_2.database_id 
+_database_2.database_code 
+PDB  1KBU       
+NDB  PD0271     
+RCSB RCSB014787 
+# 
+loop_
+_database_PDB_rev.num 
+_database_PDB_rev.date 
+_database_PDB_rev.date_original 
+_database_PDB_rev.status 
+_database_PDB_rev.replaces 
+_database_PDB_rev.mod_type 
+1 2002-06-07 2001-11-06 ? 1KBU 0 
+2 2009-02-24 ?          ? 1KBU 1 
+# 
+_database_PDB_rev_record.rev_num   2 
+_database_PDB_rev_record.type      VERSN 
+_database_PDB_rev_record.details   ? 
+# 
+loop_
+_pdbx_database_related.db_name 
+_pdbx_database_related.db_id 
+_pdbx_database_related.details 
+_pdbx_database_related.content_type 
+PDB 3CRX '3crx is Cre recombinase-Holliday junction complex.' unspecified 
+PDB 2CRX '2crx is Cre recombinase-Holliday junction complex.' unspecified 
+PDB 4CRX '4crx is Cre/Lox Precleavage complex.'               unspecified 
+PDB 1CRX '1crx is Cre/Lox covalent intermediate.'             unspecified 
+PDB 1F44 '1f44 is Cre trimer/Lox Y-junction complex.'         unspecified 
+PDB 1DRG '1drg is Cre trimer/Lox Y-junction complex.'         unspecified 
+# 
+_pdbx_database_status.status_code      REL 
+_pdbx_database_status.entry_id         1KBU 
+_pdbx_database_status.deposit_site     RCSB 
+_pdbx_database_status.process_site     RCSB 
+_pdbx_database_status.status_code_sf   REL 
+_pdbx_database_status.SG_entry         . 
+# 
+loop_
+_audit_author.name 
+_audit_author.pdbx_ordinal 
+'Martin, S.S.'  1 
+'Pulido, E.'    2 
+'Chu, V.C.'     3 
+'Lechner, T.'   4 
+'Baldwin, E.P.' 5 
+# 
+loop_
+_citation.id 
+_citation.title 
+_citation.journal_abbrev 
+_citation.journal_volume 
+_citation.page_first 
+_citation.page_last 
+_citation.year 
+_citation.journal_id_ASTM 
+_citation.country 
+_citation.journal_id_ISSN 
+_citation.journal_id_CSD 
+_citation.book_publisher 
+_citation.pdbx_database_id_PubMed 
+_citation.pdbx_database_id_DOI 
+primary 
+;The Order of Strand Exchanges in Cre-LoxP Recombination and its Basis Suggested by the Crystal Structure of a 
+    Cre-LoxP Holliday Junction Complex
+;
+J.Mol.Biol. 319 107  127  2002 JMOBAK UK 0022-2836 0070 ? 12051940 '10.1016/S0022-2836(02)00246-2' 
+1       'Structure of the Holliday Junction Intermediate in Cre-loxP Site-Specific Recombination' 'Embo J.'   17  4175 4187 1998 
+EMJODG UK 0261-4189 0897 ? ?        10.1093/emboj/17.14.4175        
+2       
+;Quasi-Equivalence in Site-Specific Recombinase Structure and Function: Crystal Structure and Activity of Trimeric Cre Recombinase Bound to a Three-Way Lox DNA Junction
+;
+J.Mol.Biol. 313 49   69   2001 JMOBAK UK 0022-2836 0070 ? ?        10.1006/jmbi.2001.5012          
+# 
+loop_
+_citation_author.citation_id 
+_citation_author.name 
+_citation_author.ordinal 
+primary 'Martin, S.S.'    1  
+primary 'Pulido, E.'      2  
+primary 'Chu, V.C.'       3  
+primary 'Lechner, T.S.'   4  
+primary 'Baldwin, E.P.'   5  
+1       'Gopaul, D.N.'    6  
+1       'Guo, F.'         7  
+1       'van Duyne, G.D.' 8  
+2       'Woods, K.C.'     9  
+2       'Martin, S.S.'    10 
+2       'Chu, V.C.'       11 
+2       'Baldwin, E.P.'   12 
+# 
+_cell.entry_id           1KBU 
+_cell.length_a           107.170 
+_cell.length_b           121.600 
+_cell.length_c           179.310 
+_cell.angle_alpha        90.00 
+_cell.angle_beta         90.00 
+_cell.angle_gamma        90.00 
+_cell.Z_PDB              16 
+_cell.pdbx_unique_axis   ? 
+# 
+_symmetry.entry_id                         1KBU 
+_symmetry.space_group_name_H-M             'C 2 2 21' 
+_symmetry.pdbx_full_space_group_name_H-M   ? 
+_symmetry.cell_setting                     ? 
+_symmetry.Int_Tables_number                ? 
+# 
+loop_
+_entity.id 
+_entity.type 
+_entity.src_method 
+_entity.pdbx_description 
+_entity.formula_weight 
+_entity.pdbx_number_of_molecules 
+_entity.details 
+_entity.pdbx_mutation 
+_entity.pdbx_fragment 
+_entity.pdbx_ec 
+1 polymer syn LOXP              10510.898 1   'part of Holliday junction' ? ? ? 
+2 polymer syn LOXP              10399.838 1   'part of Holliday junction' ? ? ? 
+3 polymer man 'CRE RECOMBINASE' 39424.367 2   
+'LYS86 AND LYS201 INTERACTIONS WITH THE SCISSILE BASE SUGGEST HOW STRAND EXCHANGE ORDER IS DETERMINED' ? ? ? 
+4 water   nat water             18.015    237 ? ? ? ? 
+# 
+loop_
+_entity_keywords.entity_id 
+_entity_keywords.text 
+1 ? 
+2 ? 
+3 ? 
+4 ? 
+# 
+loop_
+_entity_name_com.entity_id 
+_entity_name_com.name 
+1 ?                               
+2 ?                               
+3 'CRE SITE-SPECIFIC RECOMBINASE' 
+4 ?                               
+# 
+loop_
+_entity_poly.entity_id 
+_entity_poly.type 
+_entity_poly.nstd_linkage 
+_entity_poly.nstd_monomer 
+_entity_poly.pdbx_seq_one_letter_code 
+_entity_poly.pdbx_seq_one_letter_code_can 
+_entity_poly.pdbx_strand_id 
+1 polydeoxyribonucleotide no no 
+;(DA)(DT)(DA)(DA)(DG)(DT)(DT)(DC)(DG)(DT)(DA)(DT)(DA)(DA)(DT)(DG)(DT)(DA)(DT)(DG)
+(DC)(DT)(DA)(DT)(DA)(DC)(DG)(DA)(DA)(DG)(DT)(DT)(DA)(DT)
+;
+ATAAGTTCGTATAATGTATGCTATACGAAGTTAT C   
+2 polydeoxyribonucleotide no no 
+;(DA)(DT)(DA)(DA)(DC)(DT)(DT)(DC)(DG)(DT)(DA)(DT)(DA)(DG)(DC)(DA)(DT)(DA)(DC)(DA)
+(DT)(DT)(DA)(DT)(DA)(DC)(DG)(DA)(DA)(DC)(DT)(DT)(DA)(DT)
+;
+ATAACTTCGTATAGCATACATTATACGAACTTAT D   
+3 'polypeptide(L)'        no no 
+;MHHHHHHSNLLTVHQNLPALPVDATSDEVRKNLMDMFRDRQAFSEHTWKMLLSVCRSWAAWCKLNNRKWFPAEPEDVRDY
+LLYLQARGLAVKTIQQHLGQLNMLHRRSGLPRPSDSNAVSLVMRRIRKENVDAGERAKQALAFERTDFDQVRSLMENSDR
+CQDIRNLAFLGIAYNTLLRIAEIARIRVKDISRTDGGRMLIHIGRTKTLVSTAGVEKALSLGVTKLVERWISVSGVADDP
+NNYLFCRVRKNGVAAPSATSQLSTRALEGIFEATHRLIYGAKDDSGQRYLAWSGHSARVGAARDMARAGVSIPEIMQAGG
+WTNVNIVMNYIRNLDSETGAMVRLLEDGD
+;
+;MHHHHHHSNLLTVHQNLPALPVDATSDEVRKNLMDMFRDRQAFSEHTWKMLLSVCRSWAAWCKLNNRKWFPAEPEDVRDY
+LLYLQARGLAVKTIQQHLGQLNMLHRRSGLPRPSDSNAVSLVMRRIRKENVDAGERAKQALAFERTDFDQVRSLMENSDR
+CQDIRNLAFLGIAYNTLLRIAEIARIRVKDISRTDGGRMLIHIGRTKTLVSTAGVEKALSLGVTKLVERWISVSGVADDP
+NNYLFCRVRKNGVAAPSATSQLSTRALEGIFEATHRLIYGAKDDSGQRYLAWSGHSARVGAARDMARAGVSIPEIMQAGG
+WTNVNIVMNYIRNLDSETGAMVRLLEDGD
+;
+A,B 
+# 
+loop_
+_entity_poly_seq.entity_id 
+_entity_poly_seq.num 
+_entity_poly_seq.mon_id 
+_entity_poly_seq.hetero 
+1 1   DA  n 
+1 2   DT  n 
+1 3   DA  n 
+1 4   DA  n 
+1 5   DG  n 
+1 6   DT  n 
+1 7   DT  n 
+1 8   DC  n 
+1 9   DG  n 
+1 10  DT  n 
+1 11  DA  n 
+1 12  DT  n 
+1 13  DA  n 
+1 14  DA  n 
+1 15  DT  n 
+1 16  DG  n 
+1 17  DT  n 
+1 18  DA  n 
+1 19  DT  n 
+1 20  DG  n 
+1 21  DC  n 
+1 22  DT  n 
+1 23  DA  n 
+1 24  DT  n 
+1 25  DA  n 
+1 26  DC  n 
+1 27  DG  n 
+1 28  DA  n 
+1 29  DA  n 
+1 30  DG  n 
+1 31  DT  n 
+1 32  DT  n 
+1 33  DA  n 
+1 34  DT  n 
+2 1   DA  n 
+2 2   DT  n 
+2 3   DA  n 
+2 4   DA  n 
+2 5   DC  n 
+2 6   DT  n 
+2 7   DT  n 
+2 8   DC  n 
+2 9   DG  n 
+2 10  DT  n 
+2 11  DA  n 
+2 12  DT  n 
+2 13  DA  n 
+2 14  DG  n 
+2 15  DC  n 
+2 16  DA  n 
+2 17  DT  n 
+2 18  DA  n 
+2 19  DC  n 
+2 20  DA  n 
+2 21  DT  n 
+2 22  DT  n 
+2 23  DA  n 
+2 24  DT  n 
+2 25  DA  n 
+2 26  DC  n 
+2 27  DG  n 
+2 28  DA  n 
+2 29  DA  n 
+2 30  DC  n 
+2 31  DT  n 
+2 32  DT  n 
+2 33  DA  n 
+2 34  DT  n 
+3 1   MET n 
+3 2   HIS n 
+3 3   HIS n 
+3 4   HIS n 
+3 5   HIS n 
+3 6   HIS n 
+3 7   HIS n 
+3 8   SER n 
+3 9   ASN n 
+3 10  LEU n 
+3 11  LEU n 
+3 12  THR n 
+3 13  VAL n 
+3 14  HIS n 
+3 15  GLN n 
+3 16  ASN n 
+3 17  LEU n 
+3 18  PRO n 
+3 19  ALA n 
+3 20  LEU n 
+3 21  PRO n 
+3 22  VAL n 
+3 23  ASP n 
+3 24  ALA n 
+3 25  THR n 
+3 26  SER n 
+3 27  ASP n 
+3 28  GLU n 
+3 29  VAL n 
+3 30  ARG n 
+3 31  LYS n 
+3 32  ASN n 
+3 33  LEU n 
+3 34  MET n 
+3 35  ASP n 
+3 36  MET n 
+3 37  PHE n 
+3 38  ARG n 
+3 39  ASP n 
+3 40  ARG n 
+3 41  GLN n 
+3 42  ALA n 
+3 43  PHE n 
+3 44  SER n 
+3 45  GLU n 
+3 46  HIS n 
+3 47  THR n 
+3 48  TRP n 
+3 49  LYS n 
+3 50  MET n 
+3 51  LEU n 
+3 52  LEU n 
+3 53  SER n 
+3 54  VAL n 
+3 55  CYS n 
+3 56  ARG n 
+3 57  SER n 
+3 58  TRP n 
+3 59  ALA n 
+3 60  ALA n 
+3 61  TRP n 
+3 62  CYS n 
+3 63  LYS n 
+3 64  LEU n 
+3 65  ASN n 
+3 66  ASN n 
+3 67  ARG n 
+3 68  LYS n 
+3 69  TRP n 
+3 70  PHE n 
+3 71  PRO n 
+3 72  ALA n 
+3 73  GLU n 
+3 74  PRO n 
+3 75  GLU n 
+3 76  ASP n 
+3 77  VAL n 
+3 78  ARG n 
+3 79  ASP n 
+3 80  TYR n 
+3 81  LEU n 
+3 82  LEU n 
+3 83  TYR n 
+3 84  LEU n 
+3 85  GLN n 
+3 86  ALA n 
+3 87  ARG n 
+3 88  GLY n 
+3 89  LEU n 
+3 90  ALA n 
+3 91  VAL n 
+3 92  LYS n 
+3 93  THR n 
+3 94  ILE n 
+3 95  GLN n 
+3 96  GLN n 
+3 97  HIS n 
+3 98  LEU n 
+3 99  GLY n 
+3 100 GLN n 
+3 101 LEU n 
+3 102 ASN n 
+3 103 MET n 
+3 104 LEU n 
+3 105 HIS n 
+3 106 ARG n 
+3 107 ARG n 
+3 108 SER n 
+3 109 GLY n 
+3 110 LEU n 
+3 111 PRO n 
+3 112 ARG n 
+3 113 PRO n 
+3 114 SER n 
+3 115 ASP n 
+3 116 SER n 
+3 117 ASN n 
+3 118 ALA n 
+3 119 VAL n 
+3 120 SER n 
+3 121 LEU n 
+3 122 VAL n 
+3 123 MET n 
+3 124 ARG n 
+3 125 ARG n 
+3 126 ILE n 
+3 127 ARG n 
+3 128 LYS n 
+3 129 GLU n 
+3 130 ASN n 
+3 131 VAL n 
+3 132 ASP n 
+3 133 ALA n 
+3 134 GLY n 
+3 135 GLU n 
+3 136 ARG n 
+3 137 ALA n 
+3 138 LYS n 
+3 139 GLN n 
+3 140 ALA n 
+3 141 LEU n 
+3 142 ALA n 
+3 143 PHE n 
+3 144 GLU n 
+3 145 ARG n 
+3 146 THR n 
+3 147 ASP n 
+3 148 PHE n 
+3 149 ASP n 
+3 150 GLN n 
+3 151 VAL n 
+3 152 ARG n 
+3 153 SER n 
+3 154 LEU n 
+3 155 MET n 
+3 156 GLU n 
+3 157 ASN n 
+3 158 SER n 
+3 159 ASP n 
+3 160 ARG n 
+3 161 CYS n 
+3 162 GLN n 
+3 163 ASP n 
+3 164 ILE n 
+3 165 ARG n 
+3 166 ASN n 
+3 167 LEU n 
+3 168 ALA n 
+3 169 PHE n 
+3 170 LEU n 
+3 171 GLY n 
+3 172 ILE n 
+3 173 ALA n 
+3 174 TYR n 
+3 175 ASN n 
+3 176 THR n 
+3 177 LEU n 
+3 178 LEU n 
+3 179 ARG n 
+3 180 ILE n 
+3 181 ALA n 
+3 182 GLU n 
+3 183 ILE n 
+3 184 ALA n 
+3 185 ARG n 
+3 186 ILE n 
+3 187 ARG n 
+3 188 VAL n 
+3 189 LYS n 
+3 190 ASP n 
+3 191 ILE n 
+3 192 SER n 
+3 193 ARG n 
+3 194 THR n 
+3 195 ASP n 
+3 196 GLY n 
+3 197 GLY n 
+3 198 ARG n 
+3 199 MET n 
+3 200 LEU n 
+3 201 ILE n 
+3 202 HIS n 
+3 203 ILE n 
+3 204 GLY n 
+3 205 ARG n 
+3 206 THR n 
+3 207 LYS n 
+3 208 THR n 
+3 209 LEU n 
+3 210 VAL n 
+3 211 SER n 
+3 212 THR n 
+3 213 ALA n 
+3 214 GLY n 
+3 215 VAL n 
+3 216 GLU n 
+3 217 LYS n 
+3 218 ALA n 
+3 219 LEU n 
+3 220 SER n 
+3 221 LEU n 
+3 222 GLY n 
+3 223 VAL n 
+3 224 THR n 
+3 225 LYS n 
+3 226 LEU n 
+3 227 VAL n 
+3 228 GLU n 
+3 229 ARG n 
+3 230 TRP n 
+3 231 ILE n 
+3 232 SER n 
+3 233 VAL n 
+3 234 SER n 
+3 235 GLY n 
+3 236 VAL n 
+3 237 ALA n 
+3 238 ASP n 
+3 239 ASP n 
+3 240 PRO n 
+3 241 ASN n 
+3 242 ASN n 
+3 243 TYR n 
+3 244 LEU n 
+3 245 PHE n 
+3 246 CYS n 
+3 247 ARG n 
+3 248 VAL n 
+3 249 ARG n 
+3 250 LYS n 
+3 251 ASN n 
+3 252 GLY n 
+3 253 VAL n 
+3 254 ALA n 
+3 255 ALA n 
+3 256 PRO n 
+3 257 SER n 
+3 258 ALA n 
+3 259 THR n 
+3 260 SER n 
+3 261 GLN n 
+3 262 LEU n 
+3 263 SER n 
+3 264 THR n 
+3 265 ARG n 
+3 266 ALA n 
+3 267 LEU n 
+3 268 GLU n 
+3 269 GLY n 
+3 270 ILE n 
+3 271 PHE n 
+3 272 GLU n 
+3 273 ALA n 
+3 274 THR n 
+3 275 HIS n 
+3 276 ARG n 
+3 277 LEU n 
+3 278 ILE n 
+3 279 TYR n 
+3 280 GLY n 
+3 281 ALA n 
+3 282 LYS n 
+3 283 ASP n 
+3 284 ASP n 
+3 285 SER n 
+3 286 GLY n 
+3 287 GLN n 
+3 288 ARG n 
+3 289 TYR n 
+3 290 LEU n 
+3 291 ALA n 
+3 292 TRP n 
+3 293 SER n 
+3 294 GLY n 
+3 295 HIS n 
+3 296 SER n 
+3 297 ALA n 
+3 298 ARG n 
+3 299 VAL n 
+3 300 GLY n 
+3 301 ALA n 
+3 302 ALA n 
+3 303 ARG n 
+3 304 ASP n 
+3 305 MET n 
+3 306 ALA n 
+3 307 ARG n 
+3 308 ALA n 
+3 309 GLY n 
+3 310 VAL n 
+3 311 SER n 
+3 312 ILE n 
+3 313 PRO n 
+3 314 GLU n 
+3 315 ILE n 
+3 316 MET n 
+3 317 GLN n 
+3 318 ALA n 
+3 319 GLY n 
+3 320 GLY n 
+3 321 TRP n 
+3 322 THR n 
+3 323 ASN n 
+3 324 VAL n 
+3 325 ASN n 
+3 326 ILE n 
+3 327 VAL n 
+3 328 MET n 
+3 329 ASN n 
+3 330 TYR n 
+3 331 ILE n 
+3 332 ARG n 
+3 333 ASN n 
+3 334 LEU n 
+3 335 ASP n 
+3 336 SER n 
+3 337 GLU n 
+3 338 THR n 
+3 339 GLY n 
+3 340 ALA n 
+3 341 MET n 
+3 342 VAL n 
+3 343 ARG n 
+3 344 LEU n 
+3 345 LEU n 
+3 346 GLU n 
+3 347 ASP n 
+3 348 GLY n 
+3 349 ASP n 
+# 
+_entity_src_gen.entity_id                          3 
+_entity_src_gen.gene_src_common_name               ? 
+_entity_src_gen.gene_src_genus                     'P1-like viruses' 
+_entity_src_gen.pdbx_gene_src_gene                 CRE 
+_entity_src_gen.gene_src_species                   ? 
+_entity_src_gen.gene_src_strain                    ? 
+_entity_src_gen.gene_src_tissue                    ? 
+_entity_src_gen.gene_src_tissue_fraction           ? 
+_entity_src_gen.gene_src_details                   ? 
+_entity_src_gen.pdbx_gene_src_fragment             ? 
+_entity_src_gen.pdbx_gene_src_scientific_name      'Enterobacteria phage P1' 
+_entity_src_gen.pdbx_gene_src_ncbi_taxonomy_id     10678 
+_entity_src_gen.pdbx_gene_src_variant              ? 
+_entity_src_gen.pdbx_gene_src_cell_line            ? 
+_entity_src_gen.pdbx_gene_src_atcc                 ? 
+_entity_src_gen.pdbx_gene_src_organ                ? 
+_entity_src_gen.pdbx_gene_src_organelle            ? 
+_entity_src_gen.pdbx_gene_src_cell                 ? 
+_entity_src_gen.pdbx_gene_src_cellular_location    ? 
+_entity_src_gen.host_org_common_name               ? 
+_entity_src_gen.pdbx_host_org_scientific_name      'Escherichia coli BL21(DE3)' 
+_entity_src_gen.pdbx_host_org_ncbi_taxonomy_id     469008 
+_entity_src_gen.host_org_genus                     Escherichia 
+_entity_src_gen.pdbx_host_org_gene                 ? 
+_entity_src_gen.pdbx_host_org_organ                ? 
+_entity_src_gen.host_org_species                   'Escherichia coli' 
+_entity_src_gen.pdbx_host_org_tissue               ? 
+_entity_src_gen.pdbx_host_org_tissue_fraction      ? 
+_entity_src_gen.pdbx_host_org_strain               'BL21(DE3)' 
+_entity_src_gen.pdbx_host_org_variant              ? 
+_entity_src_gen.pdbx_host_org_cell_line            ? 
+_entity_src_gen.pdbx_host_org_atcc                 ? 
+_entity_src_gen.pdbx_host_org_culture_collection   ? 
+_entity_src_gen.pdbx_host_org_cell                 ? 
+_entity_src_gen.pdbx_host_org_organelle            ? 
+_entity_src_gen.pdbx_host_org_cellular_location    ? 
+_entity_src_gen.pdbx_host_org_vector_type          PLASMID 
+_entity_src_gen.pdbx_host_org_vector               ? 
+_entity_src_gen.plasmid_name                       'pET28b(+)' 
+_entity_src_gen.plasmid_details                    ? 
+_entity_src_gen.pdbx_description                   ? 
+# 
+loop_
+_struct_ref.id 
+_struct_ref.db_name 
+_struct_ref.db_code 
+_struct_ref.entity_id 
+_struct_ref.pdbx_seq_one_letter_code 
+_struct_ref.pdbx_align_begin 
+_struct_ref.biol_id 
+_struct_ref.pdbx_db_accession 
+1 UNP RECR_BPP1 3 
+; MSNLLTVHQN LPALPVDATS DEVRKNLMDM FRDRQAFSEH TWKMLLSVCR SWAAWCKLNN  
+     RKWFPAEPED VRDYLLYLQA RGLAVKTIQQ HLGQLNMLHR RSGLPRPSDS NAVSLVMRRI  
+     RKENVDAGER AKQALAFERT DFDQVRSLME NSDRCQDIRN LAFLGIAYNT LLRIAEIARI  
+     RVKDISRTDG GRMLIHIGRT KTLVSTAGVE KALSLGVTKL VERWISVSGV ADDPNNYLFC  
+     RVRKNGVAAP SATSQLSTRA LEGIFEATHR LIYGAKDDSG QRYLAWSGHS ARVGAARDMA  
+     RAGVSIPEIM QAGGWTNVNI VMNYIRNLDS ETGAMVRLLE DGD
+;
+1  . P06956 
+2 GB  M10494    2 'ataactt cgtatagcat acattatacg aagttat' 14 . 215626 
+3 PDB 1KBU      1 ? ?  . 1KBU   
+# 
+loop_
+_struct_ref_seq.align_id 
+_struct_ref_seq.ref_id 
+_struct_ref_seq.pdbx_PDB_id_code 
+_struct_ref_seq.pdbx_strand_id 
+_struct_ref_seq.seq_align_beg 
+_struct_ref_seq.pdbx_seq_align_beg_ins_code 
+_struct_ref_seq.seq_align_end 
+_struct_ref_seq.pdbx_seq_align_end_ins_code 
+_struct_ref_seq.pdbx_db_accession 
+_struct_ref_seq.db_align_beg 
+_struct_ref_seq.pdbx_db_align_beg_ins_code 
+_struct_ref_seq.db_align_end 
+_struct_ref_seq.pdbx_db_align_end_ins_code 
+_struct_ref_seq.pdbx_auth_seq_align_beg 
+_struct_ref_seq.pdbx_auth_seq_align_end 
+1 1 1KBU A 1 ? 349 ? P06956 1  ? 343 ? -5 343 
+2 1 1KBU B 1 ? 349 ? P06956 1  ? 343 ? -5 343 
+3 2 1KBU D 1 ? 34  ? 215626 14 ? 47  ? 1  34  
+4 3 1KBU C 1 ? 34  ? 1KBU   1  ? 34  ? 1  34  
+# 
+loop_
+_struct_ref_seq_dif.align_id 
+_struct_ref_seq_dif.pdbx_pdb_id_code 
+_struct_ref_seq_dif.mon_id 
+_struct_ref_seq_dif.pdbx_pdb_strand_id 
+_struct_ref_seq_dif.seq_num 
+_struct_ref_seq_dif.pdbx_seq_db_name 
+_struct_ref_seq_dif.pdbx_seq_db_accession_code 
+_struct_ref_seq_dif.db_mon_id 
+_struct_ref_seq_dif.pdbx_seq_db_seq_num 
+_struct_ref_seq_dif.details 
+_struct_ref_seq_dif.pdbx_auth_seq_num 
+_struct_ref_seq_dif.pdbx_pdb_ins_code 
+_struct_ref_seq_dif.pdbx_ordinal 
+1 1KBU HIS A 2  UNP P06956 ? ?  'EXPRESSION TAG' -4 ? 1  
+1 1KBU HIS A 3  UNP P06956 ? ?  'EXPRESSION TAG' -3 ? 2  
+1 1KBU HIS A 4  UNP P06956 ? ?  'EXPRESSION TAG' -2 ? 3  
+1 1KBU HIS A 5  UNP P06956 ? ?  'EXPRESSION TAG' -1 ? 4  
+1 1KBU HIS A 6  UNP P06956 ? ?  'EXPRESSION TAG' 0  ? 5  
+1 1KBU HIS A 7  UNP P06956 ? ?  'EXPRESSION TAG' 1  ? 6  
+2 1KBU HIS B 2  UNP P06956 ? ?  'EXPRESSION TAG' -4 ? 7  
+2 1KBU HIS B 3  UNP P06956 ? ?  'EXPRESSION TAG' -3 ? 8  
+2 1KBU HIS B 4  UNP P06956 ? ?  'EXPRESSION TAG' -2 ? 9  
+2 1KBU HIS B 5  UNP P06956 ? ?  'EXPRESSION TAG' -1 ? 10 
+2 1KBU HIS B 6  UNP P06956 ? ?  'EXPRESSION TAG' 0  ? 11 
+2 1KBU HIS B 7  UNP P06956 ? ?  'EXPRESSION TAG' 1  ? 12 
+3 1KBU DC  D 30 GB  215626 G 43 'see remark 999' 30 ? 13 
+# 
+loop_
+_chem_comp.id 
+_chem_comp.type 
+_chem_comp.mon_nstd_flag 
+_chem_comp.name 
+_chem_comp.pdbx_synonyms 
+_chem_comp.formula 
+_chem_comp.formula_weight 
+DA  'DNA linking'       y "2'-DEOXYADENOSINE-5'-MONOPHOSPHATE" ? 'C10 H14 N5 O6 P' 331.224 
+DT  'DNA linking'       y "THYMIDINE-5'-MONOPHOSPHATE"         ? 'C10 H15 N2 O8 P' 322.211 
+DG  'DNA linking'       y "2'-DEOXYGUANOSINE-5'-MONOPHOSPHATE" ? 'C10 H14 N5 O7 P' 347.224 
+DC  'DNA linking'       y "2'-DEOXYCYTIDINE-5'-MONOPHOSPHATE"  ? 'C9 H14 N3 O7 P'  307.199 
+ALA 'L-peptide linking' y ALANINE                              ? 'C3 H7 N O2'      89.094  
+THR 'L-peptide linking' y THREONINE                            ? 'C4 H9 N O3'      119.120 
+SER 'L-peptide linking' y SERINE                               ? 'C3 H7 N O3'      105.093 
+ASP 'L-peptide linking' y 'ASPARTIC ACID'                      ? 'C4 H7 N O4'      133.104 
+GLU 'L-peptide linking' y 'GLUTAMIC ACID'                      ? 'C5 H9 N O4'      147.130 
+VAL 'L-peptide linking' y VALINE                               ? 'C5 H11 N O2'     117.147 
+ARG 'L-peptide linking' y ARGININE                             ? 'C6 H15 N4 O2 1'  175.210 
+LYS 'L-peptide linking' y LYSINE                               ? 'C6 H15 N2 O2 1'  147.197 
+ASN 'L-peptide linking' y ASPARAGINE                           ? 'C4 H8 N2 O3'     132.119 
+LEU 'L-peptide linking' y LEUCINE                              ? 'C6 H13 N O2'     131.174 
+MET 'L-peptide linking' y METHIONINE                           ? 'C5 H11 N O2 S'   149.207 
+PHE 'L-peptide linking' y PHENYLALANINE                        ? 'C9 H11 N O2'     165.191 
+GLN 'L-peptide linking' y GLUTAMINE                            ? 'C5 H10 N2 O3'    146.146 
+HIS 'L-peptide linking' y HISTIDINE                            ? 'C6 H10 N3 O2 1'  156.164 
+TRP 'L-peptide linking' y TRYPTOPHAN                           ? 'C11 H12 N2 O2'   204.228 
+CYS 'L-peptide linking' y CYSTEINE                             ? 'C3 H7 N O2 S'    121.154 
+PRO 'L-peptide linking' y PROLINE                              ? 'C5 H9 N O2'      115.132 
+TYR 'L-peptide linking' y TYROSINE                             ? 'C9 H11 N O3'     181.191 
+GLY 'PEPTIDE LINKING'   y GLYCINE                              ? 'C2 H5 N O2'      75.067  
+ILE 'L-peptide linking' y ISOLEUCINE                           ? 'C6 H13 N O2'     131.174 
+HOH NON-POLYMER         . WATER                                ? 'H2 O'            18.015  
+G   'RNA linking'       y "GUANOSINE-5'-MONOPHOSPHATE"         ? 'C10 H14 N5 O8 P' 363.223 
+# 
+_exptl.entry_id          1KBU 
+_exptl.method            'X-RAY DIFFRACTION' 
+_exptl.crystals_number   1 
+# 
+_exptl_crystal.id                    1 
+_exptl_crystal.density_meas          ? 
+_exptl_crystal.density_Matthews      2.91 
+_exptl_crystal.density_percent_sol   57.69 
+_exptl_crystal.description           ? 
+# 
+_exptl_crystal_grow.crystal_id      1 
+_exptl_crystal_grow.method          'VAPOR DIFFUSION, HANGING DROP' 
+_exptl_crystal_grow.temp            294 
+_exptl_crystal_grow.temp_details    ? 
+_exptl_crystal_grow.pH              5.00 
+_exptl_crystal_grow.pdbx_details    
+'MPD, sodium acetate, calcium chloride, pH 5.00, VAPOR DIFFUSION, HANGING DROP, temperature 294K' 
+_exptl_crystal_grow.pdbx_pH_range   . 
+# 
+loop_
+_exptl_crystal_grow_comp.crystal_id 
+_exptl_crystal_grow_comp.id 
+_exptl_crystal_grow_comp.sol_id 
+_exptl_crystal_grow_comp.name 
+_exptl_crystal_grow_comp.volume 
+_exptl_crystal_grow_comp.conc 
+_exptl_crystal_grow_comp.details 
+1 1 1 MPD              ? ? ? 
+1 2 1 'sodium acetate' ? ? ? 
+1 3 1 CaCl2            ? ? ? 
+# 
+_diffrn.id                     1 
+_diffrn.ambient_temp           100 
+_diffrn.ambient_temp_details   ? 
+_diffrn.crystal_id             1 
+# 
+_diffrn_detector.diffrn_id              1 
+_diffrn_detector.detector               CCD 
+_diffrn_detector.type                   'ADSC QUANTUM 4' 
+_diffrn_detector.pdbx_collection_date   2000-02-27 
+_diffrn_detector.details                ? 
+# 
+_diffrn_radiation.diffrn_id                        1 
+_diffrn_radiation.wavelength_id                    1 
+_diffrn_radiation.pdbx_monochromatic_or_laue_m_l   M 
+_diffrn_radiation.monochromator                    'double crystal' 
+_diffrn_radiation.pdbx_diffrn_protocol             'SINGLE WAVELENGTH' 
+_diffrn_radiation.pdbx_scattering_type             x-ray 
+# 
+_diffrn_radiation_wavelength.id           1 
+_diffrn_radiation_wavelength.wavelength   1.0 
+_diffrn_radiation_wavelength.wt           1.0 
+# 
+_diffrn_source.diffrn_id                   1 
+_diffrn_source.source                      SYNCHROTRON 
+_diffrn_source.type                        'SSRL BEAMLINE BL9-2' 
+_diffrn_source.pdbx_synchrotron_site       SSRL 
+_diffrn_source.pdbx_synchrotron_beamline   BL9-2 
+_diffrn_source.pdbx_wavelength             ? 
+_diffrn_source.pdbx_wavelength_list        1.0 
+# 
+_reflns.entry_id                     1KBU 
+_reflns.observed_criterion_sigma_I   -3.0 
+_reflns.observed_criterion_sigma_F   0.0 
+_reflns.d_resolution_low             24.5 
+_reflns.d_resolution_high            2.2 
+_reflns.number_obs                   53320 
+_reflns.number_all                   53608 
+_reflns.percent_possible_obs         89 
+_reflns.pdbx_Rmerge_I_obs            0.048 
+_reflns.pdbx_Rsym_value              0.037 
+_reflns.pdbx_netI_over_sigmaI        9.6 
+_reflns.B_iso_Wilson_estimate        47 
+_reflns.pdbx_redundancy              3.6 
+_reflns.R_free_details               ? 
+_reflns.pdbx_ordinal                 1 
+_reflns.pdbx_diffrn_id               1 
+# 
+_reflns_shell.d_res_high             2.20 
+_reflns_shell.d_res_low              2.32 
+_reflns_shell.percent_possible_all   89.8 
+_reflns_shell.Rmerge_I_obs           0.406 
+_reflns_shell.pdbx_Rsym_value        0.287 
+_reflns_shell.meanI_over_sigI_obs    2.4 
+_reflns_shell.pdbx_redundancy        2.9 
+_reflns_shell.percent_possible_obs   ? 
+_reflns_shell.number_unique_all      7169 
+_reflns_shell.pdbx_ordinal           1 
+_reflns_shell.pdbx_diffrn_id         1 
+# 
+_computing.entry_id                           1KBU 
+_computing.pdbx_data_reduction_ii             MOSFLM 
+_computing.pdbx_data_reduction_ds             'CCP4 (SCALA)' 
+_computing.data_collection                    ? 
+_computing.structure_solution                 TNT 
+_computing.structure_refinement               TNT 
+_computing.pdbx_structure_refinement_method   ? 
+# 
+_refine.entry_id                               1KBU 
+_refine.ls_number_reflns_obs                   53233 
+_refine.ls_number_reflns_all                   53233 
+_refine.pdbx_ls_sigma_I                        ? 
+_refine.pdbx_ls_sigma_F                        0.0 
+_refine.pdbx_data_cutoff_high_absF             ? 
+_refine.pdbx_data_cutoff_low_absF              ? 
+_refine.ls_d_res_low                           5.0 
+_refine.ls_d_res_high                          2.2 
+_refine.ls_percent_reflns_obs                  89 
+_refine.ls_R_factor_obs                        0.231 
+_refine.ls_R_factor_all                        0.231 
+_refine.ls_R_factor_R_work                     0.231 
+_refine.ls_R_factor_R_free                     0.279 
+_refine.ls_R_factor_R_free_error               ? 
+_refine.ls_R_factor_R_free_error_details       ? 
+_refine.ls_percent_reflns_R_free               ? 
+_refine.ls_number_reflns_R_free                2682 
+_refine.ls_number_parameters                   ? 
+_refine.ls_number_restraints                   ? 
+_refine.occupancy_min                          ? 
+_refine.occupancy_max                          ? 
+_refine.B_iso_mean                             57.8 
+_refine.aniso_B[1][1]                          ? 
+_refine.aniso_B[2][2]                          ? 
+_refine.aniso_B[3][3]                          ? 
+_refine.aniso_B[1][2]                          ? 
+_refine.aniso_B[1][3]                          ? 
+_refine.aniso_B[2][3]                          ? 
+_refine.solvent_model_details                  NONE 
+_refine.solvent_model_param_ksol               ? 
+_refine.solvent_model_param_bsol               ? 
+_refine.pdbx_ls_cross_valid_method             throughout 
+_refine.details                                ? 
+_refine.pdbx_starting_model                    'combination of 1CRX and 4CRX (see publication for details)' 
+_refine.pdbx_method_to_determine_struct        'ISOMORPHOUS MOLECULAR REPLACEMENT' 
+_refine.pdbx_isotropic_thermal_model           isotropic 
+_refine.pdbx_stereochemistry_target_values     'Engh & Huber' 
+_refine.pdbx_stereochem_target_val_spec_case   ? 
+_refine.pdbx_R_Free_selection_details          RANDOM 
+_refine.pdbx_overall_ESU_R_Free                ? 
+_refine.overall_SU_B                           ? 
+_refine.ls_redundancy_reflns_obs               ? 
+_refine.correlation_coeff_Fo_to_Fc             ? 
+_refine.overall_SU_R_Cruickshank_DPI           ? 
+_refine.overall_SU_R_free                      ? 
+_refine.overall_SU_ML                          ? 
+_refine.pdbx_overall_ESU_R                     ? 
+_refine.pdbx_data_cutoff_high_rms_absF         ? 
+_refine.correlation_coeff_Fo_to_Fc_free        ? 
+_refine.pdbx_solvent_vdw_probe_radii           ? 
+_refine.pdbx_solvent_ion_probe_radii           ? 
+_refine.pdbx_solvent_shrinkage_radii           ? 
+_refine.pdbx_refine_id                         'X-RAY DIFFRACTION' 
+_refine.pdbx_diffrn_id                         1 
+# 
+_refine_hist.pdbx_refine_id                   'X-RAY DIFFRACTION' 
+_refine_hist.cycle_id                         LAST 
+_refine_hist.pdbx_number_atoms_protein        5089 
+_refine_hist.pdbx_number_atoms_nucleic_acid   1388 
+_refine_hist.pdbx_number_atoms_ligand         0 
+_refine_hist.number_atoms_solvent             237 
+_refine_hist.number_atoms_total               6714 
+_refine_hist.d_res_high                       2.2 
+_refine_hist.d_res_low                        5.0 
+# 
+loop_
+_refine_ls_restr.type 
+_refine_ls_restr.dev_ideal 
+_refine_ls_restr.dev_ideal_target 
+_refine_ls_restr.weight 
+_refine_ls_restr.number 
+_refine_ls_restr.pdbx_refine_id 
+t_bond_d    0.006 ? ? ? 'X-RAY DIFFRACTION' 
+t_angle_deg 1.58  ? ? ? 'X-RAY DIFFRACTION' 
+# 
+_refine_ls_shell.pdbx_total_number_of_bins_used   ? 
+_refine_ls_shell.d_res_high                       2.2 
+_refine_ls_shell.d_res_low                        2.28 
+_refine_ls_shell.number_reflns_R_work             ? 
+_refine_ls_shell.R_factor_R_work                  0.380 
+_refine_ls_shell.percent_reflns_obs               ? 
+_refine_ls_shell.R_factor_R_free                  0.390 
+_refine_ls_shell.R_factor_R_free_error            ? 
+_refine_ls_shell.percent_reflns_R_free            ? 
+_refine_ls_shell.number_reflns_R_free             220 
+_refine_ls_shell.redundancy_reflns_obs            ? 
+_refine_ls_shell.pdbx_refine_id                   'X-RAY DIFFRACTION' 
+# 
+_struct.entry_id                  1KBU 
+_struct.title                     'CRE RECOMBINASE BOUND TO A LOXP HOLLIDAY JUNCTION' 
+_struct.pdbx_descriptor           'CRE RECOMBINASE/DNA Complex' 
+_struct.pdbx_model_details        ? 
+_struct.pdbx_CASP_flag            ? 
+_struct.pdbx_model_type_details   ? 
+# 
+_struct_keywords.entry_id        1KBU 
+_struct_keywords.pdbx_keywords   'HYDROLASE, LIGASE/DNA' 
+_struct_keywords.text            
+;SITE-SPECIFIC RECOMBINASE, HOLLIDAY JUNCTION COMPLEX, DNA-PROTEIN CO-CRYSTAL, INT RECOMBINASE MECHANISM, HYDROLASE, LIGASE-DNA COMPLEX
+;
+# 
+loop_
+_struct_asym.id 
+_struct_asym.pdbx_blank_PDB_chainid_flag 
+_struct_asym.pdbx_modified 
+_struct_asym.entity_id 
+_struct_asym.details 
+A N N 1 ? 
+B N N 2 ? 
+C N N 3 ? 
+D N N 3 ? 
+E N N 4 ? 
+F N N 4 ? 
+G N N 4 ? 
+H N N 4 ? 
+# 
+_struct_biol.id                    1 
+_struct_biol.details               
+;THE BIOLOGICAL ASSEMBLY IS A CRE TETRAMER BOUND TO TWO LOXP SITES, GENERATED FROM THE ASYMMETRIC UNIT BY THE  
+CRYSTALLOGRAPHIC TWO-FOLD AXIS PLUS TRANSLATIONS: 
+x, -y+1, -z+1
+;
+_struct_biol.pdbx_parent_biol_id   ? 
+# 
+loop_
+_struct_conf.conf_type_id 
+_struct_conf.id 
+_struct_conf.pdbx_PDB_helix_id 
+_struct_conf.beg_label_comp_id 
+_struct_conf.beg_label_asym_id 
+_struct_conf.beg_label_seq_id 
+_struct_conf.pdbx_beg_PDB_ins_code 
+_struct_conf.end_label_comp_id 
+_struct_conf.end_label_asym_id 
+_struct_conf.end_label_seq_id 
+_struct_conf.pdbx_end_PDB_ins_code 
+_struct_conf.beg_auth_comp_id 
+_struct_conf.beg_auth_asym_id 
+_struct_conf.beg_auth_seq_id 
+_struct_conf.end_auth_comp_id 
+_struct_conf.end_auth_asym_id 
+_struct_conf.end_auth_seq_id 
+_struct_conf.pdbx_PDB_helix_class 
+_struct_conf.details 
+_struct_conf.pdbx_PDB_helix_length 
+HELX_P HELX_P1  1  THR C 25  ? ASP C 39  ? THR A 19  ASP A 33  1 ? 15 
+HELX_P HELX_P2  2  ARG C 40  ? PHE C 43  ? ARG A 34  PHE A 37  5 ? 4  
+HELX_P HELX_P3  3  SER C 44  ? ASN C 66  ? SER A 38  ASN A 60  1 ? 23 
+HELX_P HELX_P4  4  GLU C 73  ? ARG C 87  ? GLU A 67  ARG A 81  1 ? 15 
+HELX_P HELX_P5  5  ALA C 90  ? ARG C 107 ? ALA A 84  ARG A 101 1 ? 18 
+HELX_P HELX_P6  6  ARG C 112 ? ASP C 115 ? ARG A 106 ASP A 109 5 ? 4  
+HELX_P HELX_P7  7  SER C 116 ? ASP C 132 ? SER A 110 ASP A 126 1 ? 17 
+HELX_P HELX_P8  8  GLU C 144 ? GLU C 156 ? GLU A 138 GLU A 150 1 ? 13 
+HELX_P HELX_P9  9  ARG C 160 ? ASN C 175 ? ARG A 154 ASN A 169 1 ? 16 
+HELX_P HELX_P10 10 ARG C 179 ? ILE C 186 ? ARG A 173 ILE A 180 1 ? 8  
+HELX_P HELX_P11 11 ARG C 187 ? ILE C 191 ? ARG A 181 ILE A 185 5 ? 5  
+HELX_P HELX_P12 12 ARG C 193 ? ARG C 198 ? ARG A 187 ARG A 192 1 ? 6  
+HELX_P HELX_P13 13 GLY C 222 ? GLY C 235 ? GLY A 216 GLY A 229 1 ? 14 
+HELX_P HELX_P14 14 VAL C 236 ? ASP C 239 ? VAL A 230 ASP A 233 5 ? 4  
+HELX_P HELX_P15 15 SER C 263 ? GLY C 280 ? SER A 257 GLY A 274 1 ? 18 
+HELX_P HELX_P16 16 HIS C 295 ? ALA C 308 ? HIS A 289 ALA A 302 1 ? 14 
+HELX_P HELX_P17 17 ILE C 312 ? GLN C 317 ? ILE A 306 GLN A 311 1 ? 6  
+HELX_P HELX_P18 18 ASN C 325 ? ILE C 331 ? ASN A 319 ILE A 325 1 ? 7  
+HELX_P HELX_P19 19 GLY C 339 ? GLU C 346 ? GLY A 333 GLU A 340 1 ? 8  
+HELX_P HELX_P20 20 SER D 26  ? ASP D 39  ? SER B 20  ASP B 33  1 ? 14 
+HELX_P HELX_P21 21 ARG D 40  ? PHE D 43  ? ARG B 34  PHE B 37  5 ? 4  
+HELX_P HELX_P22 22 SER D 44  ? LEU D 64  ? SER B 38  LEU B 58  1 ? 21 
+HELX_P HELX_P23 23 GLU D 73  ? ARG D 87  ? GLU B 67  ARG B 81  1 ? 15 
+HELX_P HELX_P24 24 ALA D 90  ? ARG D 107 ? ALA B 84  ARG B 101 1 ? 18 
+HELX_P HELX_P25 25 ARG D 112 ? ASP D 115 ? ARG B 106 ASP B 109 5 ? 4  
+HELX_P HELX_P26 26 SER D 116 ? ASP D 132 ? SER B 110 ASP B 126 1 ? 17 
+HELX_P HELX_P27 27 GLU D 144 ? GLU D 156 ? GLU B 138 GLU B 150 1 ? 13 
+HELX_P HELX_P28 28 ARG D 160 ? LEU D 177 ? ARG B 154 LEU B 171 1 ? 18 
+HELX_P HELX_P29 29 ARG D 179 ? ARG D 185 ? ARG B 173 ARG B 179 1 ? 7  
+HELX_P HELX_P30 30 ARG D 187 ? LYS D 189 ? ARG B 181 LYS B 183 5 ? 3  
+HELX_P HELX_P31 31 SER D 220 ? GLY D 235 ? SER B 214 GLY B 229 1 ? 16 
+HELX_P HELX_P32 32 SER D 263 ? GLY D 280 ? SER B 257 GLY B 274 1 ? 18 
+HELX_P HELX_P33 33 HIS D 295 ? GLY D 309 ? HIS B 289 GLY B 303 1 ? 15 
+HELX_P HELX_P34 34 SER D 311 ? GLY D 320 ? SER B 305 GLY B 314 1 ? 10 
+HELX_P HELX_P35 35 VAL D 324 ? TYR D 330 ? VAL B 318 TYR B 324 1 ? 7  
+HELX_P HELX_P36 36 ALA D 340 ? LEU D 345 ? ALA B 334 LEU B 339 1 ? 6  
+# 
+_struct_conf_type.id          HELX_P 
+_struct_conf_type.criteria    ? 
+_struct_conf_type.reference   ? 
+# 
+loop_
+_struct_conn.id 
+_struct_conn.conn_type_id 
+_struct_conn.pdbx_PDB_id 
+_struct_conn.ptnr1_label_asym_id 
+_struct_conn.ptnr1_label_comp_id 
+_struct_conn.ptnr1_label_seq_id 
+_struct_conn.ptnr1_label_atom_id 
+_struct_conn.pdbx_ptnr1_label_alt_id 
+_struct_conn.pdbx_ptnr1_PDB_ins_code 
+_struct_conn.pdbx_ptnr1_standard_comp_id 
+_struct_conn.ptnr1_symmetry 
+_struct_conn.ptnr2_label_asym_id 
+_struct_conn.ptnr2_label_comp_id 
+_struct_conn.ptnr2_label_seq_id 
+_struct_conn.ptnr2_label_atom_id 
+_struct_conn.pdbx_ptnr2_label_alt_id 
+_struct_conn.pdbx_ptnr2_PDB_ins_code 
+_struct_conn.ptnr1_auth_asym_id 
+_struct_conn.ptnr1_auth_comp_id 
+_struct_conn.ptnr1_auth_seq_id 
+_struct_conn.ptnr2_auth_asym_id 
+_struct_conn.ptnr2_auth_comp_id 
+_struct_conn.ptnr2_auth_seq_id 
+_struct_conn.ptnr2_symmetry 
+_struct_conn.pdbx_ptnr3_label_atom_id 
+_struct_conn.pdbx_ptnr3_label_seq_id 
+_struct_conn.pdbx_ptnr3_label_comp_id 
+_struct_conn.pdbx_ptnr3_label_asym_id 
+_struct_conn.pdbx_ptnr3_label_alt_id 
+_struct_conn.pdbx_ptnr3_PDB_ins_code 
+_struct_conn.details 
+_struct_conn.pdbx_dist_value 
+_struct_conn.pdbx_value_order 
+hydrog1  hydrog ? A DA 1  N1 ? ? ? 1_555 B DT 34 N3 ? ? C DA 1  D DT 34 1_555 ? ? ? ? ? ? 'DA-DT PAIR' ? ? 
+hydrog2  hydrog ? A DT 2  N3 ? ? ? 1_555 B DA 33 N1 ? ? C DT 2  D DA 33 1_555 ? ? ? ? ? ? WATSON-CRICK ? ? 
+hydrog3  hydrog ? A DT 2  O4 ? ? ? 1_555 B DA 33 N6 ? ? C DT 2  D DA 33 1_555 ? ? ? ? ? ? WATSON-CRICK ? ? 
+hydrog4  hydrog ? A DA 3  N1 ? ? ? 1_555 B DT 32 N3 ? ? C DA 3  D DT 32 1_555 ? ? ? ? ? ? WATSON-CRICK ? ? 
+hydrog5  hydrog ? A DA 3  N6 ? ? ? 1_555 B DT 32 O4 ? ? C DA 3  D DT 32 1_555 ? ? ? ? ? ? WATSON-CRICK ? ? 
+hydrog6  hydrog ? A DA 4  N1 ? ? ? 1_555 B DT 31 N3 ? ? C DA 4  D DT 31 1_555 ? ? ? ? ? ? WATSON-CRICK ? ? 
+hydrog7  hydrog ? A DA 4  N6 ? ? ? 1_555 B DT 31 O4 ? ? C DA 4  D DT 31 1_555 ? ? ? ? ? ? WATSON-CRICK ? ? 
+hydrog8  hydrog ? A DG 5  N1 ? ? ? 1_555 B DC 30 N3 ? ? C DG 5  D DC 30 1_555 ? ? ? ? ? ? WATSON-CRICK ? ? 
+hydrog9  hydrog ? A DG 5  N2 ? ? ? 1_555 B DC 30 O2 ? ? C DG 5  D DC 30 1_555 ? ? ? ? ? ? WATSON-CRICK ? ? 
+hydrog10 hydrog ? A DG 5  O6 ? ? ? 1_555 B DC 30 N4 ? ? C DG 5  D DC 30 1_555 ? ? ? ? ? ? WATSON-CRICK ? ? 
+hydrog11 hydrog ? A DT 6  N3 ? ? ? 1_555 B DA 29 N1 ? ? C DT 6  D DA 29 1_555 ? ? ? ? ? ? WATSON-CRICK ? ? 
+hydrog12 hydrog ? A DT 6  O4 ? ? ? 1_555 B DA 29 N6 ? ? C DT 6  D DA 29 1_555 ? ? ? ? ? ? WATSON-CRICK ? ? 
+hydrog13 hydrog ? A DT 7  N3 ? ? ? 1_555 B DA 28 N1 ? ? C DT 7  D DA 28 1_555 ? ? ? ? ? ? WATSON-CRICK ? ? 
+hydrog14 hydrog ? A DT 7  O4 ? ? ? 1_555 B DA 28 N6 ? ? C DT 7  D DA 28 1_555 ? ? ? ? ? ? WATSON-CRICK ? ? 
+hydrog15 hydrog ? A DC 8  N3 ? ? ? 1_555 B DG 27 N1 ? ? C DC 8  D DG 27 1_555 ? ? ? ? ? ? WATSON-CRICK ? ? 
+hydrog16 hydrog ? A DC 8  N4 ? ? ? 1_555 B DG 27 O6 ? ? C DC 8  D DG 27 1_555 ? ? ? ? ? ? WATSON-CRICK ? ? 
+hydrog17 hydrog ? A DC 8  O2 ? ? ? 1_555 B DG 27 N2 ? ? C DC 8  D DG 27 1_555 ? ? ? ? ? ? WATSON-CRICK ? ? 
+hydrog18 hydrog ? A DG 9  N1 ? ? ? 1_555 B DC 26 N3 ? ? C DG 9  D DC 26 1_555 ? ? ? ? ? ? WATSON-CRICK ? ? 
+hydrog19 hydrog ? A DG 9  N2 ? ? ? 1_555 B DC 26 O2 ? ? C DG 9  D DC 26 1_555 ? ? ? ? ? ? WATSON-CRICK ? ? 
+hydrog20 hydrog ? A DG 9  O6 ? ? ? 1_555 B DC 26 N4 ? ? C DG 9  D DC 26 1_555 ? ? ? ? ? ? WATSON-CRICK ? ? 
+hydrog21 hydrog ? A DT 10 N3 ? ? ? 1_555 B DA 25 N1 ? ? C DT 10 D DA 25 1_555 ? ? ? ? ? ? WATSON-CRICK ? ? 
+hydrog22 hydrog ? A DT 10 O4 ? ? ? 1_555 B DA 25 N6 ? ? C DT 10 D DA 25 1_555 ? ? ? ? ? ? WATSON-CRICK ? ? 
+hydrog23 hydrog ? A DA 11 N1 ? ? ? 1_555 B DT 24 N3 ? ? C DA 11 D DT 24 1_555 ? ? ? ? ? ? WATSON-CRICK ? ? 
+hydrog24 hydrog ? A DA 11 N6 ? ? ? 1_555 B DT 24 O4 ? ? C DA 11 D DT 24 1_555 ? ? ? ? ? ? WATSON-CRICK ? ? 
+hydrog25 hydrog ? A DT 12 N3 ? ? ? 1_555 B DA 23 N1 ? ? C DT 12 D DA 23 1_555 ? ? ? ? ? ? WATSON-CRICK ? ? 
+hydrog26 hydrog ? A DT 12 O4 ? ? ? 1_555 B DA 23 N6 ? ? C DT 12 D DA 23 1_555 ? ? ? ? ? ? WATSON-CRICK ? ? 
+hydrog27 hydrog ? A DA 13 N1 ? ? ? 1_555 B DT 22 N3 ? ? C DA 13 D DT 22 1_555 ? ? ? ? ? ? WATSON-CRICK ? ? 
+hydrog28 hydrog ? A DA 13 N6 ? ? ? 1_555 B DT 22 O4 ? ? C DA 13 D DT 22 1_555 ? ? ? ? ? ? WATSON-CRICK ? ? 
+hydrog29 hydrog ? A DA 14 N1 ? ? ? 1_555 B DT 21 N3 ? ? C DA 14 D DT 21 1_555 ? ? ? ? ? ? WATSON-CRICK ? ? 
+hydrog30 hydrog ? A DA 14 N6 ? ? ? 1_555 B DT 21 O4 ? ? C DA 14 D DT 21 1_555 ? ? ? ? ? ? WATSON-CRICK ? ? 
+hydrog31 hydrog ? A DT 15 N3 ? ? ? 1_555 B DA 20 N1 ? ? C DT 15 D DA 20 1_555 ? ? ? ? ? ? 'DT-DA PAIR' ? ? 
+hydrog32 hydrog ? A DG 16 N1 ? ? ? 1_555 B DC 19 N3 ? ? C DG 16 D DC 19 1_555 ? ? ? ? ? ? WATSON-CRICK ? ? 
+hydrog33 hydrog ? A DG 16 N2 ? ? ? 1_555 B DC 19 O2 ? ? C DG 16 D DC 19 1_555 ? ? ? ? ? ? WATSON-CRICK ? ? 
+hydrog34 hydrog ? A DG 16 O6 ? ? ? 1_555 B DC 19 N4 ? ? C DG 16 D DC 19 1_555 ? ? ? ? ? ? WATSON-CRICK ? ? 
+# 
+_struct_conn_type.id          hydrog 
+_struct_conn_type.criteria    
+'For hydrogen bonding between nucleic acid bases, donor to acceptor distance of 2.2 -3.5 Angstroms was used.' 
+_struct_conn_type.reference   ? 
+# 
+loop_
+_struct_mon_prot_cis.pdbx_id 
+_struct_mon_prot_cis.label_comp_id 
+_struct_mon_prot_cis.label_seq_id 
+_struct_mon_prot_cis.label_asym_id 
+_struct_mon_prot_cis.label_alt_id 
+_struct_mon_prot_cis.pdbx_PDB_ins_code 
+_struct_mon_prot_cis.auth_comp_id 
+_struct_mon_prot_cis.auth_seq_id 
+_struct_mon_prot_cis.auth_asym_id 
+_struct_mon_prot_cis.pdbx_label_comp_id_2 
+_struct_mon_prot_cis.pdbx_label_seq_id_2 
+_struct_mon_prot_cis.pdbx_label_asym_id_2 
+_struct_mon_prot_cis.pdbx_PDB_ins_code_2 
+_struct_mon_prot_cis.pdbx_auth_comp_id_2 
+_struct_mon_prot_cis.pdbx_auth_seq_id_2 
+_struct_mon_prot_cis.pdbx_auth_asym_id_2 
+_struct_mon_prot_cis.pdbx_PDB_model_num 
+_struct_mon_prot_cis.pdbx_omega_angle 
+1 PHE 70 C . ? PHE 64 A PRO 71 C ? PRO 65 A 1 1.71  
+2 PHE 70 D . ? PHE 64 B PRO 71 D ? PRO 65 B 1 -0.99 
+# 
+loop_
+_struct_sheet.id 
+_struct_sheet.type 
+_struct_sheet.number_strands 
+_struct_sheet.details 
+A ? 2 ? 
+B ? 3 ? 
+# 
+loop_
+_struct_sheet_order.sheet_id 
+_struct_sheet_order.range_id_1 
+_struct_sheet_order.range_id_2 
+_struct_sheet_order.offset 
+_struct_sheet_order.sense 
+A 1 2 ? anti-parallel 
+B 1 2 ? anti-parallel 
+B 2 3 ? anti-parallel 
+# 
+loop_
+_struct_sheet_range.sheet_id 
+_struct_sheet_range.id 
+_struct_sheet_range.beg_label_comp_id 
+_struct_sheet_range.beg_label_asym_id 
+_struct_sheet_range.beg_label_seq_id 
+_struct_sheet_range.pdbx_beg_PDB_ins_code 
+_struct_sheet_range.end_label_comp_id 
+_struct_sheet_range.end_label_asym_id 
+_struct_sheet_range.end_label_seq_id 
+_struct_sheet_range.pdbx_end_PDB_ins_code 
+_struct_sheet_range.symmetry 
+_struct_sheet_range.beg_auth_comp_id 
+_struct_sheet_range.beg_auth_asym_id 
+_struct_sheet_range.beg_auth_seq_id 
+_struct_sheet_range.end_auth_comp_id 
+_struct_sheet_range.end_auth_asym_id 
+_struct_sheet_range.end_auth_seq_id 
+A 1 LEU C 200 ? HIS C 202 ? ? LEU A 194 HIS A 196 
+A 2 GLU C 216 ? ALA C 218 ? ? GLU A 210 ALA A 212 
+B 1 ILE D 191 ? ARG D 193 ? ? ILE B 185 ARG B 187 
+B 2 MET D 199 ? ILE D 203 ? ? MET B 193 ILE B 197 
+B 3 VAL D 215 ? ALA D 218 ? ? VAL B 209 ALA B 212 
+# 
+loop_
+_pdbx_struct_sheet_hbond.sheet_id 
+_pdbx_struct_sheet_hbond.range_id_1 
+_pdbx_struct_sheet_hbond.range_id_2 
+_pdbx_struct_sheet_hbond.range_1_label_atom_id 
+_pdbx_struct_sheet_hbond.range_1_label_comp_id 
+_pdbx_struct_sheet_hbond.range_1_label_asym_id 
+_pdbx_struct_sheet_hbond.range_1_label_seq_id 
+_pdbx_struct_sheet_hbond.range_1_PDB_ins_code 
+_pdbx_struct_sheet_hbond.range_1_auth_atom_id 
+_pdbx_struct_sheet_hbond.range_1_auth_comp_id 
+_pdbx_struct_sheet_hbond.range_1_auth_asym_id 
+_pdbx_struct_sheet_hbond.range_1_auth_seq_id 
+_pdbx_struct_sheet_hbond.range_2_label_atom_id 
+_pdbx_struct_sheet_hbond.range_2_label_comp_id 
+_pdbx_struct_sheet_hbond.range_2_label_asym_id 
+_pdbx_struct_sheet_hbond.range_2_label_seq_id 
+_pdbx_struct_sheet_hbond.range_2_PDB_ins_code 
+_pdbx_struct_sheet_hbond.range_2_auth_atom_id 
+_pdbx_struct_sheet_hbond.range_2_auth_comp_id 
+_pdbx_struct_sheet_hbond.range_2_auth_asym_id 
+_pdbx_struct_sheet_hbond.range_2_auth_seq_id 
+A 1 2 N ILE C 201 ? N ILE A 195 O LYS C 217 ? O LYS A 211 
+B 1 2 N SER D 192 ? N SER B 186 O LEU D 200 ? O LEU B 194 
+B 2 3 N ILE D 201 ? N ILE B 195 O LYS D 217 ? O LYS B 211 
+# 
+_database_PDB_matrix.entry_id          1KBU 
+_database_PDB_matrix.origx[1][1]       1.000000 
+_database_PDB_matrix.origx[1][2]       0.000000 
+_database_PDB_matrix.origx[1][3]       0.000000 
+_database_PDB_matrix.origx[2][1]       0.000000 
+_database_PDB_matrix.origx[2][2]       1.000000 
+_database_PDB_matrix.origx[2][3]       0.000000 
+_database_PDB_matrix.origx[3][1]       0.000000 
+_database_PDB_matrix.origx[3][2]       0.000000 
+_database_PDB_matrix.origx[3][3]       1.000000 
+_database_PDB_matrix.origx_vector[1]   0.00000 
+_database_PDB_matrix.origx_vector[2]   0.00000 
+_database_PDB_matrix.origx_vector[3]   0.00000 
+# 
+_atom_sites.entry_id                    1KBU 
+_atom_sites.Cartn_transform_axes        ? 
+_atom_sites.fract_transf_matrix[1][1]   0.009331 
+_atom_sites.fract_transf_matrix[1][2]   0.000000 
+_atom_sites.fract_transf_matrix[1][3]   0.000000 
+_atom_sites.fract_transf_matrix[2][1]   0.000000 
+_atom_sites.fract_transf_matrix[2][2]   0.008224 
+_atom_sites.fract_transf_matrix[2][3]   0.000000 
+_atom_sites.fract_transf_matrix[3][1]   0.000000 
+_atom_sites.fract_transf_matrix[3][2]   0.000000 
+_atom_sites.fract_transf_matrix[3][3]   0.005577 
+_atom_sites.fract_transf_vector[1]      0.00000 
+_atom_sites.fract_transf_vector[2]      0.00000 
+_atom_sites.fract_transf_vector[3]      0.00000 
+# 
+loop_
+_atom_type.symbol 
+O 
+C 
+N 
+P 
+S 
+# 
+loop_
+_atom_site.group_PDB 
+_atom_site.id 
+_atom_site.type_symbol 
+_atom_site.label_atom_id 
+_atom_site.label_alt_id 
+_atom_site.label_comp_id 
+_atom_site.label_asym_id 
+_atom_site.label_entity_id 
+_atom_site.label_seq_id 
+_atom_site.pdbx_PDB_ins_code 
+_atom_site.Cartn_x 
+_atom_site.Cartn_y 
+_atom_site.Cartn_z 
+_atom_site.occupancy 
+_atom_site.B_iso_or_equiv 
+_atom_site.Cartn_x_esd 
+_atom_site.Cartn_y_esd 
+_atom_site.Cartn_z_esd 
+_atom_site.occupancy_esd 
+_atom_site.B_iso_or_equiv_esd 
+_atom_site.pdbx_formal_charge 
+_atom_site.auth_seq_id 
+_atom_site.auth_comp_id 
+_atom_site.auth_asym_id 
+_atom_site.auth_atom_id 
+_atom_site.pdbx_PDB_model_num 
+ATOM   1    O "O5'" . DA  A 1 1   ? 72.298  6.925  60.408  1.00 71.81  ? ? ? ? ? ? 1   DA  C "O5'" 1 
+ATOM   2    C "C5'" . DA  A 1 1   ? 73.381  6.379  59.662  1.00 100.00 ? ? ? ? ? ? 1   DA  C "C5'" 1 
+ATOM   3    C "C4'" . DA  A 1 1   ? 74.716  6.942  60.118  1.00 100.00 ? ? ? ? ? ? 1   DA  C "C4'" 1 
+ATOM   4    O "O4'" . DA  A 1 1   ? 75.099  8.026  59.239  1.00 100.00 ? ? ? ? ? ? 1   DA  C "O4'" 1 
+ATOM   5    C "C3'" . DA  A 1 1   ? 74.737  7.586  61.495  1.00 100.00 ? ? ? ? ? ? 1   DA  C "C3'" 1 
+ATOM   6    O "O3'" . DA  A 1 1   ? 76.088  7.618  61.937  1.00 100.00 ? ? ? ? ? ? 1   DA  C "O3'" 1 
+ATOM   7    C "C2'" . DA  A 1 1   ? 74.193  8.986  61.212  1.00 51.34  ? ? ? ? ? ? 1   DA  C "C2'" 1 
+ATOM   8    C "C1'" . DA  A 1 1   ? 74.609  9.244  59.763  1.00 68.08  ? ? ? ? ? ? 1   DA  C "C1'" 1 
+ATOM   9    N N9    . DA  A 1 1   ? 73.522  9.710  58.901  1.00 60.54  ? ? ? ? ? ? 1   DA  C N9    1 
+ATOM   10   C C8    . DA  A 1 1   ? 72.265  9.189  58.766  1.00 56.64  ? ? ? ? ? ? 1   DA  C C8    1 
+ATOM   11   N N7    . DA  A 1 1   ? 71.511  9.825  57.901  1.00 55.25  ? ? ? ? ? ? 1   DA  C N7    1 
+ATOM   12   C C5    . DA  A 1 1   ? 72.332  10.831 57.425  1.00 56.97  ? ? ? ? ? ? 1   DA  C C5    1 
+ATOM   13   C C6    . DA  A 1 1   ? 72.114  11.857 56.487  1.00 55.94  ? ? ? ? ? ? 1   DA  C C6    1 
+ATOM   14   N N6    . DA  A 1 1   ? 70.949  12.019 55.851  1.00 55.87  ? ? ? ? ? ? 1   DA  C N6    1 
+ATOM   15   N N1    . DA  A 1 1   ? 73.131  12.706 56.232  1.00 56.80  ? ? ? ? ? ? 1   DA  C N1    1 
+ATOM   16   C C2    . DA  A 1 1   ? 74.286  12.529 56.887  1.00 58.49  ? ? ? ? ? ? 1   DA  C C2    1 
+ATOM   17   N N3    . DA  A 1 1   ? 74.612  11.604 57.792  1.00 58.64  ? ? ? ? ? ? 1   DA  C N3    1 
+ATOM   18   C C4    . DA  A 1 1   ? 73.577  10.776 58.027  1.00 59.27  ? ? ? ? ? ? 1   DA  C C4    1 
+ATOM   19   P P     . DT  A 1 2   ? 76.500  8.326  63.309  1.00 100.00 ? ? ? ? ? ? 2   DT  C P     1 
+ATOM   20   O OP1   . DT  A 1 2   ? 77.942  8.063  63.523  1.00 100.00 ? ? ? ? ? ? 2   DT  C OP1   1 
+ATOM   21   O OP2   . DT  A 1 2   ? 75.503  7.957  64.340  1.00 98.80  ? ? ? ? ? ? 2   DT  C OP2   1 
+ATOM   22   O "O5'" . DT  A 1 2   ? 76.347  9.881  62.969  1.00 100.00 ? ? ? ? ? ? 2   DT  C "O5'" 1 
+ATOM   23   C "C5'" . DT  A 1 2   ? 77.223  10.472 62.017  1.00 97.35  ? ? ? ? ? ? 2   DT  C "C5'" 1 
+ATOM   24   C "C4'" . DT  A 1 2   ? 77.128  11.987 62.046  1.00 92.23  ? ? ? ? ? ? 2   DT  C "C4'" 1 
+ATOM   25   O "O4'" . DT  A 1 2   ? 76.220  12.447 61.010  1.00 88.41  ? ? ? ? ? ? 2   DT  C "O4'" 1 
+ATOM   26   C "C3'" . DT  A 1 2   ? 76.629  12.597 63.354  1.00 81.16  ? ? ? ? ? ? 2   DT  C "C3'" 1 
+ATOM   27   O "O3'" . DT  A 1 2   ? 77.355  13.789 63.631  1.00 74.78  ? ? ? ? ? ? 2   DT  C "O3'" 1 
+ATOM   28   C "C2'" . DT  A 1 2   ? 75.185  12.941 63.005  1.00 66.87  ? ? ? ? ? ? 2   DT  C "C2'" 1 
+ATOM   29   C "C1'" . DT  A 1 2   ? 75.392  13.435 61.580  1.00 55.22  ? ? ? ? ? ? 2   DT  C "C1'" 1 
+ATOM   30   N N1    . DT  A 1 2   ? 74.134  13.587 60.793  1.00 52.86  ? ? ? ? ? ? 2   DT  C N1    1 
+ATOM   31   C C2    . DT  A 1 2   ? 74.077  14.676 59.948  1.00 51.77  ? ? ? ? ? ? 2   DT  C C2    1 
+ATOM   32   O O2    . DT  A 1 2   ? 75.016  15.433 59.788  1.00 51.85  ? ? ? ? ? ? 2   DT  C O2    1 
+ATOM   33   N N3    . DT  A 1 2   ? 72.905  14.835 59.262  1.00 49.02  ? ? ? ? ? ? 2   DT  C N3    1 
+ATOM   34   C C4    . DT  A 1 2   ? 71.795  14.027 59.371  1.00 53.60  ? ? ? ? ? ? 2   DT  C C4    1 
+ATOM   35   O O4    . DT  A 1 2   ? 70.804  14.298 58.705  1.00 53.31  ? ? ? ? ? ? 2   DT  C O4    1 
+ATOM   36   C C5    . DT  A 1 2   ? 71.912  12.914 60.278  1.00 48.61  ? ? ? ? ? ? 2   DT  C C5    1 
+ATOM   37   C C7    . DT  A 1 2   ? 70.763  11.968 60.469  1.00 48.39  ? ? ? ? ? ? 2   DT  C C7    1 
+ATOM   38   C C6    . DT  A 1 2   ? 73.055  12.744 60.953  1.00 48.29  ? ? ? ? ? ? 2   DT  C C6    1 
+ATOM   39   P P     . DA  A 1 3   ? 78.032  14.066 65.054  1.00 73.86  ? ? ? ? ? ? 3   DA  C P     1 
+ATOM   40   O OP1   . DA  A 1 3   ? 79.165  13.128 65.231  1.00 81.58  ? ? ? ? ? ? 3   DA  C OP1   1 
+ATOM   41   O OP2   . DA  A 1 3   ? 76.965  14.161 66.075  1.00 89.58  ? ? ? ? ? ? 3   DA  C OP2   1 
+ATOM   42   O "O5'" . DA  A 1 3   ? 78.651  15.520 64.824  1.00 69.16  ? ? ? ? ? ? 3   DA  C "O5'" 1 
+ATOM   43   C "C5'" . DA  A 1 3   ? 79.498  15.653 63.690  1.00 59.49  ? ? ? ? ? ? 3   DA  C "C5'" 1 
+ATOM   44   C "C4'" . DA  A 1 3   ? 79.457  17.051 63.106  1.00 50.07  ? ? ? ? ? ? 3   DA  C "C4'" 1 
+ATOM   45   O "O4'" . DA  A 1 3   ? 78.185  17.264 62.448  1.00 52.26  ? ? ? ? ? ? 3   DA  C "O4'" 1 
+ATOM   46   C "C3'" . DA  A 1 3   ? 79.561  18.186 64.114  1.00 47.65  ? ? ? ? ? ? 3   DA  C "C3'" 1 
+ATOM   47   O "O3'" . DA  A 1 3   ? 79.980  19.349 63.417  1.00 48.09  ? ? ? ? ? ? 3   DA  C "O3'" 1 
+ATOM   48   C "C2'" . DA  A 1 3   ? 78.106  18.305 64.551  1.00 59.16  ? ? ? ? ? ? 3   DA  C "C2'" 1 
+ATOM   49   C "C1'" . DA  A 1 3   ? 77.389  18.150 63.213  1.00 53.62  ? ? ? ? ? ? 3   DA  C "C1'" 1 
+ATOM   50   N N9    . DA  A 1 3   ? 76.123  17.445 63.335  1.00 41.75  ? ? ? ? ? ? 3   DA  C N9    1 
+ATOM   51   C C8    . DA  A 1 3   ? 75.774  16.465 64.198  1.00 42.27  ? ? ? ? ? ? 3   DA  C C8    1 
+ATOM   52   N N7    . DA  A 1 3   ? 74.561  15.990 64.014  1.00 42.14  ? ? ? ? ? ? 3   DA  C N7    1 
+ATOM   53   C C5    . DA  A 1 3   ? 74.089  16.683 62.938  1.00 37.08  ? ? ? ? ? ? 3   DA  C C5    1 
+ATOM   54   C C6    . DA  A 1 3   ? 72.874  16.662 62.232  1.00 36.16  ? ? ? ? ? ? 3   DA  C C6    1 
+ATOM   55   N N6    . DA  A 1 3   ? 71.909  15.816 62.601  1.00 40.19  ? ? ? ? ? ? 3   DA  C N6    1 
+ATOM   56   N N1    . DA  A 1 3   ? 72.705  17.490 61.186  1.00 34.77  ? ? ? ? ? ? 3   DA  C N1    1 
+ATOM   57   C C2    . DA  A 1 3   ? 73.733  18.301 60.909  1.00 35.04  ? ? ? ? ? ? 3   DA  C C2    1 
+ATOM   58   N N3    . DA  A 1 3   ? 74.901  18.467 61.481  1.00 34.63  ? ? ? ? ? ? 3   DA  C N3    1 
+ATOM   59   C C4    . DA  A 1 3   ? 75.043  17.583 62.505  1.00 34.46  ? ? ? ? ? ? 3   DA  C C4    1 
+ATOM   60   P P     . DA  A 1 4   ? 80.528  20.655 64.148  1.00 45.88  ? ? ? ? ? ? 4   DA  C P     1 
+ATOM   61   O OP1   . DA  A 1 4   ? 81.512  21.277 63.233  1.00 40.50  ? ? ? ? ? ? 4   DA  C OP1   1 
+ATOM   62   O OP2   . DA  A 1 4   ? 80.853  20.300 65.547  1.00 49.05  ? ? ? ? ? ? 4   DA  C OP2   1 
+ATOM   63   O "O5'" . DA  A 1 4   ? 79.228  21.559 64.121  1.00 54.20  ? ? ? ? ? ? 4   DA  C "O5'" 1 
+ATOM   64   C "C5'" . DA  A 1 4   ? 78.958  22.269 62.937  1.00 45.88  ? ? ? ? ? ? 4   DA  C "C5'" 1 
+ATOM   65   C "C4'" . DA  A 1 4   ? 77.531  22.766 63.002  1.00 36.21  ? ? ? ? ? ? 4   DA  C "C4'" 1 
+ATOM   66   O "O4'" . DA  A 1 4   ? 76.651  21.622 63.159  1.00 33.89  ? ? ? ? ? ? 4   DA  C "O4'" 1 
+ATOM   67   C "C3'" . DA  A 1 4   ? 77.291  23.637 64.232  1.00 37.41  ? ? ? ? ? ? 4   DA  C "C3'" 1 
+ATOM   68   O "O3'" . DA  A 1 4   ? 76.653  24.841 63.853  1.00 32.21  ? ? ? ? ? ? 4   DA  C "O3'" 1 
+ATOM   69   C "C2'" . DA  A 1 4   ? 76.402  22.802 65.146  1.00 36.47  ? ? ? ? ? ? 4   DA  C "C2'" 1 
+ATOM   70   C "C1'" . DA  A 1 4   ? 75.661  22.004 64.087  1.00 28.03  ? ? ? ? ? ? 4   DA  C "C1'" 1 
+ATOM   71   N N9    . DA  A 1 4   ? 74.852  20.897 64.586  1.00 27.98  ? ? ? ? ? ? 4   DA  C N9    1 
+ATOM   72   C C8    . DA  A 1 4   ? 74.992  20.089 65.678  1.00 27.58  ? ? ? ? ? ? 4   DA  C C8    1 
+ATOM   73   N N7    . DA  A 1 4   ? 73.987  19.253 65.827  1.00 30.83  ? ? ? ? ? ? 4   DA  C N7    1 
+ATOM   74   C C5    . DA  A 1 4   ? 73.114  19.563 64.789  1.00 33.15  ? ? ? ? ? ? 4   DA  C C5    1 
+ATOM   75   C C6    . DA  A 1 4   ? 71.858  19.048 64.392  1.00 27.60  ? ? ? ? ? ? 4   DA  C C6    1 
+ATOM   76   N N6    . DA  A 1 4   ? 71.209  18.051 65.008  1.00 26.33  ? ? ? ? ? ? 4   DA  C N6    1 
+ATOM   77   N N1    . DA  A 1 4   ? 71.276  19.595 63.311  1.00 28.52  ? ? ? ? ? ? 4   DA  C N1    1 
+ATOM   78   C C2    . DA  A 1 4   ? 71.901  20.592 62.673  1.00 32.94  ? ? ? ? ? ? 4   DA  C C2    1 
+ATOM   79   N N3    . DA  A 1 4   ? 73.070  21.163 62.947  1.00 33.73  ? ? ? ? ? ? 4   DA  C N3    1 
+ATOM   80   C C4    . DA  A 1 4   ? 73.633  20.594 64.025  1.00 32.94  ? ? ? ? ? ? 4   DA  C C4    1 
+ATOM   81   P P     . DG  A 1 5   ? 77.056  26.188 64.613  1.00 36.64  ? ? ? ? ? ? 5   DG  C P     1 
+ATOM   82   O OP1   . DG  A 1 5   ? 77.190  27.290 63.637  1.00 32.28  ? ? ? ? ? ? 5   DG  C OP1   1 
+ATOM   83   O OP2   . DG  A 1 5   ? 78.181  25.858 65.511  1.00 53.61  ? ? ? ? ? ? 5   DG  C OP2   1 
+ATOM   84   O "O5'" . DG  A 1 5   ? 75.755  26.496 65.486  1.00 44.34  ? ? ? ? ? ? 5   DG  C "O5'" 1 
+ATOM   85   C "C5'" . DG  A 1 5   ? 74.739  25.531 65.663  1.00 35.78  ? ? ? ? ? ? 5   DG  C "C5'" 1 
+ATOM   86   C "C4'" . DG  A 1 5   ? 73.696  25.680 64.572  1.00 34.96  ? ? ? ? ? ? 5   DG  C "C4'" 1 
+ATOM   87   O "O4'" . DG  A 1 5   ? 73.211  24.343 64.299  1.00 36.37  ? ? ? ? ? ? 5   DG  C "O4'" 1 
+ATOM   88   C "C3'" . DG  A 1 5   ? 72.487  26.528 64.953  1.00 49.50  ? ? ? ? ? ? 5   DG  C "C3'" 1 
+ATOM   89   O "O3'" . DG  A 1 5   ? 72.046  27.451 63.974  1.00 46.00  ? ? ? ? ? ? 5   DG  C "O3'" 1 
+ATOM   90   C "C2'" . DG  A 1 5   ? 71.367  25.531 65.211  1.00 66.00  ? ? ? ? ? ? 5   DG  C "C2'" 1 
+ATOM   91   C "C1'" . DG  A 1 5   ? 71.833  24.231 64.564  1.00 40.84  ? ? ? ? ? ? 5   DG  C "C1'" 1 
+ATOM   92   N N9    . DG  A 1 5   ? 71.731  23.149 65.524  1.00 29.75  ? ? ? ? ? ? 5   DG  C N9    1 
+ATOM   93   C C8    . DG  A 1 5   ? 72.581  22.784 66.534  1.00 30.09  ? ? ? ? ? ? 5   DG  C C8    1 
+ATOM   94   N N7    . DG  A 1 5   ? 72.120  21.798 67.252  1.00 31.60  ? ? ? ? ? ? 5   DG  C N7    1 
+ATOM   95   C C5    . DG  A 1 5   ? 70.885  21.515 66.691  1.00 29.75  ? ? ? ? ? ? 5   DG  C C5    1 
+ATOM   96   C C6    . DG  A 1 5   ? 69.929  20.538 67.043  1.00 38.97  ? ? ? ? ? ? 5   DG  C C6    1 
+ATOM   97   O O6    . DG  A 1 5   ? 69.998  19.704 67.950  1.00 44.57  ? ? ? ? ? ? 5   DG  C O6    1 
+ATOM   98   N N1    . DG  A 1 5   ? 68.802  20.583 66.230  1.00 34.25  ? ? ? ? ? ? 5   DG  C N1    1 
+ATOM   99   C C2    . DG  A 1 5   ? 68.632  21.476 65.205  1.00 38.67  ? ? ? ? ? ? 5   DG  C C2    1 
+ATOM   100  N N2    . DG  A 1 5   ? 67.475  21.377 64.534  1.00 41.73  ? ? ? ? ? ? 5   DG  C N2    1 
+ATOM   101  N N3    . DG  A 1 5   ? 69.524  22.397 64.855  1.00 35.73  ? ? ? ? ? ? 5   DG  C N3    1 
+ATOM   102  C C4    . DG  A 1 5   ? 70.624  22.352 65.638  1.00 32.82  ? ? ? ? ? ? 5   DG  C C4    1 
+ATOM   103  P P     . DT  A 1 6   ? 71.013  28.523 64.566  1.00 45.47  ? ? ? ? ? ? 6   DT  C P     1 
+ATOM   104  O OP1   . DT  A 1 6   ? 71.010  29.707 63.673  1.00 32.85  ? ? ? ? ? ? 6   DT  C OP1   1 
+ATOM   105  O OP2   . DT  A 1 6   ? 71.311  28.677 66.014  1.00 50.94  ? ? ? ? ? ? 6   DT  C OP2   1 
+ATOM   106  O "O5'" . DT  A 1 6   ? 69.603  27.777 64.470  1.00 47.62  ? ? ? ? ? ? 6   DT  C "O5'" 1 
+ATOM   107  C "C5'" . DT  A 1 6   ? 69.094  27.299 63.242  1.00 44.05  ? ? ? ? ? ? 6   DT  C "C5'" 1 
+ATOM   108  C "C4'" . DT  A 1 6   ? 67.626  26.953 63.404  1.00 46.56  ? ? ? ? ? ? 6   DT  C "C4'" 1 
+ATOM   109  O "O4'" . DT  A 1 6   ? 67.471  25.755 64.202  1.00 49.48  ? ? ? ? ? ? 6   DT  C "O4'" 1 
+ATOM   110  C "C3'" . DT  A 1 6   ? 66.763  28.000 64.094  1.00 45.90  ? ? ? ? ? ? 6   DT  C "C3'" 1 
+ATOM   111  O "O3'" . DT  A 1 6   ? 65.489  27.972 63.500  1.00 58.58  ? ? ? ? ? ? 6   DT  C "O3'" 1 
+ATOM   112  C "C2'" . DT  A 1 6   ? 66.665  27.516 65.536  1.00 32.96  ? ? ? ? ? ? 6   DT  C "C2'" 1 
+ATOM   113  C "C1'" . DT  A 1 6   ? 66.717  26.004 65.372  1.00 30.57  ? ? ? ? ? ? 6   DT  C "C1'" 1 
+ATOM   114  N N1    . DT  A 1 6   ? 67.449  25.284 66.443  1.00 32.09  ? ? ? ? ? ? 6   DT  C N1    1 
+ATOM   115  C C2    . DT  A 1 6   ? 66.840  24.122 66.839  1.00 35.30  ? ? ? ? ? ? 6   DT  C C2    1 
+ATOM   116  O O2    . DT  A 1 6   ? 65.751  23.793 66.408  1.00 37.36  ? ? ? ? ? ? 6   DT  C O2    1 
+ATOM   117  N N3    . DT  A 1 6   ? 67.525  23.373 67.764  1.00 37.82  ? ? ? ? ? ? 6   DT  C N3    1 
+ATOM   118  C C4    . DT  A 1 6   ? 68.754  23.672 68.323  1.00 37.40  ? ? ? ? ? ? 6   DT  C C4    1 
+ATOM   119  O O4    . DT  A 1 6   ? 69.261  22.928 69.160  1.00 36.62  ? ? ? ? ? ? 6   DT  C O4    1 
+ATOM   120  C C5    . DT  A 1 6   ? 69.346  24.895 67.851  1.00 32.95  ? ? ? ? ? ? 6   DT  C C5    1 
+ATOM   121  C C7    . DT  A 1 6   ? 70.684  25.319 68.380  1.00 31.72  ? ? ? ? ? ? 6   DT  C C7    1 
+ATOM   122  C C6    . DT  A 1 6   ? 68.693  25.617 66.930  1.00 33.78  ? ? ? ? ? ? 6   DT  C C6    1 
+ATOM   123  P P     . DT  A 1 7   ? 64.438  29.138 63.793  1.00 64.26  ? ? ? ? ? ? 7   DT  C P     1 
+ATOM   124  O OP1   . DT  A 1 7   ? 63.863  29.508 62.478  1.00 87.31  ? ? ? ? ? ? 7   DT  C OP1   1 
+ATOM   125  O OP2   . DT  A 1 7   ? 65.077  30.174 64.633  1.00 44.73  ? ? ? ? ? ? 7   DT  C OP2   1 
+ATOM   126  O "O5'" . DT  A 1 7   ? 63.322  28.385 64.657  1.00 51.85  ? ? ? ? ? ? 7   DT  C "O5'" 1 
+ATOM   127  C "C5'" . DT  A 1 7   ? 63.077  26.998 64.449  1.00 39.81  ? ? ? ? ? ? 7   DT  C "C5'" 1 
+ATOM   128  C "C4'" . DT  A 1 7   ? 62.245  26.417 65.577  1.00 54.44  ? ? ? ? ? ? 7   DT  C "C4'" 1 
+ATOM   129  O "O4'" . DT  A 1 7   ? 63.089  25.758 66.557  1.00 59.94  ? ? ? ? ? ? 7   DT  C "O4'" 1 
+ATOM   130  C "C3'" . DT  A 1 7   ? 61.393  27.414 66.349  1.00 57.66  ? ? ? ? ? ? 7   DT  C "C3'" 1 
+ATOM   131  O "O3'" . DT  A 1 7   ? 60.120  26.798 66.559  1.00 62.29  ? ? ? ? ? ? 7   DT  C "O3'" 1 
+ATOM   132  C "C2'" . DT  A 1 7   ? 62.192  27.596 67.640  1.00 49.24  ? ? ? ? ? ? 7   DT  C "C2'" 1 
+ATOM   133  C "C1'" . DT  A 1 7   ? 62.764  26.199 67.861  1.00 40.70  ? ? ? ? ? ? 7   DT  C "C1'" 1 
+ATOM   134  N N1    . DT  A 1 7   ? 64.018  26.111 68.693  1.00 38.80  ? ? ? ? ? ? 7   DT  C N1    1 
+ATOM   135  C C2    . DT  A 1 7   ? 64.164  24.935 69.397  1.00 39.41  ? ? ? ? ? ? 7   DT  C C2    1 
+ATOM   136  O O2    . DT  A 1 7   ? 63.308  24.072 69.392  1.00 40.57  ? ? ? ? ? ? 7   DT  C O2    1 
+ATOM   137  N N3    . DT  A 1 7   ? 65.321  24.811 70.130  1.00 38.52  ? ? ? ? ? ? 7   DT  C N3    1 
+ATOM   138  C C4    . DT  A 1 7   ? 66.353  25.731 70.210  1.00 38.88  ? ? ? ? ? ? 7   DT  C C4    1 
+ATOM   139  O O4    . DT  A 1 7   ? 67.338  25.494 70.910  1.00 37.86  ? ? ? ? ? ? 7   DT  C O4    1 
+ATOM   140  C C5    . DT  A 1 7   ? 66.144  26.941 69.450  1.00 41.04  ? ? ? ? ? ? 7   DT  C C5    1 
+ATOM   141  C C7    . DT  A 1 7   ? 67.212  28.000 69.456  1.00 39.46  ? ? ? ? ? ? 7   DT  C C7    1 
+ATOM   142  C C6    . DT  A 1 7   ? 65.017  27.068 68.728  1.00 38.86  ? ? ? ? ? ? 7   DT  C C6    1 
+ATOM   143  P P     . DC  A 1 8   ? 58.804  27.520 67.113  1.00 57.96  ? ? ? ? ? ? 8   DC  C P     1 
+ATOM   144  O OP1   . DC  A 1 8   ? 57.659  26.870 66.437  1.00 68.57  ? ? ? ? ? ? 8   DC  C OP1   1 
+ATOM   145  O OP2   . DC  A 1 8   ? 58.962  28.993 67.087  1.00 39.10  ? ? ? ? ? ? 8   DC  C OP2   1 
+ATOM   146  O "O5'" . DC  A 1 8   ? 58.810  27.035 68.633  1.00 43.87  ? ? ? ? ? ? 8   DC  C "O5'" 1 
+ATOM   147  C "C5'" . DC  A 1 8   ? 58.860  25.633 68.846  1.00 45.30  ? ? ? ? ? ? 8   DC  C "C5'" 1 
+ATOM   148  C "C4'" . DC  A 1 8   ? 58.748  25.359 70.331  1.00 55.46  ? ? ? ? ? ? 8   DC  C "C4'" 1 
+ATOM   149  O "O4'" . DC  A 1 8   ? 60.070  25.099 70.872  1.00 56.17  ? ? ? ? ? ? 8   DC  C "O4'" 1 
+ATOM   150  C "C3'" . DC  A 1 8   ? 58.209  26.546 71.121  1.00 57.52  ? ? ? ? ? ? 8   DC  C "C3'" 1 
+ATOM   151  O "O3'" . DC  A 1 8   ? 57.539  26.047 72.264  1.00 72.00  ? ? ? ? ? ? 8   DC  C "O3'" 1 
+ATOM   152  C "C2'" . DC  A 1 8   ? 59.492  27.248 71.547  1.00 33.09  ? ? ? ? ? ? 8   DC  C "C2'" 1 
+ATOM   153  C "C1'" . DC  A 1 8   ? 60.281  26.006 71.935  1.00 39.82  ? ? ? ? ? ? 8   DC  C "C1'" 1 
+ATOM   154  N N1    . DC  A 1 8   ? 61.718  26.307 72.147  1.00 32.56  ? ? ? ? ? ? 8   DC  C N1    1 
+ATOM   155  C C2    . DC  A 1 8   ? 62.474  25.455 72.955  1.00 31.20  ? ? ? ? ? ? 8   DC  C C2    1 
+ATOM   156  O O2    . DC  A 1 8   ? 61.946  24.434 73.435  1.00 26.02  ? ? ? ? ? ? 8   DC  C O2    1 
+ATOM   157  N N3    . DC  A 1 8   ? 63.774  25.788 73.169  1.00 32.43  ? ? ? ? ? ? 8   DC  C N3    1 
+ATOM   158  C C4    . DC  A 1 8   ? 64.288  26.890 72.606  1.00 30.96  ? ? ? ? ? ? 8   DC  C C4    1 
+ATOM   159  N N4    . DC  A 1 8   ? 65.570  27.189 72.833  1.00 31.43  ? ? ? ? ? ? 8   DC  C N4    1 
+ATOM   160  C C5    . DC  A 1 8   ? 63.522  27.764 71.790  1.00 24.22  ? ? ? ? ? ? 8   DC  C C5    1 
+ATOM   161  C C6    . DC  A 1 8   ? 62.241  27.444 71.602  1.00 23.71  ? ? ? ? ? ? 8   DC  C C6    1 
+ATOM   162  P P     . DG  A 1 9   ? 56.009  26.419 72.519  1.00 67.03  ? ? ? ? ? ? 9   DG  C P     1 
+ATOM   163  O OP1   . DG  A 1 9   ? 55.224  25.544 71.621  1.00 60.52  ? ? ? ? ? ? 9   DG  C OP1   1 
+ATOM   164  O OP2   . DG  A 1 9   ? 55.881  27.893 72.450  1.00 58.45  ? ? ? ? ? ? 9   DG  C OP2   1 
+ATOM   165  O "O5'" . DG  A 1 9   ? 55.817  25.958 74.039  1.00 51.12  ? ? ? ? ? ? 9   DG  C "O5'" 1 
+ATOM   166  C "C5'" . DG  A 1 9   ? 56.192  24.629 74.380  1.00 52.25  ? ? ? ? ? ? 9   DG  C "C5'" 1 
+ATOM   167  C "C4'" . DG  A 1 9   ? 56.869  24.556 75.738  1.00 54.72  ? ? ? ? ? ? 9   DG  C "C4'" 1 
+ATOM   168  O "O4'" . DG  A 1 9   ? 58.305  24.655 75.570  1.00 48.77  ? ? ? ? ? ? 9   DG  C "O4'" 1 
+ATOM   169  C "C3'" . DG  A 1 9   ? 56.443  25.617 76.751  1.00 61.89  ? ? ? ? ? ? 9   DG  C "C3'" 1 
+ATOM   170  O "O3'" . DG  A 1 9   ? 55.838  25.054 77.915  1.00 53.68  ? ? ? ? ? ? 9   DG  C "O3'" 1 
+ATOM   171  C "C2'" . DG  A 1 9   ? 57.734  26.321 77.146  1.00 55.62  ? ? ? ? ? ? 9   DG  C "C2'" 1 
+ATOM   172  C "C1'" . DG  A 1 9   ? 58.847  25.421 76.620  1.00 41.57  ? ? ? ? ? ? 9   DG  C "C1'" 1 
+ATOM   173  N N9    . DG  A 1 9   ? 59.881  26.299 76.096  1.00 36.63  ? ? ? ? ? ? 9   DG  C N9    1 
+ATOM   174  C C8    . DG  A 1 9   ? 59.780  27.392 75.267  1.00 37.04  ? ? ? ? ? ? 9   DG  C C8    1 
+ATOM   175  N N7    . DG  A 1 9   ? 60.908  28.020 75.097  1.00 35.09  ? ? ? ? ? ? 9   DG  C N7    1 
+ATOM   176  C C5    . DG  A 1 9   ? 61.796  27.312 75.899  1.00 35.14  ? ? ? ? ? ? 9   DG  C C5    1 
+ATOM   177  C C6    . DG  A 1 9   ? 63.171  27.513 76.119  1.00 29.55  ? ? ? ? ? ? 9   DG  C C6    1 
+ATOM   178  O O6    . DG  A 1 9   ? 63.906  28.385 75.638  1.00 32.01  ? ? ? ? ? ? 9   DG  C O6    1 
+ATOM   179  N N1    . DG  A 1 9   ? 63.679  26.586 77.020  1.00 27.64  ? ? ? ? ? ? 9   DG  C N1    1 
+ATOM   180  C C2    . DG  A 1 9   ? 62.976  25.572 77.616  1.00 26.85  ? ? ? ? ? ? 9   DG  C C2    1 
+ATOM   181  N N2    . DG  A 1 9   ? 63.693  24.793 78.445  1.00 30.40  ? ? ? ? ? ? 9   DG  C N2    1 
+ATOM   182  N N3    . DG  A 1 9   ? 61.691  25.344 77.398  1.00 31.14  ? ? ? ? ? ? 9   DG  C N3    1 
+ATOM   183  C C4    . DG  A 1 9   ? 61.177  26.261 76.539  1.00 31.84  ? ? ? ? ? ? 9   DG  C C4    1 
+ATOM   184  P P     . DT  A 1 10  ? 55.180  25.989 79.038  1.00 44.64  ? ? ? ? ? ? 10  DT  C P     1 
+ATOM   185  O OP1   . DT  A 1 10  ? 53.869  25.404 79.390  1.00 60.17  ? ? ? ? ? ? 10  DT  C OP1   1 
+ATOM   186  O OP2   . DT  A 1 10  ? 55.256  27.411 78.624  1.00 26.98  ? ? ? ? ? ? 10  DT  C OP2   1 
+ATOM   187  O "O5'" . DT  A 1 10  ? 56.188  25.754 80.256  1.00 46.10  ? ? ? ? ? ? 10  DT  C "O5'" 1 
+ATOM   188  C "C5'" . DT  A 1 10  ? 56.546  24.435 80.661  1.00 42.32  ? ? ? ? ? ? 10  DT  C "C5'" 1 
+ATOM   189  C "C4'" . DT  A 1 10  ? 57.801  24.502 81.511  1.00 46.74  ? ? ? ? ? ? 10  DT  C "C4'" 1 
+ATOM   190  O "O4'" . DT  A 1 10  ? 58.842  25.086 80.690  1.00 49.67  ? ? ? ? ? ? 10  DT  C "O4'" 1 
+ATOM   191  C "C3'" . DT  A 1 10  ? 57.683  25.395 82.739  1.00 40.42  ? ? ? ? ? ? 10  DT  C "C3'" 1 
+ATOM   192  O "O3'" . DT  A 1 10  ? 58.219  24.761 83.890  1.00 49.09  ? ? ? ? ? ? 10  DT  C "O3'" 1 
+ATOM   193  C "C2'" . DT  A 1 10  ? 58.465  26.648 82.363  1.00 28.17  ? ? ? ? ? ? 10  DT  C "C2'" 1 
+ATOM   194  C "C1'" . DT  A 1 10  ? 59.512  26.099 81.402  1.00 35.63  ? ? ? ? ? ? 10  DT  C "C1'" 1 
+ATOM   195  N N1    . DT  A 1 10  ? 59.924  27.134 80.423  1.00 36.19  ? ? ? ? ? ? 10  DT  C N1    1 
+ATOM   196  C C2    . DT  A 1 10  ? 61.271  27.429 80.332  1.00 36.03  ? ? ? ? ? ? 10  DT  C C2    1 
+ATOM   197  O O2    . DT  A 1 10  ? 62.117  26.850 80.990  1.00 35.16  ? ? ? ? ? ? 10  DT  C O2    1 
+ATOM   198  N N3    . DT  A 1 10  ? 61.590  28.422 79.435  1.00 29.67  ? ? ? ? ? ? 10  DT  C N3    1 
+ATOM   199  C C4    . DT  A 1 10  ? 60.695  29.164 78.678  1.00 32.08  ? ? ? ? ? ? 10  DT  C C4    1 
+ATOM   200  O O4    . DT  A 1 10  ? 61.101  30.074 77.953  1.00 30.55  ? ? ? ? ? ? 10  DT  C O4    1 
+ATOM   201  C C5    . DT  A 1 10  ? 59.306  28.785 78.824  1.00 38.10  ? ? ? ? ? ? 10  DT  C C5    1 
+ATOM   202  C C7    . DT  A 1 10  ? 58.262  29.501 78.016  1.00 36.43  ? ? ? ? ? ? 10  DT  C C7    1 
+ATOM   203  C C6    . DT  A 1 10  ? 58.977  27.809 79.686  1.00 35.92  ? ? ? ? ? ? 10  DT  C C6    1 
+ATOM   204  P P     . DA  A 1 11  ? 58.213  25.446 85.340  1.00 53.43  ? ? ? ? ? ? 11  DA  C P     1 
+ATOM   205  O OP1   . DA  A 1 11  ? 58.177  24.330 86.313  1.00 32.61  ? ? ? ? ? ? 11  DA  C OP1   1 
+ATOM   206  O OP2   . DA  A 1 11  ? 57.201  26.528 85.397  1.00 51.43  ? ? ? ? ? ? 11  DA  C OP2   1 
+ATOM   207  O "O5'" . DA  A 1 11  ? 59.652  26.143 85.438  1.00 55.28  ? ? ? ? ? ? 11  DA  C "O5'" 1 
+ATOM   208  C "C5'" . DA  A 1 11  ? 60.867  25.408 85.589  1.00 37.06  ? ? ? ? ? ? 11  DA  C "C5'" 1 
+ATOM   209  C "C4'" . DA  A 1 11  ? 62.033  26.374 85.595  1.00 19.69  ? ? ? ? ? ? 11  DA  C "C4'" 1 
+ATOM   210  O "O4'" . DA  A 1 11  ? 61.963  27.149 84.375  1.00 24.02  ? ? ? ? ? ? 11  DA  C "O4'" 1 
+ATOM   211  C "C3'" . DA  A 1 11  ? 61.944  27.411 86.705  1.00 23.80  ? ? ? ? ? ? 11  DA  C "C3'" 1 
+ATOM   212  O "O3'" . DA  A 1 11  ? 63.092  27.254 87.512  1.00 40.74  ? ? ? ? ? ? 11  DA  C "O3'" 1 
+ATOM   213  C "C2'" . DA  A 1 11  ? 61.954  28.767 86.003  1.00 24.27  ? ? ? ? ? ? 11  DA  C "C2'" 1 
+ATOM   214  C "C1'" . DA  A 1 11  ? 62.529  28.407 84.641  1.00 23.61  ? ? ? ? ? ? 11  DA  C "C1'" 1 
+ATOM   215  N N9    . DA  A 1 11  ? 62.169  29.347 83.578  1.00 28.89  ? ? ? ? ? ? 11  DA  C N9    1 
+ATOM   216  C C8    . DA  A 1 11  ? 60.932  29.614 83.050  1.00 24.71  ? ? ? ? ? ? 11  DA  C C8    1 
+ATOM   217  N N7    . DA  A 1 11  ? 60.957  30.540 82.121  1.00 29.70  ? ? ? ? ? ? 11  DA  C N7    1 
+ATOM   218  C C5    . DA  A 1 11  ? 62.297  30.894 82.017  1.00 30.60  ? ? ? ? ? ? 11  DA  C C5    1 
+ATOM   219  C C6    . DA  A 1 11  ? 62.972  31.826 81.208  1.00 26.27  ? ? ? ? ? ? 11  DA  C C6    1 
+ATOM   220  N N6    . DA  A 1 11  ? 62.343  32.595 80.306  1.00 25.34  ? ? ? ? ? ? 11  DA  C N6    1 
+ATOM   221  N N1    . DA  A 1 11  ? 64.308  31.946 81.356  1.00 26.92  ? ? ? ? ? ? 11  DA  C N1    1 
+ATOM   222  C C2    . DA  A 1 11  ? 64.926  31.163 82.251  1.00 27.85  ? ? ? ? ? ? 11  DA  C C2    1 
+ATOM   223  N N3    . DA  A 1 11  ? 64.402  30.251 83.064  1.00 29.21  ? ? ? ? ? ? 11  DA  C N3    1 
+ATOM   224  C C4    . DA  A 1 11  ? 63.065  30.168 82.913  1.00 30.86  ? ? ? ? ? ? 11  DA  C C4    1 
+ATOM   225  P P     . DT  A 1 12  ? 63.280  28.006 88.910  1.00 37.50  ? ? ? ? ? ? 12  DT  C P     1 
+ATOM   226  O OP1   . DT  A 1 12  ? 64.245  27.228 89.717  1.00 40.31  ? ? ? ? ? ? 12  DT  C OP1   1 
+ATOM   227  O OP2   . DT  A 1 12  ? 61.964  28.286 89.518  1.00 36.10  ? ? ? ? ? ? 12  DT  C OP2   1 
+ATOM   228  O "O5'" . DT  A 1 12  ? 63.977  29.370 88.451  1.00 39.85  ? ? ? ? ? ? 12  DT  C "O5'" 1 
+ATOM   229  C "C5'" . DT  A 1 12  ? 65.278  29.333 87.886  1.00 36.00  ? ? ? ? ? ? 12  DT  C "C5'" 1 
+ATOM   230  C "C4'" . DT  A 1 12  ? 65.721  30.711 87.439  1.00 25.81  ? ? ? ? ? ? 12  DT  C "C4'" 1 
+ATOM   231  O "O4'" . DT  A 1 12  ? 64.950  31.122 86.284  1.00 31.74  ? ? ? ? ? ? 12  DT  C "O4'" 1 
+ATOM   232  C "C3'" . DT  A 1 12  ? 65.577  31.831 88.459  1.00 30.75  ? ? ? ? ? ? 12  DT  C "C3'" 1 
+ATOM   233  O "O3'" . DT  A 1 12  ? 66.840  32.429 88.538  1.00 40.73  ? ? ? ? ? ? 12  DT  C "O3'" 1 
+ATOM   234  C "C2'" . DT  A 1 12  ? 64.627  32.828 87.800  1.00 40.12  ? ? ? ? ? ? 12  DT  C "C2'" 1 
+ATOM   235  C "C1'" . DT  A 1 12  ? 64.813  32.526 86.317  1.00 36.04  ? ? ? ? ? ? 12  DT  C "C1'" 1 
+ATOM   236  N N1    . DT  A 1 12  ? 63.672  32.976 85.449  1.00 35.79  ? ? ? ? ? ? 12  DT  C N1    1 
+ATOM   237  C C2    . DT  A 1 12  ? 63.982  33.961 84.535  1.00 38.09  ? ? ? ? ? ? 12  DT  C C2    1 
+ATOM   238  O O2    . DT  A 1 12  ? 65.109  34.401 84.385  1.00 39.07  ? ? ? ? ? ? 12  DT  C O2    1 
+ATOM   239  N N3    . DT  A 1 12  ? 62.943  34.412 83.765  1.00 33.61  ? ? ? ? ? ? 12  DT  C N3    1 
+ATOM   240  C C4    . DT  A 1 12  ? 61.637  33.981 83.813  1.00 32.29  ? ? ? ? ? ? 12  DT  C C4    1 
+ATOM   241  O O4    . DT  A 1 12  ? 60.829  34.488 83.045  1.00 31.80  ? ? ? ? ? ? 12  DT  C O4    1 
+ATOM   242  C C5    . DT  A 1 12  ? 61.365  32.961 84.788  1.00 28.30  ? ? ? ? ? ? 12  DT  C C5    1 
+ATOM   243  C C7    . DT  A 1 12  ? 59.976  32.417 84.930  1.00 28.69  ? ? ? ? ? ? 12  DT  C C7    1 
+ATOM   244  C C6    . DT  A 1 12  ? 62.374  32.511 85.547  1.00 29.19  ? ? ? ? ? ? 12  DT  C C6    1 
+ATOM   245  P P     . DA  A 1 13  ? 67.337  33.353 89.733  1.00 39.21  ? ? ? ? ? ? 13  DA  C P     1 
+ATOM   246  O OP1   . DA  A 1 13  ? 68.284  32.519 90.503  1.00 42.84  ? ? ? ? ? ? 13  DA  C OP1   1 
+ATOM   247  O OP2   . DA  A 1 13  ? 66.205  34.030 90.402  1.00 56.13  ? ? ? ? ? ? 13  DA  C OP2   1 
+ATOM   248  O "O5'" . DA  A 1 13  ? 68.153  34.450 88.915  1.00 55.27  ? ? ? ? ? ? 13  DA  C "O5'" 1 
+ATOM   249  C "C5'" . DA  A 1 13  ? 69.222  34.055 88.076  1.00 43.50  ? ? ? ? ? ? 13  DA  C "C5'" 1 
+ATOM   250  C "C4'" . DA  A 1 13  ? 69.455  35.146 87.050  1.00 31.37  ? ? ? ? ? ? 13  DA  C "C4'" 1 
+ATOM   251  O "O4'" . DA  A 1 13  ? 68.287  35.301 86.202  1.00 36.38  ? ? ? ? ? ? 13  DA  C "O4'" 1 
+ATOM   252  C "C3'" . DA  A 1 13  ? 69.733  36.528 87.626  1.00 31.19  ? ? ? ? ? ? 13  DA  C "C3'" 1 
+ATOM   253  O "O3'" . DA  A 1 13  ? 70.728  37.102 86.799  1.00 34.00  ? ? ? ? ? ? 13  DA  C "O3'" 1 
+ATOM   254  C "C2'" . DA  A 1 13  ? 68.413  37.263 87.422  1.00 31.68  ? ? ? ? ? ? 13  DA  C "C2'" 1 
+ATOM   255  C "C1'" . DA  A 1 13  ? 67.966  36.672 86.092  1.00 28.31  ? ? ? ? ? ? 13  DA  C "C1'" 1 
+ATOM   256  N N9    . DA  A 1 13  ? 66.527  36.770 85.916  1.00 30.83  ? ? ? ? ? ? 13  DA  C N9    1 
+ATOM   257  C C8    . DA  A 1 13  ? 65.565  36.070 86.585  1.00 32.03  ? ? ? ? ? ? 13  DA  C C8    1 
+ATOM   258  N N7    . DA  A 1 13  ? 64.346  36.388 86.226  1.00 36.18  ? ? ? ? ? ? 13  DA  C N7    1 
+ATOM   259  C C5    . DA  A 1 13  ? 64.523  37.371 85.270  1.00 31.40  ? ? ? ? ? ? 13  DA  C C5    1 
+ATOM   260  C C6    . DA  A 1 13  ? 63.599  38.112 84.510  1.00 38.49  ? ? ? ? ? ? 13  DA  C C6    1 
+ATOM   261  N N6    . DA  A 1 13  ? 62.284  37.921 84.637  1.00 37.24  ? ? ? ? ? ? 13  DA  C N6    1 
+ATOM   262  N N1    . DA  A 1 13  ? 64.095  39.012 83.629  1.00 36.94  ? ? ? ? ? ? 13  DA  C N1    1 
+ATOM   263  C C2    . DA  A 1 13  ? 65.428  39.148 83.543  1.00 36.55  ? ? ? ? ? ? 13  DA  C C2    1 
+ATOM   264  N N3    . DA  A 1 13  ? 66.391  38.506 84.211  1.00 34.88  ? ? ? ? ? ? 13  DA  C N3    1 
+ATOM   265  C C4    . DA  A 1 13  ? 65.864  37.621 85.067  1.00 30.84  ? ? ? ? ? ? 13  DA  C C4    1 
+ATOM   266  P P     . DA  A 1 14  ? 71.526  38.422 87.199  1.00 35.51  ? ? ? ? ? ? 14  DA  C P     1 
+ATOM   267  O OP1   . DA  A 1 14  ? 72.893  38.287 86.653  1.00 54.99  ? ? ? ? ? ? 14  DA  C OP1   1 
+ATOM   268  O OP2   . DA  A 1 14  ? 71.308  38.659 88.645  1.00 47.54  ? ? ? ? ? ? 14  DA  C OP2   1 
+ATOM   269  O "O5'" . DA  A 1 14  ? 70.813  39.565 86.346  1.00 34.76  ? ? ? ? ? ? 14  DA  C "O5'" 1 
+ATOM   270  C "C5'" . DA  A 1 14  ? 70.737  39.366 84.950  1.00 31.24  ? ? ? ? ? ? 14  DA  C "C5'" 1 
+ATOM   271  C "C4'" . DA  A 1 14  ? 70.200  40.610 84.265  1.00 54.40  ? ? ? ? ? ? 14  DA  C "C4'" 1 
+ATOM   272  O "O4'" . DA  A 1 14  ? 68.753  40.667 84.347  1.00 54.43  ? ? ? ? ? ? 14  DA  C "O4'" 1 
+ATOM   273  C "C3'" . DA  A 1 14  ? 70.634  41.967 84.803  1.00 59.43  ? ? ? ? ? ? 14  DA  C "C3'" 1 
+ATOM   274  O "O3'" . DA  A 1 14  ? 70.323  42.885 83.766  1.00 60.90  ? ? ? ? ? ? 14  DA  C "O3'" 1 
+ATOM   275  C "C2'" . DA  A 1 14  ? 69.603  42.151 85.912  1.00 51.67  ? ? ? ? ? ? 14  DA  C "C2'" 1 
+ATOM   276  C "C1'" . DA  A 1 14  ? 68.383  41.841 85.052  1.00 48.29  ? ? ? ? ? ? 14  DA  C "C1'" 1 
+ATOM   277  N N9    . DA  A 1 14  ? 67.165  41.477 85.760  1.00 41.20  ? ? ? ? ? ? 14  DA  C N9    1 
+ATOM   278  C C8    . DA  A 1 14  ? 67.010  40.690 86.866  1.00 39.63  ? ? ? ? ? ? 14  DA  C C8    1 
+ATOM   279  N N7    . DA  A 1 14  ? 65.756  40.509 87.206  1.00 40.87  ? ? ? ? ? ? 14  DA  C N7    1 
+ATOM   280  C C5    . DA  A 1 14  ? 65.054  41.200 86.231  1.00 40.59  ? ? ? ? ? ? 14  DA  C C5    1 
+ATOM   281  C C6    . DA  A 1 14  ? 63.680  41.377 86.011  1.00 39.66  ? ? ? ? ? ? 14  DA  C C6    1 
+ATOM   282  N N6    . DA  A 1 14  ? 62.771  40.832 86.825  1.00 41.14  ? ? ? ? ? ? 14  DA  C N6    1 
+ATOM   283  N N1    . DA  A 1 14  ? 63.298  42.117 84.952  1.00 39.44  ? ? ? ? ? ? 14  DA  C N1    1 
+ATOM   284  C C2    . DA  A 1 14  ? 64.244  42.643 84.163  1.00 40.59  ? ? ? ? ? ? 14  DA  C C2    1 
+ATOM   285  N N3    . DA  A 1 14  ? 65.567  42.537 84.261  1.00 40.96  ? ? ? ? ? ? 14  DA  C N3    1 
+ATOM   286  C C4    . DA  A 1 14  ? 65.904  41.792 85.323  1.00 39.90  ? ? ? ? ? ? 14  DA  C C4    1 
+ATOM   287  P P     . DT  A 1 15  ? 71.421  43.615 82.867  1.00 57.67  ? ? ? ? ? ? 15  DT  C P     1 
+ATOM   288  O OP1   . DT  A 1 15  ? 71.513  42.879 81.591  1.00 62.11  ? ? ? ? ? ? 15  DT  C OP1   1 
+ATOM   289  O OP2   . DT  A 1 15  ? 72.618  43.840 83.703  1.00 95.76  ? ? ? ? ? ? 15  DT  C OP2   1 
+ATOM   290  O "O5'" . DT  A 1 15  ? 70.699  45.016 82.591  1.00 55.49  ? ? ? ? ? ? 15  DT  C "O5'" 1 
+ATOM   291  C "C5'" . DT  A 1 15  ? 70.329  45.741 83.757  1.00 62.53  ? ? ? ? ? ? 15  DT  C "C5'" 1 
+ATOM   292  C "C4'" . DT  A 1 15  ? 69.104  46.614 83.551  1.00 80.79  ? ? ? ? ? ? 15  DT  C "C4'" 1 
+ATOM   293  O "O4'" . DT  A 1 15  ? 67.910  45.874 83.922  1.00 85.33  ? ? ? ? ? ? 15  DT  C "O4'" 1 
+ATOM   294  C "C3'" . DT  A 1 15  ? 69.124  47.862 84.424  1.00 80.16  ? ? ? ? ? ? 15  DT  C "C3'" 1 
+ATOM   295  O "O3'" . DT  A 1 15  ? 68.892  49.015 83.640  1.00 84.19  ? ? ? ? ? ? 15  DT  C "O3'" 1 
+ATOM   296  C "C2'" . DT  A 1 15  ? 68.025  47.639 85.456  1.00 68.77  ? ? ? ? ? ? 15  DT  C "C2'" 1 
+ATOM   297  C "C1'" . DT  A 1 15  ? 67.085  46.680 84.734  1.00 58.02  ? ? ? ? ? ? 15  DT  C "C1'" 1 
+ATOM   298  N N1    . DT  A 1 15  ? 66.334  45.824 85.692  1.00 56.68  ? ? ? ? ? ? 15  DT  C N1    1 
+ATOM   299  C C2    . DT  A 1 15  ? 64.959  45.821 85.613  1.00 54.84  ? ? ? ? ? ? 15  DT  C C2    1 
+ATOM   300  O O2    . DT  A 1 15  ? 64.342  46.427 84.755  1.00 53.44  ? ? ? ? ? ? 15  DT  C O2    1 
+ATOM   301  N N3    . DT  A 1 15  ? 64.339  45.046 86.561  1.00 51.23  ? ? ? ? ? ? 15  DT  C N3    1 
+ATOM   302  C C4    . DT  A 1 15  ? 64.939  44.319 87.574  1.00 52.14  ? ? ? ? ? ? 15  DT  C C4    1 
+ATOM   303  O O4    . DT  A 1 15  ? 64.253  43.669 88.360  1.00 53.55  ? ? ? ? ? ? 15  DT  C O4    1 
+ATOM   304  C C5    . DT  A 1 15  ? 66.374  44.400 87.610  1.00 53.08  ? ? ? ? ? ? 15  DT  C C5    1 
+ATOM   305  C C7    . DT  A 1 15  ? 67.127  43.640 88.660  1.00 54.39  ? ? ? ? ? ? 15  DT  C C7    1 
+ATOM   306  C C6    . DT  A 1 15  ? 66.999  45.145 86.691  1.00 50.68  ? ? ? ? ? ? 15  DT  C C6    1 
+ATOM   307  P P     A DG  A 1 16  ? 69.777  50.319 83.902  0.73 86.77  ? ? ? ? ? ? 16  DG  C P     1 
+ATOM   308  P P     B DG  A 1 16  ? 69.625  50.425 83.768  0.27 82.03  ? ? ? ? ? ? 16  DG  C P     1 
+ATOM   309  O OP1   A DG  A 1 16  ? 70.948  50.246 83.003  0.73 78.96  ? ? ? ? ? ? 16  DG  C OP1   1 
+ATOM   310  O OP1   B DG  A 1 16  ? 70.757  50.554 82.825  0.27 79.67  ? ? ? ? ? ? 16  DG  C OP1   1 
+ATOM   311  O OP2   A DG  A 1 16  ? 69.981  50.456 85.362  0.73 72.52  ? ? ? ? ? ? 16  DG  C OP2   1 
+ATOM   312  O OP2   B DG  A 1 16  ? 69.864  50.547 85.225  0.27 82.04  ? ? ? ? ? ? 16  DG  C OP2   1 
+ATOM   313  O "O5'" A DG  A 1 16  ? 68.795  51.456 83.350  0.73 67.43  ? ? ? ? ? ? 16  DG  C "O5'" 1 
+ATOM   314  O "O5'" B DG  A 1 16  ? 68.481  51.456 83.316  0.27 86.45  ? ? ? ? ? ? 16  DG  C "O5'" 1 
+ATOM   315  C "C5'" A DG  A 1 16  ? 68.235  51.226 82.058  0.73 38.17  ? ? ? ? ? ? 16  DG  C "C5'" 1 
+ATOM   316  C "C5'" B DG  A 1 16  ? 68.146  51.652 81.936  0.27 91.79  ? ? ? ? ? ? 16  DG  C "C5'" 1 
+ATOM   317  C "C4'" A DG  A 1 16  ? 66.888  51.898 81.858  0.73 87.29  ? ? ? ? ? ? 16  DG  C "C4'" 1 
+ATOM   318  C "C4'" B DG  A 1 16  ? 66.741  52.203 81.742  0.27 96.42  ? ? ? ? ? ? 16  DG  C "C4'" 1 
+ATOM   319  O "O4'" A DG  A 1 16  ? 65.821  51.083 82.404  0.73 86.93  ? ? ? ? ? ? 16  DG  C "O4'" 1 
+ATOM   320  O "O4'" B DG  A 1 16  ? 65.782  51.275 82.316  0.27 97.17  ? ? ? ? ? ? 16  DG  C "O4'" 1 
+ATOM   321  C "C3'" A DG  A 1 16  ? 66.739  53.297 82.436  0.73 100.00 ? ? ? ? ? ? 16  DG  C "C3'" 1 
+ATOM   322  C "C3'" B DG  A 1 16  ? 66.515  53.571 82.380  0.27 98.64  ? ? ? ? ? ? 16  DG  C "C3'" 1 
+ATOM   323  O "O3'" A DG  A 1 16  ? 66.259  54.180 81.435  0.73 100.00 ? ? ? ? ? ? 16  DG  C "O3'" 1 
+ATOM   324  O "O3'" B DG  A 1 16  ? 66.621  54.732 81.493  0.27 100.00 ? ? ? ? ? ? 16  DG  C "O3'" 1 
+ATOM   325  C "C2'" A DG  A 1 16  ? 65.748  53.150 83.588  0.73 100.00 ? ? ? ? ? ? 16  DG  C "C2'" 1 
+ATOM   326  C "C2'" B DG  A 1 16  ? 65.285  53.409 83.276  0.27 99.47  ? ? ? ? ? ? 16  DG  C "C2'" 1 
+ATOM   327  C "C1'" A DG  A 1 16  ? 65.084  51.790 83.381  0.73 99.55  ? ? ? ? ? ? 16  DG  C "C1'" 1 
+ATOM   328  C "C1'" B DG  A 1 16  ? 64.971  51.908 83.285  0.27 99.58  ? ? ? ? ? ? 16  DG  C "C1'" 1 
+ATOM   329  N N9    A DG  A 1 16  ? 65.083  50.975 84.591  0.73 98.06  ? ? ? ? ? ? 16  DG  C N9    1 
+ATOM   330  N N9    B DG  A 1 16  ? 65.061  51.151 84.540  0.27 99.50  ? ? ? ? ? ? 16  DG  C N9    1 
+ATOM   331  C C8    A DG  A 1 16  ? 66.174  50.616 85.348  0.73 97.81  ? ? ? ? ? ? 16  DG  C C8    1 
+ATOM   332  C C8    B DG  A 1 16  ? 66.169  50.809 85.281  0.27 99.47  ? ? ? ? ? ? 16  DG  C C8    1 
+ATOM   333  N N7    A DG  A 1 16  ? 65.883  49.874 86.379  0.73 96.46  ? ? ? ? ? ? 16  DG  C N7    1 
+ATOM   334  N N7    B DG  A 1 16  ? 65.901  50.076 86.328  0.27 99.34  ? ? ? ? ? ? 16  DG  C N7    1 
+ATOM   335  C C5    A DG  A 1 16  ? 64.503  49.725 86.303  0.73 95.15  ? ? ? ? ? ? 16  DG  C C5    1 
+ATOM   336  C C5    B DG  A 1 16  ? 64.525  49.889 86.270  0.27 100.00 ? ? ? ? ? ? 16  DG  C C5    1 
+ATOM   337  C C6    A DG  A 1 16  ? 63.625  49.016 87.156  0.73 90.08  ? ? ? ? ? ? 16  DG  C C6    1 
+ATOM   338  C C6    B DG  A 1 16  ? 63.663  49.174 87.139  0.27 98.34  ? ? ? ? ? ? 16  DG  C C6    1 
+ATOM   339  O O6    A DG  A 1 16  ? 63.905  48.362 88.173  0.73 87.06  ? ? ? ? ? ? 16  DG  C O6    1 
+ATOM   340  O O6    B DG  A 1 16  ? 63.956  48.543 88.165  0.27 96.36  ? ? ? ? ? ? 16  DG  C O6    1 
+ATOM   341  N N1    A DG  A 1 16  ? 62.303  49.115 86.729  0.73 88.78  ? ? ? ? ? ? 16  DG  C N1    1 
+ATOM   342  N N1    B DG  A 1 16  ? 62.336  49.236 86.719  0.27 98.01  ? ? ? ? ? ? 16  DG  C N1    1 
+ATOM   343  C C2    A DG  A 1 16  ? 61.887  49.815 85.622  0.73 90.55  ? ? ? ? ? ? 16  DG  C C2    1 
+ATOM   344  C C2    B DG  A 1 16  ? 61.901  49.906 85.601  0.27 98.11  ? ? ? ? ? ? 16  DG  C C2    1 
+ATOM   345  N N2    A DG  A 1 16  ? 60.571  49.794 85.370  0.73 95.02  ? ? ? ? ? ? 16  DG  C N2    1 
+ATOM   346  N N2    B DG  A 1 16  ? 60.584  49.853 85.353  0.27 99.02  ? ? ? ? ? ? 16  DG  C N2    1 
+ATOM   347  N N3    A DG  A 1 16  ? 62.701  50.482 84.813  0.73 92.31  ? ? ? ? ? ? 16  DG  C N3    1 
+ATOM   348  N N3    B DG  A 1 16  ? 62.699  50.578 84.779  0.27 98.63  ? ? ? ? ? ? 16  DG  C N3    1 
+ATOM   349  C C4    A DG  A 1 16  ? 63.994  50.396 85.211  0.73 94.74  ? ? ? ? ? ? 16  DG  C C4    1 
+ATOM   350  C C4    B DG  A 1 16  ? 63.997  50.531 85.169  0.27 99.47  ? ? ? ? ? ? 16  DG  C C4    1 
+ATOM   351  P P     B DT  A 1 17  ? 65.674  55.535 80.459  0.27 100.00 ? ? ? ? ? ? 17  DT  C P     1 
+ATOM   352  O OP1   B DT  A 1 17  ? 65.738  54.854 79.145  0.27 100.00 ? ? ? ? ? ? 17  DT  C OP1   1 
+ATOM   353  O OP2   B DT  A 1 17  ? 66.011  56.979 80.543  0.27 100.00 ? ? ? ? ? ? 17  DT  C OP2   1 
+ATOM   354  O "O5'" B DT  A 1 17  ? 64.195  55.350 81.038  0.27 96.30  ? ? ? ? ? ? 17  DT  C "O5'" 1 
+ATOM   355  C "C5'" B DT  A 1 17  ? 63.966  55.923 82.316  0.27 90.54  ? ? ? ? ? ? 17  DT  C "C5'" 1 
+ATOM   356  C "C4'" B DT  A 1 17  ? 62.529  55.762 82.774  0.27 87.70  ? ? ? ? ? ? 17  DT  C "C4'" 1 
+ATOM   357  O "O4'" B DT  A 1 17  ? 62.449  54.582 83.619  0.27 85.85  ? ? ? ? ? ? 17  DT  C "O4'" 1 
+ATOM   358  C "C3'" B DT  A 1 17  ? 62.082  56.919 83.658  0.27 87.75  ? ? ? ? ? ? 17  DT  C "C3'" 1 
+ATOM   359  O "O3'" B DT  A 1 17  ? 60.682  57.116 83.642  0.27 87.60  ? ? ? ? ? ? 17  DT  C "O3'" 1 
+ATOM   360  C "C2'" B DT  A 1 17  ? 62.482  56.420 85.034  0.27 85.76  ? ? ? ? ? ? 17  DT  C "C2'" 1 
+ATOM   361  C "C1'" B DT  A 1 17  ? 62.004  54.983 84.900  0.27 85.27  ? ? ? ? ? ? 17  DT  C "C1'" 1 
+ATOM   362  N N1    B DT  A 1 17  ? 62.606  54.172 85.983  0.27 85.68  ? ? ? ? ? ? 17  DT  C N1    1 
+ATOM   363  C C2    B DT  A 1 17  ? 61.829  53.247 86.646  0.27 84.89  ? ? ? ? ? ? 17  DT  C C2    1 
+ATOM   364  O O2    B DT  A 1 17  ? 60.704  52.936 86.300  0.27 83.81  ? ? ? ? ? ? 17  DT  C O2    1 
+ATOM   365  N N3    B DT  A 1 17  ? 62.468  52.638 87.696  0.27 84.36  ? ? ? ? ? ? 17  DT  C N3    1 
+ATOM   366  C C4    B DT  A 1 17  ? 63.738  52.913 88.169  0.27 85.15  ? ? ? ? ? ? 17  DT  C C4    1 
+ATOM   367  O O4    B DT  A 1 17  ? 64.176  52.281 89.124  0.27 84.13  ? ? ? ? ? ? 17  DT  C O4    1 
+ATOM   368  C C5    B DT  A 1 17  ? 64.457  53.943 87.464  0.27 87.12  ? ? ? ? ? ? 17  DT  C C5    1 
+ATOM   369  C C7    B DT  A 1 17  ? 65.848  54.313 87.884  0.27 86.84  ? ? ? ? ? ? 17  DT  C C7    1 
+ATOM   370  C C6    B DT  A 1 17  ? 63.855  54.542 86.433  0.27 87.07  ? ? ? ? ? ? 17  DT  C C6    1 
+ATOM   371  P P     B DA  A 1 18  ? 60.227  58.509 84.276  0.27 87.15  ? ? ? ? ? ? 18  DA  C P     1 
+ATOM   372  O OP1   B DA  A 1 18  ? 61.263  58.935 85.245  0.27 82.68  ? ? ? ? ? ? 18  DA  C OP1   1 
+ATOM   373  O OP2   B DA  A 1 18  ? 58.813  58.385 84.691  0.27 88.34  ? ? ? ? ? ? 18  DA  C OP2   1 
+ATOM   374  O "O5'" B DA  A 1 18  ? 60.323  59.440 82.982  0.27 88.46  ? ? ? ? ? ? 18  DA  C "O5'" 1 
+ATOM   375  C "C5'" B DA  A 1 18  ? 60.264  58.748 81.742  0.27 87.59  ? ? ? ? ? ? 18  DA  C "C5'" 1 
+ATOM   376  C "C4'" B DA  A 1 18  ? 59.492  59.559 80.723  0.27 86.66  ? ? ? ? ? ? 18  DA  C "C4'" 1 
+ATOM   377  O "O4'" B DA  A 1 18  ? 60.192  60.823 80.576  0.27 83.05  ? ? ? ? ? ? 18  DA  C "O4'" 1 
+ATOM   378  C "C3'" B DA  A 1 18  ? 59.453  58.931 79.332  0.27 91.52  ? ? ? ? ? ? 18  DA  C "C3'" 1 
+ATOM   379  O "O3'" B DA  A 1 18  ? 58.250  59.165 78.591  0.27 98.75  ? ? ? ? ? ? 18  DA  C "O3'" 1 
+ATOM   380  C "C2'" B DA  A 1 18  ? 60.641  59.585 78.649  0.27 82.13  ? ? ? ? ? ? 18  DA  C "C2'" 1 
+ATOM   381  C "C1'" B DA  A 1 18  ? 60.482  60.991 79.206  0.27 77.55  ? ? ? ? ? ? 18  DA  C "C1'" 1 
+ATOM   382  N N9    B DA  A 1 18  ? 61.695  61.755 78.971  0.27 74.49  ? ? ? ? ? ? 18  DA  C N9    1 
+ATOM   383  C C8    B DA  A 1 18  ? 62.750  61.290 78.241  0.27 73.85  ? ? ? ? ? ? 18  DA  C C8    1 
+ATOM   384  N N7    B DA  A 1 18  ? 63.741  62.133 78.118  0.27 73.98  ? ? ? ? ? ? 18  DA  C N7    1 
+ATOM   385  C C5    B DA  A 1 18  ? 63.295  63.245 78.806  0.27 77.26  ? ? ? ? ? ? 18  DA  C C5    1 
+ATOM   386  C C6    B DA  A 1 18  ? 63.892  64.496 79.046  0.27 76.98  ? ? ? ? ? ? 18  DA  C C6    1 
+ATOM   387  N N6    B DA  A 1 18  ? 65.105  64.826 78.594  0.27 74.67  ? ? ? ? ? ? 18  DA  C N6    1 
+ATOM   388  N N1    B DA  A 1 18  ? 63.192  65.396 79.765  0.27 77.17  ? ? ? ? ? ? 18  DA  C N1    1 
+ATOM   389  C C2    B DA  A 1 18  ? 61.976  65.056 80.210  0.27 78.15  ? ? ? ? ? ? 18  DA  C C2    1 
+ATOM   390  N N3    B DA  A 1 18  ? 61.312  63.911 80.050  0.27 77.79  ? ? ? ? ? ? 18  DA  C N3    1 
+ATOM   391  C C4    B DA  A 1 18  ? 62.034  63.039 79.330  0.27 76.62  ? ? ? ? ? ? 18  DA  C C4    1 
+ATOM   392  P P     A DT  A 1 19  ? 57.429  60.603 78.119  0.73 100.00 ? ? ? ? ? ? 19  DT  C P     1 
+ATOM   393  P P     B DT  A 1 19  ? 57.298  60.457 78.558  0.27 100.00 ? ? ? ? ? ? 19  DT  C P     1 
+ATOM   394  O OP1   A DT  A 1 19  ? 57.835  59.545 79.072  0.73 100.00 ? ? ? ? ? ? 19  DT  C OP1   1 
+ATOM   395  O OP1   B DT  A 1 19  ? 57.532  61.289 79.759  0.27 95.12  ? ? ? ? ? ? 19  DT  C OP1   1 
+ATOM   396  O OP2   A DT  A 1 19  ? 56.186  61.370 78.357  0.73 100.00 ? ? ? ? ? ? 19  DT  C OP2   1 
+ATOM   397  O OP2   B DT  A 1 19  ? 55.934  59.942 78.306  0.27 97.64  ? ? ? ? ? ? 19  DT  C OP2   1 
+ATOM   398  O "O5'" A DT  A 1 19  ? 58.652  61.623 77.943  0.73 100.00 ? ? ? ? ? ? 19  DT  C "O5'" 1 
+ATOM   399  O "O5'" B DT  A 1 19  ? 57.737  61.321 77.275  0.27 100.00 ? ? ? ? ? ? 19  DT  C "O5'" 1 
+ATOM   400  C "C5'" A DT  A 1 19  ? 58.623  62.612 76.924  0.73 97.11  ? ? ? ? ? ? 19  DT  C "C5'" 1 
+ATOM   401  C "C5'" B DT  A 1 19  ? 58.699  62.391 77.251  0.27 98.33  ? ? ? ? ? ? 19  DT  C "C5'" 1 
+ATOM   402  C "C4'" A DT  A 1 19  ? 58.106  63.928 77.470  0.73 95.06  ? ? ? ? ? ? 19  DT  C "C4'" 1 
+ATOM   403  C "C4'" B DT  A 1 19  ? 58.151  63.771 77.598  0.27 95.98  ? ? ? ? ? ? 19  DT  C "C4'" 1 
+ATOM   404  O "O4'" A DT  A 1 19  ? 59.243  64.777 77.766  0.73 95.00  ? ? ? ? ? ? 19  DT  C "O4'" 1 
+ATOM   405  O "O4'" B DT  A 1 19  ? 59.255  64.681 77.851  0.27 94.99  ? ? ? ? ? ? 19  DT  C "O4'" 1 
+ATOM   406  C "C3'" A DT  A 1 19  ? 57.350  64.720 76.421  0.73 96.22  ? ? ? ? ? ? 19  DT  C "C3'" 1 
+ATOM   407  C "C3'" B DT  A 1 19  ? 57.347  64.508 76.534  0.27 95.97  ? ? ? ? ? ? 19  DT  C "C3'" 1 
+ATOM   408  O "O3'" A DT  A 1 19  ? 56.727  65.825 77.069  0.73 100.00 ? ? ? ? ? ? 19  DT  C "O3'" 1 
+ATOM   409  O "O3'" B DT  A 1 19  ? 56.652  65.577 77.174  0.27 100.00 ? ? ? ? ? ? 19  DT  C "O3'" 1 
+ATOM   410  C "C2'" A DT  A 1 19  ? 58.525  65.169 75.558  0.73 80.10  ? ? ? ? ? ? 19  DT  C "C2'" 1 
+ATOM   411  C "C2'" B DT  A 1 19  ? 58.471  65.063 75.665  0.27 87.03  ? ? ? ? ? ? 19  DT  C "C2'" 1 
+ATOM   412  C "C1'" A DT  A 1 19  ? 59.516  65.589 76.639  0.73 75.27  ? ? ? ? ? ? 19  DT  C "C1'" 1 
+ATOM   413  C "C1'" B DT  A 1 19  ? 59.458  65.527 76.733  0.27 84.69  ? ? ? ? ? ? 19  DT  C "C1'" 1 
+ATOM   414  N N1    A DT  A 1 19  ? 60.944  65.438 76.258  0.73 73.67  ? ? ? ? ? ? 19  DT  C N1    1 
+ATOM   415  N N1    B DT  A 1 19  ? 60.894  65.420 76.330  0.27 83.97  ? ? ? ? ? ? 19  DT  C N1    1 
+ATOM   416  C C2    A DT  A 1 19  ? 61.785  66.495 76.549  0.73 70.55  ? ? ? ? ? ? 19  DT  C C2    1 
+ATOM   417  C C2    B DT  A 1 19  ? 61.749  66.448 76.677  0.27 82.32  ? ? ? ? ? ? 19  DT  C C2    1 
+ATOM   418  O O2    A DT  A 1 19  ? 61.429  67.520 77.108  0.73 67.29  ? ? ? ? ? ? 19  DT  C O2    1 
+ATOM   419  O O2    B DT  A 1 19  ? 61.389  67.452 77.268  0.27 80.67  ? ? ? ? ? ? 19  DT  C O2    1 
+ATOM   420  N N3    A DT  A 1 19  ? 63.087  66.299 76.165  0.73 71.91  ? ? ? ? ? ? 19  DT  C N3    1 
+ATOM   421  N N3    B DT  A 1 19  ? 63.056  66.263 76.296  0.27 82.14  ? ? ? ? ? ? 19  DT  C N3    1 
+ATOM   422  C C4    A DT  A 1 19  ? 63.611  65.183 75.531  0.73 72.72  ? ? ? ? ? ? 19  DT  C C4    1 
+ATOM   423  C C4    B DT  A 1 19  ? 63.587  65.175 75.626  0.27 82.60  ? ? ? ? ? ? 19  DT  C C4    1 
+ATOM   424  O O4    A DT  A 1 19  ? 64.804  65.155 75.244  0.73 71.72  ? ? ? ? ? ? 19  DT  C O4    1 
+ATOM   425  O O4    B DT  A 1 19  ? 64.783  65.155 75.346  0.27 81.62  ? ? ? ? ? ? 19  DT  C O4    1 
+ATOM   426  C C5    A DT  A 1 19  ? 62.670  64.123 75.260  0.73 75.36  ? ? ? ? ? ? 19  DT  C C5    1 
+ATOM   427  C C5    B DT  A 1 19  ? 62.638  64.138 75.306  0.27 83.55  ? ? ? ? ? ? 19  DT  C C5    1 
+ATOM   428  C C7    A DT  A 1 19  ? 63.122  62.870 74.565  0.73 75.15  ? ? ? ? ? ? 19  DT  C C7    1 
+ATOM   429  C C7    B DT  A 1 19  ? 63.088  62.906 74.576  0.27 82.88  ? ? ? ? ? ? 19  DT  C C7    1 
+ATOM   430  C C6    A DT  A 1 19  ? 61.395  64.295 75.630  0.73 74.40  ? ? ? ? ? ? 19  DT  C C6    1 
+ATOM   431  C C6    B DT  A 1 19  ? 61.359  64.301 75.672  0.27 83.70  ? ? ? ? ? ? 19  DT  C C6    1 
+ATOM   432  P P     . DG  A 1 20  ? 55.344  66.400 76.523  1.00 95.03  ? ? ? ? ? ? 20  DG  C P     1 
+ATOM   433  O OP1   . DG  A 1 20  ? 54.457  66.677 77.677  1.00 95.76  ? ? ? ? ? ? 20  DG  C OP1   1 
+ATOM   434  O OP2   . DG  A 1 20  ? 54.902  65.486 75.440  1.00 90.27  ? ? ? ? ? ? 20  DG  C OP2   1 
+ATOM   435  O "O5'" . DG  A 1 20  ? 55.784  67.796 75.891  1.00 66.58  ? ? ? ? ? ? 20  DG  C "O5'" 1 
+ATOM   436  C "C5'" . DG  A 1 20  ? 56.112  68.881 76.750  1.00 58.47  ? ? ? ? ? ? 20  DG  C "C5'" 1 
+ATOM   437  C "C4'" . DG  A 1 20  ? 56.852  69.928 75.941  1.00 73.27  ? ? ? ? ? ? 20  DG  C "C4'" 1 
+ATOM   438  O "O4'" . DG  A 1 20  ? 58.186  69.444 75.637  1.00 68.14  ? ? ? ? ? ? 20  DG  C "O4'" 1 
+ATOM   439  C "C3'" . DG  A 1 20  ? 56.241  70.238 74.580  1.00 88.72  ? ? ? ? ? ? 20  DG  C "C3'" 1 
+ATOM   440  O "O3'" . DG  A 1 20  ? 56.641  71.549 74.216  1.00 85.15  ? ? ? ? ? ? 20  DG  C "O3'" 1 
+ATOM   441  C "C2'" . DG  A 1 20  ? 56.943  69.215 73.687  1.00 68.95  ? ? ? ? ? ? 20  DG  C "C2'" 1 
+ATOM   442  C "C1'" . DG  A 1 20  ? 58.343  69.428 74.238  1.00 57.98  ? ? ? ? ? ? 20  DG  C "C1'" 1 
+ATOM   443  N N9    . DG  A 1 20  ? 59.377  68.467 73.883  1.00 53.02  ? ? ? ? ? ? 20  DG  C N9    1 
+ATOM   444  C C8    . DG  A 1 20  ? 59.453  67.178 73.415  1.00 58.69  ? ? ? ? ? ? 20  DG  C C8    1 
+ATOM   445  N N7    . DG  A 1 20  ? 60.697  66.801 73.246  1.00 53.76  ? ? ? ? ? ? 20  DG  C N7    1 
+ATOM   446  C C5    . DG  A 1 20  ? 61.463  67.905 73.627  1.00 51.83  ? ? ? ? ? ? 20  DG  C C5    1 
+ATOM   447  C C6    . DG  A 1 20  ? 62.865  68.093 73.672  1.00 51.24  ? ? ? ? ? ? 20  DG  C C6    1 
+ATOM   448  O O6    . DG  A 1 20  ? 63.749  67.285 73.363  1.00 50.67  ? ? ? ? ? ? 20  DG  C O6    1 
+ATOM   449  N N1    . DG  A 1 20  ? 63.197  69.373 74.136  1.00 47.72  ? ? ? ? ? ? 20  DG  C N1    1 
+ATOM   450  C C2    . DG  A 1 20  ? 62.293  70.337 74.510  1.00 53.70  ? ? ? ? ? ? 20  DG  C C2    1 
+ATOM   451  N N2    . DG  A 1 20  ? 62.806  71.507 74.925  1.00 52.59  ? ? ? ? ? ? 20  DG  C N2    1 
+ATOM   452  N N3    . DG  A 1 20  ? 60.978  70.173 74.480  1.00 56.02  ? ? ? ? ? ? 20  DG  C N3    1 
+ATOM   453  C C4    . DG  A 1 20  ? 60.652  68.939 74.029  1.00 53.47  ? ? ? ? ? ? 20  DG  C C4    1 
+ATOM   454  P P     . DC  A 1 21  ? 55.566  72.721 74.322  1.00 72.97  ? ? ? ? ? ? 21  DC  C P     1 
+ATOM   455  O OP1   . DC  A 1 21  ? 55.256  72.919 75.760  1.00 65.47  ? ? ? ? ? ? 21  DC  C OP1   1 
+ATOM   456  O OP2   . DC  A 1 21  ? 54.517  72.361 73.345  1.00 66.49  ? ? ? ? ? ? 21  DC  C OP2   1 
+ATOM   457  O "O5'" . DC  A 1 21  ? 56.376  73.996 73.797  1.00 61.53  ? ? ? ? ? ? 21  DC  C "O5'" 1 
+ATOM   458  C "C5'" . DC  A 1 21  ? 57.188  74.761 74.678  1.00 49.32  ? ? ? ? ? ? 21  DC  C "C5'" 1 
+ATOM   459  C "C4'" . DC  A 1 21  ? 58.574  74.887 74.080  1.00 41.91  ? ? ? ? ? ? 21  DC  C "C4'" 1 
+ATOM   460  O "O4'" . DC  A 1 21  ? 59.024  73.585 73.641  1.00 51.05  ? ? ? ? ? ? 21  DC  C "O4'" 1 
+ATOM   461  C "C3'" . DC  A 1 21  ? 58.647  75.742 72.828  1.00 31.36  ? ? ? ? ? ? 21  DC  C "C3'" 1 
+ATOM   462  O "O3'" . DC  A 1 21  ? 59.360  76.886 73.211  1.00 36.41  ? ? ? ? ? ? 21  DC  C "O3'" 1 
+ATOM   463  C "C2'" . DC  A 1 21  ? 59.451  74.923 71.814  1.00 38.35  ? ? ? ? ? ? 21  DC  C "C2'" 1 
+ATOM   464  C "C1'" . DC  A 1 21  ? 60.008  73.771 72.647  1.00 41.61  ? ? ? ? ? ? 21  DC  C "C1'" 1 
+ATOM   465  N N1    . DC  A 1 21  ? 60.225  72.452 71.952  1.00 38.27  ? ? ? ? ? ? 21  DC  C N1    1 
+ATOM   466  C C2    . DC  A 1 21  ? 61.534  72.027 71.652  1.00 33.43  ? ? ? ? ? ? 21  DC  C C2    1 
+ATOM   467  O O2    . DC  A 1 21  ? 62.494  72.764 71.925  1.00 38.82  ? ? ? ? ? ? 21  DC  C O2    1 
+ATOM   468  N N3    . DC  A 1 21  ? 61.734  70.823 71.057  1.00 29.49  ? ? ? ? ? ? 21  DC  C N3    1 
+ATOM   469  C C4    . DC  A 1 21  ? 60.685  70.048 70.777  1.00 31.65  ? ? ? ? ? ? 21  DC  C C4    1 
+ATOM   470  N N4    . DC  A 1 21  ? 60.914  68.869 70.182  1.00 28.89  ? ? ? ? ? ? 21  DC  C N4    1 
+ATOM   471  C C5    . DC  A 1 21  ? 59.351  70.448 71.098  1.00 31.51  ? ? ? ? ? ? 21  DC  C C5    1 
+ATOM   472  C C6    . DC  A 1 21  ? 59.164  71.638 71.680  1.00 32.55  ? ? ? ? ? ? 21  DC  C C6    1 
+ATOM   473  P P     . DT  A 1 22  ? 59.749  77.831 72.001  1.00 41.67  ? ? ? ? ? ? 22  DT  C P     1 
+ATOM   474  O OP1   . DT  A 1 22  ? 60.081  79.165 72.539  1.00 32.30  ? ? ? ? ? ? 22  DT  C OP1   1 
+ATOM   475  O OP2   . DT  A 1 22  ? 58.673  77.628 71.011  1.00 50.13  ? ? ? ? ? ? 22  DT  C OP2   1 
+ATOM   476  O "O5'" . DT  A 1 22  ? 61.111  77.167 71.493  1.00 59.79  ? ? ? ? ? ? 22  DT  C "O5'" 1 
+ATOM   477  C "C5'" . DT  A 1 22  ? 62.359  77.792 71.774  1.00 52.30  ? ? ? ? ? ? 22  DT  C "C5'" 1 
+ATOM   478  C "C4'" . DT  A 1 22  ? 63.444  77.275 70.846  1.00 54.83  ? ? ? ? ? ? 22  DT  C "C4'" 1 
+ATOM   479  O "O4'" . DT  A 1 22  ? 63.295  75.856 70.567  1.00 53.09  ? ? ? ? ? ? 22  DT  C "O4'" 1 
+ATOM   480  C "C3'" . DT  A 1 22  ? 63.510  77.958 69.487  1.00 51.02  ? ? ? ? ? ? 22  DT  C "C3'" 1 
+ATOM   481  O "O3'" . DT  A 1 22  ? 64.876  78.123 69.151  1.00 56.30  ? ? ? ? ? ? 22  DT  C "O3'" 1 
+ATOM   482  C "C2'" . DT  A 1 22  ? 62.840  76.944 68.567  1.00 38.86  ? ? ? ? ? ? 22  DT  C "C2'" 1 
+ATOM   483  C "C1'" . DT  A 1 22  ? 63.460  75.693 69.172  1.00 37.99  ? ? ? ? ? ? 22  DT  C "C1'" 1 
+ATOM   484  N N1    . DT  A 1 22  ? 62.882  74.408 68.707  1.00 36.58  ? ? ? ? ? ? 22  DT  C N1    1 
+ATOM   485  C C2    . DT  A 1 22  ? 63.786  73.413 68.391  1.00 35.76  ? ? ? ? ? ? 22  DT  C C2    1 
+ATOM   486  O O2    . DT  A 1 22  ? 64.992  73.536 68.524  1.00 37.87  ? ? ? ? ? ? 22  DT  C O2    1 
+ATOM   487  N N3    . DT  A 1 22  ? 63.218  72.241 67.973  1.00 27.02  ? ? ? ? ? ? 22  DT  C N3    1 
+ATOM   488  C C4    . DT  A 1 22  ? 61.867  71.986 67.799  1.00 28.48  ? ? ? ? ? ? 22  DT  C C4    1 
+ATOM   489  O O4    . DT  A 1 22  ? 61.512  70.882 67.393  1.00 27.81  ? ? ? ? ? ? 22  DT  C O4    1 
+ATOM   490  C C5    . DT  A 1 22  ? 60.982  73.074 68.141  1.00 27.76  ? ? ? ? ? ? 22  DT  C C5    1 
+ATOM   491  C C7    . DT  A 1 22  ? 59.492  72.903 68.008  1.00 27.38  ? ? ? ? ? ? 22  DT  C C7    1 
+ATOM   492  C C6    . DT  A 1 22  ? 61.522  74.227 68.555  1.00 29.78  ? ? ? ? ? ? 22  DT  C C6    1 
+ATOM   493  P P     . DA  A 1 23  ? 65.187  79.312 68.135  1.00 60.43  ? ? ? ? ? ? 23  DA  C P     1 
+ATOM   494  O OP1   . DA  A 1 23  ? 65.852  80.389 68.905  1.00 72.50  ? ? ? ? ? ? 23  DA  C OP1   1 
+ATOM   495  O OP2   . DA  A 1 23  ? 63.934  79.564 67.396  1.00 66.48  ? ? ? ? ? ? 23  DA  C OP2   1 
+ATOM   496  O "O5'" . DA  A 1 23  ? 66.278  78.669 67.169  1.00 65.82  ? ? ? ? ? ? 23  DA  C "O5'" 1 
+ATOM   497  C "C5'" . DA  A 1 23  ? 67.518  78.386 67.800  1.00 65.54  ? ? ? ? ? ? 23  DA  C "C5'" 1 
+ATOM   498  C "C4'" . DA  A 1 23  ? 68.102  77.120 67.213  1.00 59.28  ? ? ? ? ? ? 23  DA  C "C4'" 1 
+ATOM   499  O "O4'" . DA  A 1 23  ? 67.072  76.107 67.254  1.00 57.88  ? ? ? ? ? ? 23  DA  C "O4'" 1 
+ATOM   500  C "C3'" . DA  A 1 23  ? 68.447  77.279 65.740  1.00 57.79  ? ? ? ? ? ? 23  DA  C "C3'" 1 
+ATOM   501  O "O3'" . DA  A 1 23  ? 69.838  77.493 65.586  1.00 56.92  ? ? ? ? ? ? 23  DA  C "O3'" 1 
+ATOM   502  C "C2'" . DA  A 1 23  ? 68.016  75.973 65.081  1.00 51.38  ? ? ? ? ? ? 23  DA  C "C2'" 1 
+ATOM   503  C "C1'" . DA  A 1 23  ? 67.243  75.226 66.164  1.00 46.39  ? ? ? ? ? ? 23  DA  C "C1'" 1 
+ATOM   504  N N9    . DA  A 1 23  ? 65.908  74.829 65.729  1.00 35.41  ? ? ? ? ? ? 23  DA  C N9    1 
+ATOM   505  C C8    . DA  A 1 23  ? 64.736  75.528 65.819  1.00 36.41  ? ? ? ? ? ? 23  DA  C C8    1 
+ATOM   506  N N7    . DA  A 1 23  ? 63.689  74.895 65.340  1.00 37.32  ? ? ? ? ? ? 23  DA  C N7    1 
+ATOM   507  C C5    . DA  A 1 23  ? 64.213  73.696 64.894  1.00 34.03  ? ? ? ? ? ? 23  DA  C C5    1 
+ATOM   508  C C6    . DA  A 1 23  ? 63.630  72.584 64.268  1.00 32.58  ? ? ? ? ? ? 23  DA  C C6    1 
+ATOM   509  N N6    . DA  A 1 23  ? 62.330  72.490 63.981  1.00 33.05  ? ? ? ? ? ? 23  DA  C N6    1 
+ATOM   510  N N1    . DA  A 1 23  ? 64.433  71.549 63.955  1.00 33.12  ? ? ? ? ? ? 23  DA  C N1    1 
+ATOM   511  C C2    . DA  A 1 23  ? 65.733  71.637 64.250  1.00 33.75  ? ? ? ? ? ? 23  DA  C C2    1 
+ATOM   512  N N3    . DA  A 1 23  ? 66.403  72.633 64.825  1.00 34.08  ? ? ? ? ? ? 23  DA  C N3    1 
+ATOM   513  C C4    . DA  A 1 23  ? 65.574  73.641 65.126  1.00 34.85  ? ? ? ? ? ? 23  DA  C C4    1 
+ATOM   514  P P     . DT  A 1 24  ? 70.393  77.819 64.126  1.00 47.83  ? ? ? ? ? ? 24  DT  C P     1 
+ATOM   515  O OP1   . DT  A 1 24  ? 71.779  78.306 64.274  1.00 53.45  ? ? ? ? ? ? 24  DT  C OP1   1 
+ATOM   516  O OP2   . DT  A 1 24  ? 69.411  78.676 63.428  1.00 51.42  ? ? ? ? ? ? 24  DT  C OP2   1 
+ATOM   517  O "O5'" . DT  A 1 24  ? 70.401  76.368 63.454  1.00 45.55  ? ? ? ? ? ? 24  DT  C "O5'" 1 
+ATOM   518  C "C5'" . DT  A 1 24  ? 71.336  75.408 63.921  1.00 47.71  ? ? ? ? ? ? 24  DT  C "C5'" 1 
+ATOM   519  C "C4'" . DT  A 1 24  ? 71.197  74.097 63.169  1.00 49.74  ? ? ? ? ? ? 24  DT  C "C4'" 1 
+ATOM   520  O "O4'" . DT  A 1 24  ? 69.813  73.665 63.160  1.00 44.94  ? ? ? ? ? ? 24  DT  C "O4'" 1 
+ATOM   521  C "C3'" . DT  A 1 24  ? 71.652  74.116 61.714  1.00 54.27  ? ? ? ? ? ? 24  DT  C "C3'" 1 
+ATOM   522  O "O3'" . DT  A 1 24  ? 72.442  72.949 61.501  1.00 50.03  ? ? ? ? ? ? 24  DT  C "O3'" 1 
+ATOM   523  C "C2'" . DT  A 1 24  ? 70.337  74.117 60.934  1.00 44.75  ? ? ? ? ? ? 24  DT  C "C2'" 1 
+ATOM   524  C "C1'" . DT  A 1 24  ? 69.438  73.292 61.850  1.00 40.16  ? ? ? ? ? ? 24  DT  C "C1'" 1 
+ATOM   525  N N1    . DT  A 1 24  ? 67.983  73.568 61.729  1.00 36.61  ? ? ? ? ? ? 24  DT  C N1    1 
+ATOM   526  C C2    . DT  A 1 24  ? 67.160  72.558 61.279  1.00 35.49  ? ? ? ? ? ? 24  DT  C C2    1 
+ATOM   527  O O2    . DT  A 1 24  ? 67.543  71.460 60.916  1.00 34.24  ? ? ? ? ? ? 24  DT  C O2    1 
+ATOM   528  N N3    . DT  A 1 24  ? 65.831  72.887 61.248  1.00 37.90  ? ? ? ? ? ? 24  DT  C N3    1 
+ATOM   529  C C4    . DT  A 1 24  ? 65.257  74.085 61.641  1.00 41.54  ? ? ? ? ? ? 24  DT  C C4    1 
+ATOM   530  O O4    . DT  A 1 24  ? 64.041  74.228 61.539  1.00 40.92  ? ? ? ? ? ? 24  DT  C O4    1 
+ATOM   531  C C5    . DT  A 1 24  ? 66.178  75.084 62.114  1.00 37.19  ? ? ? ? ? ? 24  DT  C C5    1 
+ATOM   532  C C7    . DT  A 1 24  ? 65.633  76.414 62.559  1.00 33.35  ? ? ? ? ? ? 24  DT  C C7    1 
+ATOM   533  C C6    . DT  A 1 24  ? 67.483  74.783 62.154  1.00 37.76  ? ? ? ? ? ? 24  DT  C C6    1 
+ATOM   534  P P     . DA  A 1 25  ? 72.921  72.392 60.081  1.00 48.12  ? ? ? ? ? ? 25  DA  C P     1 
+ATOM   535  O OP1   . DA  A 1 25  ? 74.352  72.049 60.231  1.00 81.53  ? ? ? ? ? ? 25  DA  C OP1   1 
+ATOM   536  O OP2   . DA  A 1 25  ? 72.492  73.336 59.027  1.00 47.07  ? ? ? ? ? ? 25  DA  C OP2   1 
+ATOM   537  O "O5'" . DA  A 1 25  ? 72.100  71.032 59.923  1.00 41.61  ? ? ? ? ? ? 25  DA  C "O5'" 1 
+ATOM   538  C "C5'" . DA  A 1 25  ? 70.854  71.132 59.262  1.00 35.27  ? ? ? ? ? ? 25  DA  C "C5'" 1 
+ATOM   539  C "C4'" . DA  A 1 25  ? 70.670  69.971 58.309  1.00 46.41  ? ? ? ? ? ? 25  DA  C "C4'" 1 
+ATOM   540  O "O4'" . DA  A 1 25  ? 69.257  69.863 58.025  1.00 49.92  ? ? ? ? ? ? 25  DA  C "O4'" 1 
+ATOM   541  C "C3'" . DA  A 1 25  ? 71.278  70.197 56.935  1.00 63.33  ? ? ? ? ? ? 25  DA  C "C3'" 1 
+ATOM   542  O "O3'" . DA  A 1 25  ? 71.440  68.941 56.296  1.00 63.41  ? ? ? ? ? ? 25  DA  C "O3'" 1 
+ATOM   543  C "C2'" . DA  A 1 25  ? 70.242  71.078 56.240  1.00 49.50  ? ? ? ? ? ? 25  DA  C "C2'" 1 
+ATOM   544  C "C1'" . DA  A 1 25  ? 68.937  70.692 56.927  1.00 49.89  ? ? ? ? ? ? 25  DA  C "C1'" 1 
+ATOM   545  N N9    . DA  A 1 25  ? 68.167  71.830 57.419  1.00 44.06  ? ? ? ? ? ? 25  DA  C N9    1 
+ATOM   546  C C8    . DA  A 1 25  ? 68.570  72.942 58.104  1.00 44.99  ? ? ? ? ? ? 25  DA  C C8    1 
+ATOM   547  N N7    . DA  A 1 25  ? 67.589  73.778 58.357  1.00 44.72  ? ? ? ? ? ? 25  DA  C N7    1 
+ATOM   548  C C5    . DA  A 1 25  ? 66.475  73.163 57.806  1.00 37.72  ? ? ? ? ? ? 25  DA  C C5    1 
+ATOM   549  C C6    . DA  A 1 25  ? 65.119  73.535 57.741  1.00 43.66  ? ? ? ? ? ? 25  DA  C C6    1 
+ATOM   550  N N6    . DA  A 1 25  ? 64.646  74.674 58.260  1.00 45.09  ? ? ? ? ? ? 25  DA  C N6    1 
+ATOM   551  N N1    . DA  A 1 25  ? 64.271  72.700 57.110  1.00 42.39  ? ? ? ? ? ? 25  DA  C N1    1 
+ATOM   552  C C2    . DA  A 1 25  ? 64.756  71.569 56.584  1.00 40.22  ? ? ? ? ? ? 25  DA  C C2    1 
+ATOM   553  N N3    . DA  A 1 25  ? 66.004  71.107 56.584  1.00 38.36  ? ? ? ? ? ? 25  DA  C N3    1 
+ATOM   554  C C4    . DA  A 1 25  ? 66.815  71.963 57.220  1.00 37.25  ? ? ? ? ? ? 25  DA  C C4    1 
+ATOM   555  P P     . DC  A 1 26  ? 72.328  68.842 54.972  1.00 57.40  ? ? ? ? ? ? 26  DC  C P     1 
+ATOM   556  O OP1   . DC  A 1 26  ? 72.679  67.409 54.803  1.00 56.45  ? ? ? ? ? ? 26  DC  C OP1   1 
+ATOM   557  O OP2   . DC  A 1 26  ? 73.385  69.877 55.039  1.00 66.81  ? ? ? ? ? ? 26  DC  C OP2   1 
+ATOM   558  O "O5'" . DC  A 1 26  ? 71.303  69.291 53.833  1.00 40.53  ? ? ? ? ? ? 26  DC  C "O5'" 1 
+ATOM   559  C "C5'" . DC  A 1 26  ? 70.282  68.399 53.445  1.00 45.54  ? ? ? ? ? ? 26  DC  C "C5'" 1 
+ATOM   560  C "C4'" . DC  A 1 26  ? 69.320  69.100 52.506  1.00 54.46  ? ? ? ? ? ? 26  DC  C "C4'" 1 
+ATOM   561  O "O4'" . DC  A 1 26  ? 68.537  70.061 53.259  1.00 59.55  ? ? ? ? ? ? 26  DC  C "O4'" 1 
+ATOM   562  C "C3'" . DC  A 1 26  ? 69.930  69.883 51.348  1.00 55.14  ? ? ? ? ? ? 26  DC  C "C3'" 1 
+ATOM   563  O "O3'" . DC  A 1 26  ? 69.196  69.574 50.175  1.00 67.47  ? ? ? ? ? ? 26  DC  C "O3'" 1 
+ATOM   564  C "C2'" . DC  A 1 26  ? 69.665  71.337 51.729  1.00 52.33  ? ? ? ? ? ? 26  DC  C "C2'" 1 
+ATOM   565  C "C1'" . DC  A 1 26  ? 68.315  71.166 52.413  1.00 53.43  ? ? ? ? ? ? 26  DC  C "C1'" 1 
+ATOM   566  N N1    . DC  A 1 26  ? 67.875  72.325 53.238  1.00 50.89  ? ? ? ? ? ? 26  DC  C N1    1 
+ATOM   567  C C2    . DC  A 1 26  ? 66.497  72.554 53.363  1.00 44.30  ? ? ? ? ? ? 26  DC  C C2    1 
+ATOM   568  O O2    . DC  A 1 26  ? 65.696  71.795 52.797  1.00 42.89  ? ? ? ? ? ? 26  DC  C O2    1 
+ATOM   569  N N3    . DC  A 1 26  ? 66.082  73.607 54.113  1.00 41.49  ? ? ? ? ? ? 26  DC  C N3    1 
+ATOM   570  C C4    . DC  A 1 26  ? 66.972  74.398 54.718  1.00 41.48  ? ? ? ? ? ? 26  DC  C C4    1 
+ATOM   571  N N4    . DC  A 1 26  ? 66.503  75.415 55.453  1.00 30.66  ? ? ? ? ? ? 26  DC  C N4    1 
+ATOM   572  C C5    . DC  A 1 26  ? 68.380  74.178 54.605  1.00 44.39  ? ? ? ? ? ? 26  DC  C C5    1 
+ATOM   573  C C6    . DC  A 1 26  ? 68.779  73.136 53.866  1.00 48.92  ? ? ? ? ? ? 26  DC  C C6    1 
+ATOM   574  P P     . DG  A 1 27  ? 69.993  69.336 48.812  1.00 68.07  ? ? ? ? ? ? 27  DG  C P     1 
+ATOM   575  O OP1   . DG  A 1 27  ? 70.642  68.016 48.969  1.00 69.82  ? ? ? ? ? ? 27  DG  C OP1   1 
+ATOM   576  O OP2   . DG  A 1 27  ? 70.789  70.549 48.520  1.00 67.36  ? ? ? ? ? ? 27  DG  C OP2   1 
+ATOM   577  O "O5'" . DG  A 1 27  ? 68.839  69.231 47.715  1.00 59.91  ? ? ? ? ? ? 27  DG  C "O5'" 1 
+ATOM   578  C "C5'" . DG  A 1 27  ? 67.776  68.331 47.951  1.00 55.31  ? ? ? ? ? ? 27  DG  C "C5'" 1 
+ATOM   579  C "C4'" . DG  A 1 27  ? 66.465  69.036 47.664  1.00 63.69  ? ? ? ? ? ? 27  DG  C "C4'" 1 
+ATOM   580  O "O4'" . DG  A 1 27  ? 66.226  70.043 48.678  1.00 66.75  ? ? ? ? ? ? 27  DG  C "O4'" 1 
+ATOM   581  C "C3'" . DG  A 1 27  ? 66.440  69.770 46.331  1.00 59.33  ? ? ? ? ? ? 27  DG  C "C3'" 1 
+ATOM   582  O "O3'" . DG  A 1 27  ? 65.204  69.538 45.678  1.00 73.15  ? ? ? ? ? ? 27  DG  C "O3'" 1 
+ATOM   583  C "C2'" . DG  A 1 27  ? 66.567  71.237 46.722  1.00 47.49  ? ? ? ? ? ? 27  DG  C "C2'" 1 
+ATOM   584  C "C1'" . DG  A 1 27  ? 65.852  71.258 48.065  1.00 46.91  ? ? ? ? ? ? 27  DG  C "C1'" 1 
+ATOM   585  N N9    . DG  A 1 27  ? 66.308  72.336 48.936  1.00 57.21  ? ? ? ? ? ? 27  DG  C N9    1 
+ATOM   586  C C8    . DG  A 1 27  ? 67.589  72.681 49.302  1.00 56.91  ? ? ? ? ? ? 27  DG  C C8    1 
+ATOM   587  N N7    . DG  A 1 27  ? 67.647  73.694 50.119  1.00 55.25  ? ? ? ? ? ? 27  DG  C N7    1 
+ATOM   588  C C5    . DG  A 1 27  ? 66.314  74.033 50.323  1.00 53.88  ? ? ? ? ? ? 27  DG  C C5    1 
+ATOM   589  C C6    . DG  A 1 27  ? 65.749  75.059 51.118  1.00 44.85  ? ? ? ? ? ? 27  DG  C C6    1 
+ATOM   590  O O6    . DG  A 1 27  ? 66.324  75.901 51.823  1.00 42.02  ? ? ? ? ? ? 27  DG  C O6    1 
+ATOM   591  N N1    . DG  A 1 27  ? 64.360  75.053 51.038  1.00 43.59  ? ? ? ? ? ? 27  DG  C N1    1 
+ATOM   592  C C2    . DG  A 1 27  ? 63.607  74.175 50.297  1.00 48.54  ? ? ? ? ? ? 27  DG  C C2    1 
+ATOM   593  N N2    . DG  A 1 27  ? 62.278  74.326 50.345  1.00 46.90  ? ? ? ? ? ? 27  DG  C N2    1 
+ATOM   594  N N3    . DG  A 1 27  ? 64.125  73.217 49.548  1.00 51.61  ? ? ? ? ? ? 27  DG  C N3    1 
+ATOM   595  C C4    . DG  A 1 27  ? 65.477  73.207 49.605  1.00 56.55  ? ? ? ? ? ? 27  DG  C C4    1 
+ATOM   596  P P     . DA  A 1 28  ? 65.037  69.974 44.148  1.00 81.39  ? ? ? ? ? ? 28  DA  C P     1 
+ATOM   597  O OP1   . DA  A 1 28  ? 64.210  68.946 43.478  1.00 89.20  ? ? ? ? ? ? 28  DA  C OP1   1 
+ATOM   598  O OP2   . DA  A 1 28  ? 66.371  70.314 43.608  1.00 100.00 ? ? ? ? ? ? 28  DA  C OP2   1 
+ATOM   599  O "O5'" . DA  A 1 28  ? 64.182  71.323 44.234  1.00 71.43  ? ? ? ? ? ? 28  DA  C "O5'" 1 
+ATOM   600  C "C5'" . DA  A 1 28  ? 62.888  71.290 44.812  1.00 69.97  ? ? ? ? ? ? 28  DA  C "C5'" 1 
+ATOM   601  C "C4'" . DA  A 1 28  ? 62.500  72.692 45.232  1.00 72.50  ? ? ? ? ? ? 28  DA  C "C4'" 1 
+ATOM   602  O "O4'" . DA  A 1 28  ? 63.464  73.155 46.213  1.00 74.52  ? ? ? ? ? ? 28  DA  C "O4'" 1 
+ATOM   603  C "C3'" . DA  A 1 28  ? 62.527  73.716 44.102  1.00 71.67  ? ? ? ? ? ? 28  DA  C "C3'" 1 
+ATOM   604  O "O3'" . DA  A 1 28  ? 61.273  74.384 44.009  1.00 75.49  ? ? ? ? ? ? 28  DA  C "O3'" 1 
+ATOM   605  C "C2'" . DA  A 1 28  ? 63.660  74.655 44.506  1.00 65.07  ? ? ? ? ? ? 28  DA  C "C2'" 1 
+ATOM   606  C "C1'" . DA  A 1 28  ? 63.574  74.547 46.022  1.00 61.87  ? ? ? ? ? ? 28  DA  C "C1'" 1 
+ATOM   607  N N9    . DA  A 1 28  ? 64.692  75.122 46.770  1.00 54.64  ? ? ? ? ? ? 28  DA  C N9    1 
+ATOM   608  C C8    . DA  A 1 28  ? 66.023  74.812 46.751  1.00 55.81  ? ? ? ? ? ? 28  DA  C C8    1 
+ATOM   609  N N7    . DA  A 1 28  ? 66.753  75.564 47.545  1.00 59.11  ? ? ? ? ? ? 28  DA  C N7    1 
+ATOM   610  C C5    . DA  A 1 28  ? 65.842  76.434 48.121  1.00 55.16  ? ? ? ? ? ? 28  DA  C C5    1 
+ATOM   611  C C6    . DA  A 1 28  ? 65.972  77.480 49.054  1.00 50.74  ? ? ? ? ? ? 28  DA  C C6    1 
+ATOM   612  N N6    . DA  A 1 28  ? 67.135  77.851 49.599  1.00 53.53  ? ? ? ? ? ? 28  DA  C N6    1 
+ATOM   613  N N1    . DA  A 1 28  ? 64.853  78.143 49.415  1.00 49.34  ? ? ? ? ? ? 28  DA  C N1    1 
+ATOM   614  C C2    . DA  A 1 28  ? 63.684  77.784 48.871  1.00 50.04  ? ? ? ? ? ? 28  DA  C C2    1 
+ATOM   615  N N3    . DA  A 1 28  ? 63.439  76.817 47.991  1.00 50.78  ? ? ? ? ? ? 28  DA  C N3    1 
+ATOM   616  C C4    . DA  A 1 28  ? 64.568  76.174 47.650  1.00 52.78  ? ? ? ? ? ? 28  DA  C C4    1 
+ATOM   617  P P     . DA  A 1 29  ? 60.687  74.637 42.542  1.00 73.64  ? ? ? ? ? ? 29  DA  C P     1 
+ATOM   618  O OP1   . DA  A 1 29  ? 60.154  73.348 42.050  1.00 78.18  ? ? ? ? ? ? 29  DA  C OP1   1 
+ATOM   619  O OP2   . DA  A 1 29  ? 61.718  75.371 41.775  1.00 69.84  ? ? ? ? ? ? 29  DA  C OP2   1 
+ATOM   620  O "O5'" . DA  A 1 29  ? 59.440  75.611 42.763  1.00 68.82  ? ? ? ? ? ? 29  DA  C "O5'" 1 
+ATOM   621  C "C5'" . DA  A 1 29  ? 58.910  75.756 44.069  1.00 76.74  ? ? ? ? ? ? 29  DA  C "C5'" 1 
+ATOM   622  C "C4'" . DA  A 1 29  ? 59.166  77.169 44.546  1.00 70.50  ? ? ? ? ? ? 29  DA  C "C4'" 1 
+ATOM   623  O "O4'" . DA  A 1 29  ? 60.507  77.249 45.086  1.00 65.49  ? ? ? ? ? ? 29  DA  C "O4'" 1 
+ATOM   624  C "C3'" . DA  A 1 29  ? 59.118  78.192 43.417  1.00 77.88  ? ? ? ? ? ? 29  DA  C "C3'" 1 
+ATOM   625  O "O3'" . DA  A 1 29  ? 58.345  79.296 43.847  1.00 90.89  ? ? ? ? ? ? 29  DA  C "O3'" 1 
+ATOM   626  C "C2'" . DA  A 1 29  ? 60.581  78.588 43.225  1.00 74.96  ? ? ? ? ? ? 29  DA  C "C2'" 1 
+ATOM   627  C "C1'" . DA  A 1 29  ? 61.023  78.495 44.677  1.00 64.16  ? ? ? ? ? ? 29  DA  C "C1'" 1 
+ATOM   628  N N9    . DA  A 1 29  ? 62.456  78.472 44.933  1.00 59.81  ? ? ? ? ? ? 29  DA  C N9    1 
+ATOM   629  C C8    . DA  A 1 29  ? 63.392  77.610 44.447  1.00 57.93  ? ? ? ? ? ? 29  DA  C C8    1 
+ATOM   630  N N7    . DA  A 1 29  ? 64.603  77.822 44.901  1.00 56.95  ? ? ? ? ? ? 29  DA  C N7    1 
+ATOM   631  C C5    . DA  A 1 29  ? 64.445  78.912 45.739  1.00 56.42  ? ? ? ? ? ? 29  DA  C C5    1 
+ATOM   632  C C6    . DA  A 1 29  ? 65.359  79.636 46.519  1.00 54.81  ? ? ? ? ? ? 29  DA  C C6    1 
+ATOM   633  N N6    . DA  A 1 29  ? 66.656  79.331 46.560  1.00 56.90  ? ? ? ? ? ? 29  DA  C N6    1 
+ATOM   634  N N1    . DA  A 1 29  ? 64.896  80.674 47.245  1.00 54.73  ? ? ? ? ? ? 29  DA  C N1    1 
+ATOM   635  C C2    . DA  A 1 29  ? 63.589  80.952 47.186  1.00 56.92  ? ? ? ? ? ? 29  DA  C C2    1 
+ATOM   636  N N3    . DA  A 1 29  ? 62.631  80.345 46.484  1.00 57.27  ? ? ? ? ? ? 29  DA  C N3    1 
+ATOM   637  C C4    . DA  A 1 29  ? 63.129  79.321 45.777  1.00 57.04  ? ? ? ? ? ? 29  DA  C C4    1 
+ATOM   638  P P     . DG  A 1 30  ? 57.871  80.382 42.775  1.00 90.74  ? ? ? ? ? ? 30  DG  C P     1 
+ATOM   639  O OP1   . DG  A 1 30  ? 56.391  80.386 42.750  1.00 100.00 ? ? ? ? ? ? 30  DG  C OP1   1 
+ATOM   640  O OP2   . DG  A 1 30  ? 58.628  80.172 41.520  1.00 97.55  ? ? ? ? ? ? 30  DG  C OP2   1 
+ATOM   641  O "O5'" . DG  A 1 30  ? 58.366  81.757 43.414  1.00 70.80  ? ? ? ? ? ? 30  DG  C "O5'" 1 
+ATOM   642  C "C5'" . DG  A 1 30  ? 58.092  82.063 44.766  1.00 64.36  ? ? ? ? ? ? 30  DG  C "C5'" 1 
+ATOM   643  C "C4'" . DG  A 1 30  ? 59.045  83.153 45.208  1.00 70.87  ? ? ? ? ? ? 30  DG  C "C4'" 1 
+ATOM   644  O "O4'" . DG  A 1 30  ? 60.383  82.603 45.264  1.00 77.14  ? ? ? ? ? ? 30  DG  C "O4'" 1 
+ATOM   645  C "C3'" . DG  A 1 30  ? 59.123  84.338 44.255  1.00 54.47  ? ? ? ? ? ? 30  DG  C "C3'" 1 
+ATOM   646  O "O3'" . DG  A 1 30  ? 59.209  85.519 45.008  1.00 66.12  ? ? ? ? ? ? 30  DG  C "O3'" 1 
+ATOM   647  C "C2'" . DG  A 1 30  ? 60.426  84.121 43.494  1.00 61.52  ? ? ? ? ? ? 30  DG  C "C2'" 1 
+ATOM   648  C "C1'" . DG  A 1 30  ? 61.272  83.451 44.566  1.00 66.51  ? ? ? ? ? ? 30  DG  C "C1'" 1 
+ATOM   649  N N9    . DG  A 1 30  ? 62.358  82.606 44.079  1.00 60.85  ? ? ? ? ? ? 30  DG  C N9    1 
+ATOM   650  C C8    . DG  A 1 30  ? 62.354  81.491 43.277  1.00 58.34  ? ? ? ? ? ? 30  DG  C C8    1 
+ATOM   651  N N7    . DG  A 1 30  ? 63.545  80.988 43.095  1.00 54.74  ? ? ? ? ? ? 30  DG  C N7    1 
+ATOM   652  C C5    . DG  A 1 30  ? 64.376  81.806 43.848  1.00 50.00  ? ? ? ? ? ? 30  DG  C C5    1 
+ATOM   653  C C6    . DG  A 1 30  ? 65.771  81.745 44.046  1.00 55.46  ? ? ? ? ? ? 30  DG  C C6    1 
+ATOM   654  O O6    . DG  A 1 30  ? 66.558  80.920 43.564  1.00 57.53  ? ? ? ? ? ? 30  DG  C O6    1 
+ATOM   655  N N1    . DG  A 1 30  ? 66.227  82.758 44.888  1.00 52.07  ? ? ? ? ? ? 30  DG  C N1    1 
+ATOM   656  C C2    . DG  A 1 30  ? 65.421  83.722 45.445  1.00 51.61  ? ? ? ? ? ? 30  DG  C C2    1 
+ATOM   657  N N2    . DG  A 1 30  ? 66.026  84.633 46.224  1.00 44.90  ? ? ? ? ? ? 30  DG  C N2    1 
+ATOM   658  N N3    . DG  A 1 30  ? 64.108  83.795 45.269  1.00 49.51  ? ? ? ? ? ? 30  DG  C N3    1 
+ATOM   659  C C4    . DG  A 1 30  ? 63.661  82.807 44.461  1.00 47.28  ? ? ? ? ? ? 30  DG  C C4    1 
+ATOM   660  P P     . DT  A 1 31  ? 58.954  86.872 44.206  1.00 76.43  ? ? ? ? ? ? 31  DT  C P     1 
+ATOM   661  O OP1   . DT  A 1 31  ? 57.905  87.642 44.905  1.00 70.50  ? ? ? ? ? ? 31  DT  C OP1   1 
+ATOM   662  O OP2   . DT  A 1 31  ? 58.839  86.541 42.768  1.00 92.11  ? ? ? ? ? ? 31  DT  C OP2   1 
+ATOM   663  O "O5'" . DT  A 1 31  ? 60.309  87.670 44.442  1.00 83.11  ? ? ? ? ? ? 31  DT  C "O5'" 1 
+ATOM   664  C "C5'" . DT  A 1 31  ? 60.822  87.774 45.752  1.00 75.47  ? ? ? ? ? ? 31  DT  C "C5'" 1 
+ATOM   665  C "C4'" . DT  A 1 31  ? 62.194  88.401 45.620  1.00 72.96  ? ? ? ? ? ? 31  DT  C "C4'" 1 
+ATOM   666  O "O4'" . DT  A 1 31  ? 63.170  87.438 45.150  1.00 68.71  ? ? ? ? ? ? 31  DT  C "O4'" 1 
+ATOM   667  C "C3'" . DT  A 1 31  ? 62.237  89.549 44.621  1.00 67.94  ? ? ? ? ? ? 31  DT  C "C3'" 1 
+ATOM   668  O "O3'" . DT  A 1 31  ? 62.807  90.645 45.306  1.00 67.86  ? ? ? ? ? ? 31  DT  C "O3'" 1 
+ATOM   669  C "C2'" . DT  A 1 31  ? 63.111  89.057 43.464  1.00 49.43  ? ? ? ? ? ? 31  DT  C "C2'" 1 
+ATOM   670  C "C1'" . DT  A 1 31  ? 64.005  88.063 44.193  1.00 44.13  ? ? ? ? ? ? 31  DT  C "C1'" 1 
+ATOM   671  N N1    . DT  A 1 31  ? 64.623  86.978 43.389  1.00 43.17  ? ? ? ? ? ? 31  DT  C N1    1 
+ATOM   672  C C2    . DT  A 1 31  ? 65.969  86.782 43.593  1.00 45.31  ? ? ? ? ? ? 31  DT  C C2    1 
+ATOM   673  O O2    . DT  A 1 31  ? 66.636  87.516 44.306  1.00 47.23  ? ? ? ? ? ? 31  DT  C O2    1 
+ATOM   674  N N3    . DT  A 1 31  ? 66.513  85.722 42.918  1.00 36.39  ? ? ? ? ? ? 31  DT  C N3    1 
+ATOM   675  C C4    . DT  A 1 31  ? 65.837  84.826 42.115  1.00 41.10  ? ? ? ? ? ? 31  DT  C C4    1 
+ATOM   676  O O4    . DT  A 1 31  ? 66.439  83.909 41.559  1.00 41.10  ? ? ? ? ? ? 31  DT  C O4    1 
+ATOM   677  C C5    . DT  A 1 31  ? 64.431  85.074 41.970  1.00 36.32  ? ? ? ? ? ? 31  DT  C C5    1 
+ATOM   678  C C7    . DT  A 1 31  ? 63.610  84.167 41.109  1.00 36.69  ? ? ? ? ? ? 31  DT  C C7    1 
+ATOM   679  C C6    . DT  A 1 31  ? 63.891  86.121 42.598  1.00 37.86  ? ? ? ? ? ? 31  DT  C C6    1 
+ATOM   680  P P     . DT  A 1 32  ? 62.537  92.118 44.759  1.00 74.26  ? ? ? ? ? ? 32  DT  C P     1 
+ATOM   681  O OP1   . DT  A 1 32  ? 61.662  92.852 45.697  1.00 82.37  ? ? ? ? ? ? 32  DT  C OP1   1 
+ATOM   682  O OP2   . DT  A 1 32  ? 62.179  92.009 43.329  1.00 77.28  ? ? ? ? ? ? 32  DT  C OP2   1 
+ATOM   683  O "O5'" . DT  A 1 32  ? 64.001  92.724 44.881  1.00 74.79  ? ? ? ? ? ? 32  DT  C "O5'" 1 
+ATOM   684  C "C5'" . DT  A 1 32  ? 64.936  91.811 44.371  1.00 70.46  ? ? ? ? ? ? 32  DT  C "C5'" 1 
+ATOM   685  C "C4'" . DT  A 1 32  ? 66.343  92.340 44.531  1.00 69.59  ? ? ? ? ? ? 32  DT  C "C4'" 1 
+ATOM   686  O "O4'" . DT  A 1 32  ? 67.215  91.221 44.236  1.00 70.32  ? ? ? ? ? ? 32  DT  C "O4'" 1 
+ATOM   687  C "C3'" . DT  A 1 32  ? 66.709  93.451 43.557  1.00 67.36  ? ? ? ? ? ? 32  DT  C "C3'" 1 
+ATOM   688  O "O3'" . DT  A 1 32  ? 67.617  94.380 44.137  1.00 81.03  ? ? ? ? ? ? 32  DT  C "O3'" 1 
+ATOM   689  C "C2'" . DT  A 1 32  ? 67.347  92.700 42.394  1.00 52.41  ? ? ? ? ? ? 32  DT  C "C2'" 1 
+ATOM   690  C "C1'" . DT  A 1 32  ? 67.915  91.431 43.025  1.00 49.03  ? ? ? ? ? ? 32  DT  C "C1'" 1 
+ATOM   691  N N1    . DT  A 1 32  ? 67.799  90.211 42.160  1.00 49.26  ? ? ? ? ? ? 32  DT  C N1    1 
+ATOM   692  C C2    . DT  A 1 32  ? 68.881  89.359 42.041  1.00 51.69  ? ? ? ? ? ? 32  DT  C C2    1 
+ATOM   693  O O2    . DT  A 1 32  ? 69.957  89.545 42.573  1.00 55.73  ? ? ? ? ? ? 32  DT  C O2    1 
+ATOM   694  N N3    . DT  A 1 32  ? 68.676  88.249 41.266  1.00 40.11  ? ? ? ? ? ? 32  DT  C N3    1 
+ATOM   695  C C4    . DT  A 1 32  ? 67.510  87.912 40.604  1.00 45.05  ? ? ? ? ? ? 32  DT  C C4    1 
+ATOM   696  O O4    . DT  A 1 32  ? 67.444  86.881 39.941  1.00 44.60  ? ? ? ? ? ? 32  DT  C O4    1 
+ATOM   697  C C5    . DT  A 1 32  ? 66.421  88.835 40.781  1.00 46.07  ? ? ? ? ? ? 32  DT  C C5    1 
+ATOM   698  C C7    . DT  A 1 32  ? 65.096  88.574 40.137  1.00 45.71  ? ? ? ? ? ? 32  DT  C C7    1 
+ATOM   699  C C6    . DT  A 1 32  ? 66.607  89.924 41.533  1.00 48.78  ? ? ? ? ? ? 32  DT  C C6    1 
+ATOM   700  P P     . DA  A 1 33  ? 67.823  95.776 43.383  1.00 79.07  ? ? ? ? ? ? 33  DA  C P     1 
+ATOM   701  O OP1   . DA  A 1 33  ? 67.821  96.879 44.371  1.00 75.40  ? ? ? ? ? ? 33  DA  C OP1   1 
+ATOM   702  O OP2   . DA  A 1 33  ? 66.896  95.806 42.230  1.00 84.63  ? ? ? ? ? ? 33  DA  C OP2   1 
+ATOM   703  O "O5'" . DA  A 1 33  ? 69.309  95.643 42.819  1.00 77.00  ? ? ? ? ? ? 33  DA  C "O5'" 1 
+ATOM   704  C "C5'" . DA  A 1 33  ? 70.278  95.022 43.639  1.00 76.29  ? ? ? ? ? ? 33  DA  C "C5'" 1 
+ATOM   705  C "C4'" . DA  A 1 33  ? 71.334  94.435 42.733  1.00 68.24  ? ? ? ? ? ? 33  DA  C "C4'" 1 
+ATOM   706  O "O4'" . DA  A 1 33  ? 70.783  93.309 42.014  1.00 68.34  ? ? ? ? ? ? 33  DA  C "O4'" 1 
+ATOM   707  C "C3'" . DA  A 1 33  ? 71.872  95.393 41.684  1.00 62.77  ? ? ? ? ? ? 33  DA  C "C3'" 1 
+ATOM   708  O "O3'" . DA  A 1 33  ? 73.273  95.378 41.893  1.00 71.39  ? ? ? ? ? ? 33  DA  C "O3'" 1 
+ATOM   709  C "C2'" . DA  A 1 33  ? 71.402  94.807 40.350  1.00 51.59  ? ? ? ? ? ? 33  DA  C "C2'" 1 
+ATOM   710  C "C1'" . DA  A 1 33  ? 71.239  93.325 40.679  1.00 47.28  ? ? ? ? ? ? 33  DA  C "C1'" 1 
+ATOM   711  N N9    . DA  A 1 33  ? 70.216  92.595 39.941  1.00 32.37  ? ? ? ? ? ? 33  DA  C N9    1 
+ATOM   712  C C8    . DA  A 1 33  ? 68.922  92.976 39.744  1.00 32.50  ? ? ? ? ? ? 33  DA  C C8    1 
+ATOM   713  N N7    . DA  A 1 33  ? 68.213  92.088 39.094  1.00 38.16  ? ? ? ? ? ? 33  DA  C N7    1 
+ATOM   714  C C5    . DA  A 1 33  ? 69.083  91.038 38.859  1.00 27.11  ? ? ? ? ? ? 33  DA  C C5    1 
+ATOM   715  C C6    . DA  A 1 33  ? 68.929  89.800 38.208  1.00 40.36  ? ? ? ? ? ? 33  DA  C C6    1 
+ATOM   716  N N6    . DA  A 1 33  ? 67.775  89.403 37.646  1.00 39.34  ? ? ? ? ? ? 33  DA  C N6    1 
+ATOM   717  N N1    . DA  A 1 33  ? 70.011  88.994 38.139  1.00 40.54  ? ? ? ? ? ? 33  DA  C N1    1 
+ATOM   718  C C2    . DA  A 1 33  ? 71.147  89.404 38.714  1.00 37.64  ? ? ? ? ? ? 33  DA  C C2    1 
+ATOM   719  N N3    . DA  A 1 33  ? 71.400  90.543 39.353  1.00 34.93  ? ? ? ? ? ? 33  DA  C N3    1 
+ATOM   720  C C4    . DA  A 1 33  ? 70.319  91.333 39.393  1.00 29.42  ? ? ? ? ? ? 33  DA  C C4    1 
+ATOM   721  P P     . DT  A 1 34  ? 74.329  96.116 40.954  1.00 76.00  ? ? ? ? ? ? 34  DT  C P     1 
+ATOM   722  O OP1   . DT  A 1 34  ? 74.873  97.278 41.694  1.00 54.21  ? ? ? ? ? ? 34  DT  C OP1   1 
+ATOM   723  O OP2   . DT  A 1 34  ? 73.706  96.309 39.623  1.00 100.00 ? ? ? ? ? ? 34  DT  C OP2   1 
+ATOM   724  O "O5'" . DT  A 1 34  ? 75.444  94.973 40.852  1.00 53.10  ? ? ? ? ? ? 34  DT  C "O5'" 1 
+ATOM   725  C "C5'" . DT  A 1 34  ? 76.218  94.880 39.660  1.00 100.00 ? ? ? ? ? ? 34  DT  C "C5'" 1 
+ATOM   726  C "C4'" . DT  A 1 34  ? 76.268  93.450 39.151  1.00 100.00 ? ? ? ? ? ? 34  DT  C "C4'" 1 
+ATOM   727  O "O4'" . DT  A 1 34  ? 74.917  92.980 38.910  1.00 79.60  ? ? ? ? ? ? 34  DT  C "O4'" 1 
+ATOM   728  C "C3'" . DT  A 1 34  ? 77.023  93.236 37.842  1.00 54.07  ? ? ? ? ? ? 34  DT  C "C3'" 1 
+ATOM   729  O "O3'" . DT  A 1 34  ? 77.681  91.974 37.877  1.00 58.45  ? ? ? ? ? ? 34  DT  C "O3'" 1 
+ATOM   730  C "C2'" . DT  A 1 34  ? 75.896  93.235 36.813  1.00 83.46  ? ? ? ? ? ? 34  DT  C "C2'" 1 
+ATOM   731  C "C1'" . DT  A 1 34  ? 74.849  92.457 37.600  1.00 50.52  ? ? ? ? ? ? 34  DT  C "C1'" 1 
+ATOM   732  N N1    . DT  A 1 34  ? 73.447  92.554 37.078  1.00 49.57  ? ? ? ? ? ? 34  DT  C N1    1 
+ATOM   733  C C2    . DT  A 1 34  ? 72.938  91.416 36.485  1.00 49.35  ? ? ? ? ? ? 34  DT  C C2    1 
+ATOM   734  O O2    . DT  A 1 34  ? 73.570  90.375 36.393  1.00 50.04  ? ? ? ? ? ? 34  DT  C O2    1 
+ATOM   735  N N3    . DT  A 1 34  ? 71.656  91.522 36.011  1.00 36.88  ? ? ? ? ? ? 34  DT  C N3    1 
+ATOM   736  C C4    . DT  A 1 34  ? 70.847  92.633 36.097  1.00 39.15  ? ? ? ? ? ? 34  DT  C C4    1 
+ATOM   737  O O4    . DT  A 1 34  ? 69.716  92.592 35.625  1.00 39.11  ? ? ? ? ? ? 34  DT  C O4    1 
+ATOM   738  C C5    . DT  A 1 34  ? 71.439  93.787 36.716  1.00 37.06  ? ? ? ? ? ? 34  DT  C C5    1 
+ATOM   739  C C7    . DT  A 1 34  ? 70.627  95.041 36.818  1.00 37.10  ? ? ? ? ? ? 34  DT  C C7    1 
+ATOM   740  C C6    . DT  A 1 34  ? 72.691  93.705 37.185  1.00 41.73  ? ? ? ? ? ? 34  DT  C C6    1 
+ATOM   741  O "O5'" . DA  B 2 1   ? 69.061  40.209 150.308 1.00 100.00 ? ? ? ? ? ? 1   DA  D "O5'" 1 
+ATOM   742  C "C5'" . DA  B 2 1   ? 68.754  38.940 149.730 1.00 42.68  ? ? ? ? ? ? 1   DA  D "C5'" 1 
+ATOM   743  C "C4'" . DA  B 2 1   ? 69.947  38.421 148.953 1.00 100.00 ? ? ? ? ? ? 1   DA  D "C4'" 1 
+ATOM   744  O "O4'" . DA  B 2 1   ? 69.818  37.010 148.666 1.00 82.60  ? ? ? ? ? ? 1   DA  D "O4'" 1 
+ATOM   745  C "C3'" . DA  B 2 1   ? 70.144  39.096 147.605 1.00 49.21  ? ? ? ? ? ? 1   DA  D "C3'" 1 
+ATOM   746  O "O3'" . DA  B 2 1   ? 71.133  40.088 147.751 1.00 74.01  ? ? ? ? ? ? 1   DA  D "O3'" 1 
+ATOM   747  C "C2'" . DA  B 2 1   ? 70.596  37.997 146.648 1.00 100.00 ? ? ? ? ? ? 1   DA  D "C2'" 1 
+ATOM   748  C "C1'" . DA  B 2 1   ? 70.496  36.712 147.464 1.00 54.13  ? ? ? ? ? ? 1   DA  D "C1'" 1 
+ATOM   749  N N9    . DA  B 2 1   ? 69.710  35.655 146.834 1.00 53.30  ? ? ? ? ? ? 1   DA  D N9    1 
+ATOM   750  C C8    . DA  B 2 1   ? 68.353  35.483 146.877 1.00 53.95  ? ? ? ? ? ? 1   DA  D C8    1 
+ATOM   751  N N7    . DA  B 2 1   ? 67.925  34.415 146.242 1.00 49.20  ? ? ? ? ? ? 1   DA  D N7    1 
+ATOM   752  C C5    . DA  B 2 1   ? 69.089  33.849 145.760 1.00 47.45  ? ? ? ? ? ? 1   DA  D C5    1 
+ATOM   753  C C6    . DA  B 2 1   ? 69.303  32.684 144.997 1.00 48.49  ? ? ? ? ? ? 1   DA  D C6    1 
+ATOM   754  N N6    . DA  B 2 1   ? 68.292  31.904 144.604 1.00 47.96  ? ? ? ? ? ? 1   DA  D N6    1 
+ATOM   755  N N1    . DA  B 2 1   ? 70.574  32.371 144.673 1.00 47.86  ? ? ? ? ? ? 1   DA  D N1    1 
+ATOM   756  C C2    . DA  B 2 1   ? 71.547  33.189 145.092 1.00 49.78  ? ? ? ? ? ? 1   DA  D C2    1 
+ATOM   757  N N3    . DA  B 2 1   ? 71.477  34.315 145.809 1.00 49.67  ? ? ? ? ? ? 1   DA  D N3    1 
+ATOM   758  C C4    . DA  B 2 1   ? 70.199  34.591 146.113 1.00 49.19  ? ? ? ? ? ? 1   DA  D C4    1 
+ATOM   759  P P     . DT  B 2 2   ? 71.222  41.118 146.540 1.00 82.28  ? ? ? ? ? ? 2   DT  D P     1 
+ATOM   760  O OP1   . DT  B 2 2   ? 72.070  42.248 146.982 1.00 72.84  ? ? ? ? ? ? 2   DT  D OP1   1 
+ATOM   761  O OP2   . DT  B 2 2   ? 69.855  41.309 146.009 1.00 58.43  ? ? ? ? ? ? 2   DT  D OP2   1 
+ATOM   762  O "O5'" . DT  B 2 2   ? 72.018  40.258 145.463 1.00 84.02  ? ? ? ? ? ? 2   DT  D "O5'" 1 
+ATOM   763  C "C5'" . DT  B 2 2   ? 73.314  39.813 145.789 1.00 73.35  ? ? ? ? ? ? 2   DT  D "C5'" 1 
+ATOM   764  C "C4'" . DT  B 2 2   ? 73.898  39.164 144.553 1.00 58.55  ? ? ? ? ? ? 2   DT  D "C4'" 1 
+ATOM   765  O "O4'" . DT  B 2 2   ? 73.221  37.903 144.316 1.00 52.33  ? ? ? ? ? ? 2   DT  D "O4'" 1 
+ATOM   766  C "C3'" . DT  B 2 2   ? 73.763  39.967 143.265 1.00 57.31  ? ? ? ? ? ? 2   DT  D "C3'" 1 
+ATOM   767  O "O3'" . DT  B 2 2   ? 74.986  39.813 142.566 1.00 58.20  ? ? ? ? ? ? 2   DT  D "O3'" 1 
+ATOM   768  C "C2'" . DT  B 2 2   ? 72.625  39.251 142.540 1.00 55.48  ? ? ? ? ? ? 2   DT  D "C2'" 1 
+ATOM   769  C "C1'" . DT  B 2 2   ? 72.848  37.801 142.959 1.00 43.95  ? ? ? ? ? ? 2   DT  D "C1'" 1 
+ATOM   770  N N1    . DT  B 2 2   ? 71.612  36.963 142.889 1.00 41.85  ? ? ? ? ? ? 2   DT  D N1    1 
+ATOM   771  C C2    . DT  B 2 2   ? 71.719  35.687 142.384 1.00 44.19  ? ? ? ? ? ? 2   DT  D C2    1 
+ATOM   772  O O2    . DT  B 2 2   ? 72.763  35.201 141.980 1.00 48.12  ? ? ? ? ? ? 2   DT  D O2    1 
+ATOM   773  N N3    . DT  B 2 2   ? 70.553  34.971 142.337 1.00 35.16  ? ? ? ? ? ? 2   DT  D N3    1 
+ATOM   774  C C4    . DT  B 2 2   ? 69.309  35.414 142.742 1.00 40.09  ? ? ? ? ? ? 2   DT  D C4    1 
+ATOM   775  O O4    . DT  B 2 2   ? 68.332  34.681 142.645 1.00 40.00  ? ? ? ? ? ? 2   DT  D O4    1 
+ATOM   776  C C5    . DT  B 2 2   ? 69.268  36.750 143.264 1.00 32.36  ? ? ? ? ? ? 2   DT  D C5    1 
+ATOM   777  C C7    . DT  B 2 2   ? 67.928  37.260 143.721 1.00 31.26  ? ? ? ? ? ? 2   DT  D C7    1 
+ATOM   778  C C6    . DT  B 2 2   ? 70.401  37.461 143.323 1.00 33.97  ? ? ? ? ? ? 2   DT  D C6    1 
+ATOM   779  P P     . DA  B 2 3   ? 75.590  40.820 141.484 1.00 54.25  ? ? ? ? ? ? 3   DA  D P     1 
+ATOM   780  O OP1   . DA  B 2 3   ? 76.761  41.489 142.089 1.00 61.14  ? ? ? ? ? ? 3   DA  D OP1   1 
+ATOM   781  O OP2   . DA  B 2 3   ? 74.519  41.654 140.898 1.00 76.46  ? ? ? ? ? ? 3   DA  D OP2   1 
+ATOM   782  O "O5'" . DA  B 2 3   ? 76.104  39.735 140.429 1.00 56.57  ? ? ? ? ? ? 3   DA  D "O5'" 1 
+ATOM   783  C "C5'" . DA  B 2 3   ? 76.860  38.655 140.963 1.00 35.40  ? ? ? ? ? ? 3   DA  D "C5'" 1 
+ATOM   784  C "C4'" . DA  B 2 3   ? 76.986  37.531 139.956 1.00 44.89  ? ? ? ? ? ? 3   DA  D "C4'" 1 
+ATOM   785  O "O4'" . DA  B 2 3   ? 75.709  36.850 139.879 1.00 54.11  ? ? ? ? ? ? 3   DA  D "O4'" 1 
+ATOM   786  C "C3'" . DA  B 2 3   ? 77.287  37.988 138.534 1.00 48.73  ? ? ? ? ? ? 3   DA  D "C3'" 1 
+ATOM   787  O "O3'" . DA  B 2 3   ? 77.993  36.959 137.825 1.00 59.39  ? ? ? ? ? ? 3   DA  D "O3'" 1 
+ATOM   788  C "C2'" . DA  B 2 3   ? 75.878  38.248 137.997 1.00 44.00  ? ? ? ? ? ? 3   DA  D "C2'" 1 
+ATOM   789  C "C1'" . DA  B 2 3   ? 75.110  37.084 138.617 1.00 48.86  ? ? ? ? ? ? 3   DA  D "C1'" 1 
+ATOM   790  N N9    . DA  B 2 3   ? 73.683  37.289 138.873 1.00 36.39  ? ? ? ? ? ? 3   DA  D N9    1 
+ATOM   791  C C8    . DA  B 2 3   ? 73.021  38.371 139.377 1.00 34.72  ? ? ? ? ? ? 3   DA  D C8    1 
+ATOM   792  N N7    . DA  B 2 3   ? 71.736  38.162 139.559 1.00 32.55  ? ? ? ? ? ? 3   DA  D N7    1 
+ATOM   793  C C5    . DA  B 2 3   ? 71.542  36.851 139.164 1.00 25.54  ? ? ? ? ? ? 3   DA  D C5    1 
+ATOM   794  C C6    . DA  B 2 3   ? 70.388  36.047 139.102 1.00 37.12  ? ? ? ? ? ? 3   DA  D C6    1 
+ATOM   795  N N6    . DA  B 2 3   ? 69.179  36.487 139.472 1.00 44.16  ? ? ? ? ? ? 3   DA  D N6    1 
+ATOM   796  N N1    . DA  B 2 3   ? 70.541  34.796 138.629 1.00 34.54  ? ? ? ? ? ? 3   DA  D N1    1 
+ATOM   797  C C2    . DA  B 2 3   ? 71.770  34.388 138.274 1.00 32.58  ? ? ? ? ? ? 3   DA  D C2    1 
+ATOM   798  N N3    . DA  B 2 3   ? 72.926  35.054 138.286 1.00 29.97  ? ? ? ? ? ? 3   DA  D N3    1 
+ATOM   799  C C4    . DA  B 2 3   ? 72.736  36.299 138.738 1.00 26.82  ? ? ? ? ? ? 3   DA  D C4    1 
+ATOM   800  P P     . DA  B 2 4   ? 78.869  37.222 136.509 1.00 58.19  ? ? ? ? ? ? 4   DA  D P     1 
+ATOM   801  O OP1   . DA  B 2 4   ? 79.883  36.152 136.414 1.00 55.47  ? ? ? ? ? ? 4   DA  D OP1   1 
+ATOM   802  O OP2   . DA  B 2 4   ? 79.298  38.635 136.467 1.00 52.95  ? ? ? ? ? ? 4   DA  D OP2   1 
+ATOM   803  O "O5'" . DA  B 2 4   ? 77.797  36.952 135.353 1.00 70.51  ? ? ? ? ? ? 4   DA  D "O5'" 1 
+ATOM   804  C "C5'" . DA  B 2 4   ? 77.433  35.596 135.113 1.00 63.76  ? ? ? ? ? ? 4   DA  D "C5'" 1 
+ATOM   805  C "C4'" . DA  B 2 4   ? 76.178  35.493 134.266 1.00 60.32  ? ? ? ? ? ? 4   DA  D "C4'" 1 
+ATOM   806  O "O4'" . DA  B 2 4   ? 75.000  35.757 135.073 1.00 53.53  ? ? ? ? ? ? 4   DA  D "O4'" 1 
+ATOM   807  C "C3'" . DA  B 2 4   ? 76.111  36.428 133.058 1.00 52.93  ? ? ? ? ? ? 4   DA  D "C3'" 1 
+ATOM   808  O "O3'" . DA  B 2 4   ? 75.743  35.694 131.877 1.00 64.22  ? ? ? ? ? ? 4   DA  D "O3'" 1 
+ATOM   809  C "C2'" . DA  B 2 4   ? 75.001  37.391 133.465 1.00 32.88  ? ? ? ? ? ? 4   DA  D "C2'" 1 
+ATOM   810  C "C1'" . DA  B 2 4   ? 74.094  36.447 134.245 1.00 32.67  ? ? ? ? ? ? 4   DA  D "C1'" 1 
+ATOM   811  N N9    . DA  B 2 4   ? 73.061  37.164 134.984 1.00 27.89  ? ? ? ? ? ? 4   DA  D N9    1 
+ATOM   812  C C8    . DA  B 2 4   ? 73.101  38.460 135.415 1.00 27.51  ? ? ? ? ? ? 4   DA  D C8    1 
+ATOM   813  N N7    . DA  B 2 4   ? 71.999  38.877 135.990 1.00 26.98  ? ? ? ? ? ? 4   DA  D N7    1 
+ATOM   814  C C5    . DA  B 2 4   ? 71.159  37.786 135.900 1.00 22.49  ? ? ? ? ? ? 4   DA  D C5    1 
+ATOM   815  C C6    . DA  B 2 4   ? 69.835  37.595 136.323 1.00 26.44  ? ? ? ? ? ? 4   DA  D C6    1 
+ATOM   816  N N6    . DA  B 2 4   ? 69.137  38.550 136.943 1.00 27.71  ? ? ? ? ? ? 4   DA  D N6    1 
+ATOM   817  N N1    . DA  B 2 4   ? 69.276  36.388 136.110 1.00 27.17  ? ? ? ? ? ? 4   DA  D N1    1 
+ATOM   818  C C2    . DA  B 2 4   ? 70.013  35.452 135.500 1.00 29.42  ? ? ? ? ? ? 4   DA  D C2    1 
+ATOM   819  N N3    . DA  B 2 4   ? 71.265  35.524 135.043 1.00 28.58  ? ? ? ? ? ? 4   DA  D N3    1 
+ATOM   820  C C4    . DA  B 2 4   ? 71.790  36.731 135.278 1.00 24.05  ? ? ? ? ? ? 4   DA  D C4    1 
+ATOM   821  P P     . DC  B 2 5   ? 76.228  36.036 130.381 1.00 58.58  ? ? ? ? ? ? 5   DC  D P     1 
+ATOM   822  O OP1   . DC  B 2 5   ? 76.817  34.822 129.773 1.00 52.00  ? ? ? ? ? ? 5   DC  D OP1   1 
+ATOM   823  O OP2   . DC  B 2 5   ? 77.051  37.262 130.450 1.00 45.72  ? ? ? ? ? ? 5   DC  D OP2   1 
+ATOM   824  O "O5'" . DC  B 2 5   ? 74.874  36.312 129.569 1.00 53.27  ? ? ? ? ? ? 5   DC  D "O5'" 1 
+ATOM   825  C "C5'" . DC  B 2 5   ? 73.753  36.957 130.153 1.00 40.96  ? ? ? ? ? ? 5   DC  D "C5'" 1 
+ATOM   826  C "C4'" . DC  B 2 5   ? 72.618  35.990 130.422 1.00 41.71  ? ? ? ? ? ? 5   DC  D "C4'" 1 
+ATOM   827  O "O4'" . DC  B 2 5   ? 72.057  36.339 131.702 1.00 36.03  ? ? ? ? ? ? 5   DC  D "O4'" 1 
+ATOM   828  C "C3'" . DC  B 2 5   ? 71.481  36.115 129.428 1.00 58.10  ? ? ? ? ? ? 5   DC  D "C3'" 1 
+ATOM   829  O "O3'" . DC  B 2 5   ? 71.551  34.978 128.602 1.00 65.76  ? ? ? ? ? ? 5   DC  D "O3'" 1 
+ATOM   830  C "C2'" . DC  B 2 5   ? 70.191  36.133 130.245 1.00 53.20  ? ? ? ? ? ? 5   DC  D "C2'" 1 
+ATOM   831  C "C1'" . DC  B 2 5   ? 70.649  36.381 131.676 1.00 31.69  ? ? ? ? ? ? 5   DC  D "C1'" 1 
+ATOM   832  N N1    . DC  B 2 5   ? 70.319  37.694 132.295 1.00 31.39  ? ? ? ? ? ? 5   DC  D N1    1 
+ATOM   833  C C2    . DC  B 2 5   ? 69.041  37.845 132.831 1.00 35.30  ? ? ? ? ? ? 5   DC  D C2    1 
+ATOM   834  O O2    . DC  B 2 5   ? 68.277  36.885 132.708 1.00 40.57  ? ? ? ? ? ? 5   DC  D O2    1 
+ATOM   835  N N3    . DC  B 2 5   ? 68.681  39.000 133.447 1.00 32.94  ? ? ? ? ? ? 5   DC  D N3    1 
+ATOM   836  C C4    . DC  B 2 5   ? 69.581  39.978 133.541 1.00 39.98  ? ? ? ? ? ? 5   DC  D C4    1 
+ATOM   837  N N4    . DC  B 2 5   ? 69.211  41.106 134.155 1.00 44.02  ? ? ? ? ? ? 5   DC  D N4    1 
+ATOM   838  C C5    . DC  B 2 5   ? 70.902  39.842 133.019 1.00 35.60  ? ? ? ? ? ? 5   DC  D C5    1 
+ATOM   839  C C6    . DC  B 2 5   ? 71.234  38.695 132.415 1.00 32.82  ? ? ? ? ? ? 5   DC  D C6    1 
+ATOM   840  P P     . DT  B 2 6   ? 70.897  35.127 127.160 1.00 58.45  ? ? ? ? ? ? 6   DT  D P     1 
+ATOM   841  O OP1   . DT  B 2 6   ? 71.080  33.843 126.448 1.00 44.84  ? ? ? ? ? ? 6   DT  D OP1   1 
+ATOM   842  O OP2   . DT  B 2 6   ? 71.405  36.386 126.569 1.00 47.23  ? ? ? ? ? ? 6   DT  D OP2   1 
+ATOM   843  O "O5'" . DT  B 2 6   ? 69.344  35.289 127.527 1.00 49.32  ? ? ? ? ? ? 6   DT  D "O5'" 1 
+ATOM   844  C "C5'" . DT  B 2 6   ? 68.596  34.178 128.038 1.00 48.28  ? ? ? ? ? ? 6   DT  D "C5'" 1 
+ATOM   845  C "C4'" . DT  B 2 6   ? 67.107  34.456 128.165 1.00 52.20  ? ? ? ? ? ? 6   DT  D "C4'" 1 
+ATOM   846  O "O4'" . DT  B 2 6   ? 66.793  35.410 129.213 1.00 60.10  ? ? ? ? ? ? 6   DT  D "O4'" 1 
+ATOM   847  C "C3'" . DT  B 2 6   ? 66.426  35.004 126.929 1.00 50.43  ? ? ? ? ? ? 6   DT  D "C3'" 1 
+ATOM   848  O "O3'" . DT  B 2 6   ? 65.113  34.510 126.987 1.00 55.62  ? ? ? ? ? ? 6   DT  D "O3'" 1 
+ATOM   849  C "C2'" . DT  B 2 6   ? 66.448  36.504 127.192 1.00 48.29  ? ? ? ? ? ? 6   DT  D "C2'" 1 
+ATOM   850  C "C1'" . DT  B 2 6   ? 66.140  36.547 128.679 1.00 37.42  ? ? ? ? ? ? 6   DT  D "C1'" 1 
+ATOM   851  N N1    . DT  B 2 6   ? 66.746  37.749 129.294 1.00 35.95  ? ? ? ? ? ? 6   DT  D N1    1 
+ATOM   852  C C2    . DT  B 2 6   ? 65.970  38.533 130.114 1.00 37.41  ? ? ? ? ? ? 6   DT  D C2    1 
+ATOM   853  O O2    . DT  B 2 6   ? 64.814  38.270 130.389 1.00 37.69  ? ? ? ? ? ? 6   DT  D O2    1 
+ATOM   854  N N3    . DT  B 2 6   ? 66.618  39.637 130.607 1.00 36.76  ? ? ? ? ? ? 6   DT  D N3    1 
+ATOM   855  C C4    . DT  B 2 6   ? 67.924  40.024 130.346 1.00 36.23  ? ? ? ? ? ? 6   DT  D C4    1 
+ATOM   856  O O4    . DT  B 2 6   ? 68.357  41.079 130.814 1.00 35.33  ? ? ? ? ? ? 6   DT  D O4    1 
+ATOM   857  C C5    . DT  B 2 6   ? 68.664  39.144 129.474 1.00 33.58  ? ? ? ? ? ? 6   DT  D C5    1 
+ATOM   858  C C7    . DT  B 2 6   ? 70.079  39.441 129.072 1.00 34.38  ? ? ? ? ? ? 6   DT  D C7    1 
+ATOM   859  C C6    . DT  B 2 6   ? 68.046  38.070 128.974 1.00 34.11  ? ? ? ? ? ? 6   DT  D C6    1 
+ATOM   860  P P     . DT  B 2 7   ? 64.236  34.541 125.660 1.00 64.20  ? ? ? ? ? ? 7   DT  D P     1 
+ATOM   861  O OP1   . DT  B 2 7   ? 63.620  33.202 125.509 1.00 64.70  ? ? ? ? ? ? 7   DT  D OP1   1 
+ATOM   862  O OP2   . DT  B 2 7   ? 65.033  35.131 124.560 1.00 78.81  ? ? ? ? ? ? 7   DT  D OP2   1 
+ATOM   863  O "O5'" . DT  B 2 7   ? 63.114  35.591 126.081 1.00 58.95  ? ? ? ? ? ? 7   DT  D "O5'" 1 
+ATOM   864  C "C5'" . DT  B 2 7   ? 62.329  35.289 127.216 1.00 46.57  ? ? ? ? ? ? 7   DT  D "C5'" 1 
+ATOM   865  C "C4'" . DT  B 2 7   ? 61.581  36.542 127.619 1.00 40.27  ? ? ? ? ? ? 7   DT  D "C4'" 1 
+ATOM   866  O "O4'" . DT  B 2 7   ? 62.534  37.553 128.023 1.00 43.99  ? ? ? ? ? ? 7   DT  D "O4'" 1 
+ATOM   867  C "C3'" . DT  B 2 7   ? 60.764  37.174 126.502 1.00 39.73  ? ? ? ? ? ? 7   DT  D "C3'" 1 
+ATOM   868  O "O3'" . DT  B 2 7   ? 59.484  37.444 127.043 1.00 53.93  ? ? ? ? ? ? 7   DT  D "O3'" 1 
+ATOM   869  C "C2'" . DT  B 2 7   ? 61.535  38.453 126.174 1.00 36.76  ? ? ? ? ? ? 7   DT  D "C2'" 1 
+ATOM   870  C "C1'" . DT  B 2 7   ? 62.108  38.808 127.540 1.00 36.68  ? ? ? ? ? ? 7   DT  D "C1'" 1 
+ATOM   871  N N1    . DT  B 2 7   ? 63.336  39.643 127.542 1.00 38.85  ? ? ? ? ? ? 7   DT  D N1    1 
+ATOM   872  C C2    . DT  B 2 7   ? 63.364  40.715 128.402 1.00 42.34  ? ? ? ? ? ? 7   DT  D C2    1 
+ATOM   873  O O2    . DT  B 2 7   ? 62.400  41.054 129.072 1.00 42.45  ? ? ? ? ? ? 7   DT  D O2    1 
+ATOM   874  N N3    . DT  B 2 7   ? 64.546  41.420 128.392 1.00 40.68  ? ? ? ? ? ? 7   DT  D N3    1 
+ATOM   875  C C4    . DT  B 2 7   ? 65.688  41.134 127.661 1.00 44.94  ? ? ? ? ? ? 7   DT  D C4    1 
+ATOM   876  O O4    . DT  B 2 7   ? 66.683  41.843 127.769 1.00 45.04  ? ? ? ? ? ? 7   DT  D O4    1 
+ATOM   877  C C5    . DT  B 2 7   ? 65.595  39.980 126.812 1.00 39.96  ? ? ? ? ? ? 7   DT  D C5    1 
+ATOM   878  C C7    . DT  B 2 7   ? 66.777  39.598 125.973 1.00 37.73  ? ? ? ? ? ? 7   DT  D C7    1 
+ATOM   879  C C6    . DT  B 2 7   ? 64.451  39.286 126.808 1.00 42.61  ? ? ? ? ? ? 7   DT  D C6    1 
+ATOM   880  P P     . DC  B 2 8   ? 58.218  37.662 126.092 1.00 63.37  ? ? ? ? ? ? 8   DC  D P     1 
+ATOM   881  O OP1   . DC  B 2 8   ? 57.163  36.709 126.501 1.00 92.72  ? ? ? ? ? ? 8   DC  D OP1   1 
+ATOM   882  O OP2   . DC  B 2 8   ? 58.696  37.710 124.692 1.00 69.50  ? ? ? ? ? ? 8   DC  D OP2   1 
+ATOM   883  O "O5'" . DC  B 2 8   ? 57.751  39.118 126.526 1.00 53.54  ? ? ? ? ? ? 8   DC  D "O5'" 1 
+ATOM   884  C "C5'" . DC  B 2 8   ? 58.875  39.937 126.710 1.00 57.54  ? ? ? ? ? ? 8   DC  D "C5'" 1 
+ATOM   885  C "C4'" . DC  B 2 8   ? 58.425  41.232 127.331 1.00 47.53  ? ? ? ? ? ? 8   DC  D "C4'" 1 
+ATOM   886  O "O4'" . DC  B 2 8   ? 59.640  41.904 127.720 1.00 43.07  ? ? ? ? ? ? 8   DC  D "O4'" 1 
+ATOM   887  C "C3'" . DC  B 2 8   ? 57.686  42.126 126.347 1.00 44.91  ? ? ? ? ? ? 8   DC  D "C3'" 1 
+ATOM   888  O "O3'" . DC  B 2 8   ? 56.557  42.711 126.977 1.00 57.98  ? ? ? ? ? ? 8   DC  D "O3'" 1 
+ATOM   889  C "C2'" . DC  B 2 8   ? 58.735  43.152 125.927 1.00 48.53  ? ? ? ? ? ? 8   DC  D "C2'" 1 
+ATOM   890  C "C1'" . DC  B 2 8   ? 59.717  43.162 127.094 1.00 41.32  ? ? ? ? ? ? 8   DC  D "C1'" 1 
+ATOM   891  N N1    . DC  B 2 8   ? 61.131  43.249 126.682 1.00 37.48  ? ? ? ? ? ? 8   DC  D N1    1 
+ATOM   892  C C2    . DC  B 2 8   ? 61.814  44.372 127.126 1.00 34.98  ? ? ? ? ? ? 8   DC  D C2    1 
+ATOM   893  O O2    . DC  B 2 8   ? 61.198  45.199 127.816 1.00 39.55  ? ? ? ? ? ? 8   DC  D O2    1 
+ATOM   894  N N3    . DC  B 2 8   ? 63.113  44.509 126.780 1.00 35.85  ? ? ? ? ? ? 8   DC  D N3    1 
+ATOM   895  C C4    . DC  B 2 8   ? 63.720  43.563 126.059 1.00 36.41  ? ? ? ? ? ? 8   DC  D C4    1 
+ATOM   896  N N4    . DC  B 2 8   ? 65.011  43.745 125.757 1.00 40.71  ? ? ? ? ? ? 8   DC  D N4    1 
+ATOM   897  C C5    . DC  B 2 8   ? 63.034  42.400 125.602 1.00 32.24  ? ? ? ? ? ? 8   DC  D C5    1 
+ATOM   898  C C6    . DC  B 2 8   ? 61.749  42.285 125.942 1.00 34.75  ? ? ? ? ? ? 8   DC  D C6    1 
+ATOM   899  P P     . DG  B 2 9   ? 55.427  43.439 126.109 1.00 53.34  ? ? ? ? ? ? 9   DG  D P     1 
+ATOM   900  O OP1   . DG  B 2 9   ? 54.155  43.425 126.863 1.00 64.29  ? ? ? ? ? ? 9   DG  D OP1   1 
+ATOM   901  O OP2   . DG  B 2 9   ? 55.484  42.925 124.725 1.00 62.96  ? ? ? ? ? ? 9   DG  D OP2   1 
+ATOM   902  O "O5'" . DG  B 2 9   ? 55.921  44.953 126.093 1.00 47.12  ? ? ? ? ? ? 9   DG  D "O5'" 1 
+ATOM   903  C "C5'" . DG  B 2 9   ? 55.837  45.722 127.277 1.00 42.07  ? ? ? ? ? ? 9   DG  D "C5'" 1 
+ATOM   904  C "C4'" . DG  B 2 9   ? 56.476  47.054 126.954 1.00 46.97  ? ? ? ? ? ? 9   DG  D "C4'" 1 
+ATOM   905  O "O4'" . DG  B 2 9   ? 57.880  46.829 126.689 1.00 47.41  ? ? ? ? ? ? 9   DG  D "O4'" 1 
+ATOM   906  C "C3'" . DG  B 2 9   ? 55.916  47.699 125.695 1.00 56.01  ? ? ? ? ? ? 9   DG  D "C3'" 1 
+ATOM   907  O "O3'" . DG  B 2 9   ? 55.318  48.915 126.088 1.00 56.55  ? ? ? ? ? ? 9   DG  D "O3'" 1 
+ATOM   908  C "C2'" . DG  B 2 9   ? 57.106  47.909 124.758 1.00 55.40  ? ? ? ? ? ? 9   DG  D "C2'" 1 
+ATOM   909  C "C1'" . DG  B 2 9   ? 58.323  47.669 125.645 1.00 49.64  ? ? ? ? ? ? 9   DG  D "C1'" 1 
+ATOM   910  N N9    . DG  B 2 9   ? 59.421  46.948 125.005 1.00 38.49  ? ? ? ? ? ? 9   DG  D N9    1 
+ATOM   911  C C8    . DG  B 2 9   ? 59.420  45.778 124.281 1.00 28.48  ? ? ? ? ? ? 9   DG  D C8    1 
+ATOM   912  N N7    . DG  B 2 9   ? 60.614  45.421 123.894 1.00 28.12  ? ? ? ? ? ? 9   DG  D N7    1 
+ATOM   913  C C5    . DG  B 2 9   ? 61.458  46.394 124.426 1.00 35.57  ? ? ? ? ? ? 9   DG  D C5    1 
+ATOM   914  C C6    . DG  B 2 9   ? 62.870  46.533 124.362 1.00 36.56  ? ? ? ? ? ? 9   DG  D C6    1 
+ATOM   915  O O6    . DG  B 2 9   ? 63.705  45.812 123.804 1.00 36.72  ? ? ? ? ? ? 9   DG  D O6    1 
+ATOM   916  N N1    . DG  B 2 9   ? 63.324  47.672 125.026 1.00 36.16  ? ? ? ? ? ? 9   DG  D N1    1 
+ATOM   917  C C2    . DG  B 2 9   ? 62.518  48.561 125.690 1.00 44.81  ? ? ? ? ? ? 9   DG  D C2    1 
+ATOM   918  N N2    . DG  B 2 9   ? 63.147  49.584 126.291 1.00 43.43  ? ? ? ? ? ? 9   DG  D N2    1 
+ATOM   919  N N3    . DG  B 2 9   ? 61.195  48.447 125.765 1.00 43.59  ? ? ? ? ? ? 9   DG  D N3    1 
+ATOM   920  C C4    . DG  B 2 9   ? 60.737  47.343 125.115 1.00 40.34  ? ? ? ? ? ? 9   DG  D C4    1 
+ATOM   921  P P     . DT  B 2 10  ? 54.863  49.941 124.958 1.00 55.53  ? ? ? ? ? ? 10  DT  D P     1 
+ATOM   922  O OP1   . DT  B 2 10  ? 53.735  50.728 125.500 1.00 67.54  ? ? ? ? ? ? 10  DT  D OP1   1 
+ATOM   923  O OP2   . DT  B 2 10  ? 54.718  49.189 123.691 1.00 66.51  ? ? ? ? ? ? 10  DT  D OP2   1 
+ATOM   924  O "O5'" . DT  B 2 10  ? 56.124  50.913 124.862 1.00 58.49  ? ? ? ? ? ? 10  DT  D "O5'" 1 
+ATOM   925  C "C5'" . DT  B 2 10  ? 56.270  51.905 125.860 1.00 58.13  ? ? ? ? ? ? 10  DT  D "C5'" 1 
+ATOM   926  C "C4'" . DT  B 2 10  ? 57.582  52.603 125.586 1.00 66.04  ? ? ? ? ? ? 10  DT  D "C4'" 1 
+ATOM   927  O "O4'" . DT  B 2 10  ? 58.542  51.599 125.169 1.00 60.65  ? ? ? ? ? ? 10  DT  D "O4'" 1 
+ATOM   928  C "C3'" . DT  B 2 10  ? 57.498  53.571 124.414 1.00 72.37  ? ? ? ? ? ? 10  DT  D "C3'" 1 
+ATOM   929  O "O3'" . DT  B 2 10  ? 58.486  54.555 124.607 1.00 80.96  ? ? ? ? ? ? 10  DT  D "O3'" 1 
+ATOM   930  C "C2'" . DT  B 2 10  ? 57.908  52.676 123.253 1.00 60.22  ? ? ? ? ? ? 10  DT  D "C2'" 1 
+ATOM   931  C "C1'" . DT  B 2 10  ? 59.093  52.025 123.944 1.00 51.57  ? ? ? ? ? ? 10  DT  D "C1'" 1 
+ATOM   932  N N1    . DT  B 2 10  ? 59.653  50.866 123.219 1.00 51.65  ? ? ? ? ? ? 10  DT  D N1    1 
+ATOM   933  C C2    . DT  B 2 10  ? 61.026  50.722 123.279 1.00 49.69  ? ? ? ? ? ? 10  DT  D C2    1 
+ATOM   934  O O2    . DT  B 2 10  ? 61.751  51.487 123.901 1.00 48.24  ? ? ? ? ? ? 10  DT  D O2    1 
+ATOM   935  N N3    . DT  B 2 10  ? 61.523  49.643 122.590 1.00 37.80  ? ? ? ? ? ? 10  DT  D N3    1 
+ATOM   936  C C4    . DT  B 2 10  ? 60.795  48.735 121.840 1.00 40.04  ? ? ? ? ? ? 10  DT  D C4    1 
+ATOM   937  O O4    . DT  B 2 10  ? 61.373  47.823 121.257 1.00 39.34  ? ? ? ? ? ? 10  DT  D O4    1 
+ATOM   938  C C5    . DT  B 2 10  ? 59.371  48.954 121.821 1.00 47.91  ? ? ? ? ? ? 10  DT  D C5    1 
+ATOM   939  C C7    . DT  B 2 10  ? 58.529  48.002 121.032 1.00 48.41  ? ? ? ? ? ? 10  DT  D C7    1 
+ATOM   940  C C6    . DT  B 2 10  ? 58.861  49.991 122.503 1.00 50.38  ? ? ? ? ? ? 10  DT  D C6    1 
+ATOM   941  P P     . DA  B 2 11  ? 58.192  56.089 124.290 1.00 82.62  ? ? ? ? ? ? 11  DA  D P     1 
+ATOM   942  O OP1   . DA  B 2 11  ? 58.319  56.786 125.588 1.00 71.98  ? ? ? ? ? ? 11  DA  D OP1   1 
+ATOM   943  O OP2   . DA  B 2 11  ? 56.956  56.192 123.485 1.00 76.09  ? ? ? ? ? ? 11  DA  D OP2   1 
+ATOM   944  O "O5'" . DA  B 2 11  ? 59.460  56.445 123.386 1.00 81.19  ? ? ? ? ? ? 11  DA  D "O5'" 1 
+ATOM   945  C "C5'" . DA  B 2 11  ? 60.684  56.380 124.097 1.00 64.25  ? ? ? ? ? ? 11  DA  D "C5'" 1 
+ATOM   946  C "C4'" . DA  B 2 11  ? 61.866  56.133 123.185 1.00 54.53  ? ? ? ? ? ? 11  DA  D "C4'" 1 
+ATOM   947  O "O4'" . DA  B 2 11  ? 61.948  54.757 122.745 1.00 55.21  ? ? ? ? ? ? 11  DA  D "O4'" 1 
+ATOM   948  C "C3'" . DA  B 2 11  ? 61.900  56.999 121.938 1.00 57.47  ? ? ? ? ? ? 11  DA  D "C3'" 1 
+ATOM   949  O "O3'" . DA  B 2 11  ? 62.928  57.952 122.154 1.00 55.33  ? ? ? ? ? ? 11  DA  D "O3'" 1 
+ATOM   950  C "C2'" . DA  B 2 11  ? 62.211  56.025 120.799 1.00 59.67  ? ? ? ? ? ? 11  DA  D "C2'" 1 
+ATOM   951  C "C1'" . DA  B 2 11  ? 62.625  54.737 121.504 1.00 48.08  ? ? ? ? ? ? 11  DA  D "C1'" 1 
+ATOM   952  N N9    . DA  B 2 11  ? 62.302  53.480 120.821 1.00 42.48  ? ? ? ? ? ? 11  DA  D N9    1 
+ATOM   953  C C8    . DA  B 2 11  ? 61.087  52.866 120.653 1.00 39.62  ? ? ? ? ? ? 11  DA  D C8    1 
+ATOM   954  N N7    . DA  B 2 11  ? 61.151  51.708 120.037 1.00 34.61  ? ? ? ? ? ? 11  DA  D N7    1 
+ATOM   955  C C5    . DA  B 2 11  ? 62.505  51.543 119.789 1.00 34.27  ? ? ? ? ? ? 11  DA  D C5    1 
+ATOM   956  C C6    . DA  B 2 11  ? 63.255  50.516 119.169 1.00 38.11  ? ? ? ? ? ? 11  DA  D C6    1 
+ATOM   957  N N6    . DA  B 2 11  ? 62.728  49.402 118.651 1.00 35.94  ? ? ? ? ? ? 11  DA  D N6    1 
+ATOM   958  N N1    . DA  B 2 11  ? 64.595  50.665 119.105 1.00 38.46  ? ? ? ? ? ? 11  DA  D N1    1 
+ATOM   959  C C2    . DA  B 2 11  ? 65.148  51.777 119.607 1.00 37.19  ? ? ? ? ? ? 11  DA  D C2    1 
+ATOM   960  N N3    . DA  B 2 11  ? 64.551  52.806 120.205 1.00 36.11  ? ? ? ? ? ? 11  DA  D N3    1 
+ATOM   961  C C4    . DA  B 2 11  ? 63.225  52.620 120.277 1.00 35.86  ? ? ? ? ? ? 11  DA  D C4    1 
+ATOM   962  P P     . DT  B 2 12  ? 63.377  59.042 121.078 1.00 52.78  ? ? ? ? ? ? 12  DT  D P     1 
+ATOM   963  O OP1   . DT  B 2 12  ? 64.423  59.878 121.706 1.00 77.56  ? ? ? ? ? ? 12  DT  D OP1   1 
+ATOM   964  O OP2   . DT  B 2 12  ? 62.167  59.688 120.522 1.00 71.01  ? ? ? ? ? ? 12  DT  D OP2   1 
+ATOM   965  O "O5'" . DT  B 2 12  ? 64.075  58.155 119.952 1.00 44.41  ? ? ? ? ? ? 12  DT  D "O5'" 1 
+ATOM   966  C "C5'" . DT  B 2 12  ? 65.485  58.064 120.000 1.00 45.72  ? ? ? ? ? ? 12  DT  D "C5'" 1 
+ATOM   967  C "C4'" . DT  B 2 12  ? 65.982  57.089 118.954 1.00 45.49  ? ? ? ? ? ? 12  DT  D "C4'" 1 
+ATOM   968  O "O4'" . DT  B 2 12  ? 65.087  55.957 118.832 1.00 42.50  ? ? ? ? ? ? 12  DT  D "O4'" 1 
+ATOM   969  C "C3'" . DT  B 2 12  ? 66.173  57.638 117.542 1.00 61.67  ? ? ? ? ? ? 12  DT  D "C3'" 1 
+ATOM   970  O "O3'" . DT  B 2 12  ? 67.553  57.556 117.227 1.00 65.91  ? ? ? ? ? ? 12  DT  D "O3'" 1 
+ATOM   971  C "C2'" . DT  B 2 12  ? 65.397  56.667 116.651 1.00 61.12  ? ? ? ? ? ? 12  DT  D "C2'" 1 
+ATOM   972  C "C1'" . DT  B 2 12  ? 65.314  55.433 117.542 1.00 50.89  ? ? ? ? ? ? 12  DT  D "C1'" 1 
+ATOM   973  N N1    . DT  B 2 12  ? 64.218  54.491 117.186 1.00 50.13  ? ? ? ? ? ? 12  DT  D N1    1 
+ATOM   974  C C2    . DT  B 2 12  ? 64.602  53.344 116.525 1.00 48.44  ? ? ? ? ? ? 12  DT  D C2    1 
+ATOM   975  O O2    . DT  B 2 12  ? 65.759  53.088 116.226 1.00 45.77  ? ? ? ? ? ? 12  DT  D O2    1 
+ATOM   976  N N3    . DT  B 2 12  ? 63.573  52.493 116.215 1.00 47.48  ? ? ? ? ? ? 12  DT  D N3    1 
+ATOM   977  C C4    . DT  B 2 12  ? 62.233  52.685 116.457 1.00 42.61  ? ? ? ? ? ? 12  DT  D C4    1 
+ATOM   978  O O4    . DT  B 2 12  ? 61.459  51.783 116.143 1.00 41.63  ? ? ? ? ? ? 12  DT  D O4    1 
+ATOM   979  C C5    . DT  B 2 12  ? 61.893  53.913 117.146 1.00 39.82  ? ? ? ? ? ? 12  DT  D C5    1 
+ATOM   980  C C7    . DT  B 2 12  ? 60.468  54.182 117.497 1.00 40.29  ? ? ? ? ? ? 12  DT  D C7    1 
+ATOM   981  C C6    . DT  B 2 12  ? 62.888  54.744 117.481 1.00 43.45  ? ? ? ? ? ? 12  DT  D C6    1 
+ATOM   982  P P     . DA  B 2 13  ? 68.307  58.568 116.250 1.00 59.21  ? ? ? ? ? ? 13  DA  D P     1 
+ATOM   983  O OP1   . DA  B 2 13  ? 69.194  59.368 117.122 1.00 76.31  ? ? ? ? ? ? 13  DA  D OP1   1 
+ATOM   984  O OP2   . DA  B 2 13  ? 67.337  59.253 115.368 1.00 51.10  ? ? ? ? ? ? 13  DA  D OP2   1 
+ATOM   985  O "O5'" . DA  B 2 13  ? 69.180  57.542 115.385 1.00 49.69  ? ? ? ? ? ? 13  DA  D "O5'" 1 
+ATOM   986  C "C5'" . DA  B 2 13  ? 69.806  56.507 116.135 1.00 45.59  ? ? ? ? ? ? 13  DA  D "C5'" 1 
+ATOM   987  C "C4'" . DA  B 2 13  ? 70.415  55.400 115.294 1.00 48.85  ? ? ? ? ? ? 13  DA  D "C4'" 1 
+ATOM   988  O "O4'" . DA  B 2 13  ? 69.457  54.334 115.082 1.00 55.28  ? ? ? ? ? ? 13  DA  D "O4'" 1 
+ATOM   989  C "C3'" . DA  B 2 13  ? 70.962  55.745 113.919 1.00 52.35  ? ? ? ? ? ? 13  DA  D "C3'" 1 
+ATOM   990  O "O3'" . DA  B 2 13  ? 72.070  54.887 113.680 1.00 56.07  ? ? ? ? ? ? 13  DA  D "O3'" 1 
+ATOM   991  C "C2'" . DA  B 2 13  ? 69.793  55.415 112.992 1.00 61.21  ? ? ? ? ? ? 13  DA  D "C2'" 1 
+ATOM   992  C "C1'" . DA  B 2 13  ? 69.078  54.278 113.720 1.00 55.79  ? ? ? ? ? ? 13  DA  D "C1'" 1 
+ATOM   993  N N9    . DA  B 2 13  ? 67.615  54.312 113.674 1.00 50.48  ? ? ? ? ? ? 13  DA  D N9    1 
+ATOM   994  C C8    . DA  B 2 13  ? 66.724  55.231 114.162 1.00 49.80  ? ? ? ? ? ? 13  DA  D C8    1 
+ATOM   995  N N7    . DA  B 2 13  ? 65.465  54.901 113.972 1.00 45.40  ? ? ? ? ? ? 13  DA  D N7    1 
+ATOM   996  C C5    . DA  B 2 13  ? 65.538  53.674 113.331 1.00 46.15  ? ? ? ? ? ? 13  DA  D C5    1 
+ATOM   997  C C6    . DA  B 2 13  ? 64.555  52.787 112.847 1.00 42.11  ? ? ? ? ? ? 13  DA  D C6    1 
+ATOM   998  N N6    . DA  B 2 13  ? 63.240  53.015 112.932 1.00 37.68  ? ? ? ? ? ? 13  DA  D N6    1 
+ATOM   999  N N1    . DA  B 2 13  ? 64.974  51.644 112.269 1.00 44.52  ? ? ? ? ? ? 13  DA  D N1    1 
+ATOM   1000 C C2    . DA  B 2 13  ? 66.289  51.407 112.172 1.00 48.29  ? ? ? ? ? ? 13  DA  D C2    1 
+ATOM   1001 N N3    . DA  B 2 13  ? 67.306  52.166 112.577 1.00 48.82  ? ? ? ? ? ? 13  DA  D N3    1 
+ATOM   1002 C C4    . DA  B 2 13  ? 66.856  53.293 113.152 1.00 47.67  ? ? ? ? ? ? 13  DA  D C4    1 
+ATOM   1003 P P     . DG  B 2 14  ? 72.721  54.817 112.223 1.00 65.99  ? ? ? ? ? ? 14  DG  D P     1 
+ATOM   1004 O OP1   . DG  B 2 14  ? 74.146  54.438 112.354 1.00 64.08  ? ? ? ? ? ? 14  DG  D OP1   1 
+ATOM   1005 O OP2   . DG  B 2 14  ? 72.321  56.038 111.487 1.00 61.69  ? ? ? ? ? ? 14  DG  D OP2   1 
+ATOM   1006 O "O5'" . DG  B 2 14  ? 71.955  53.563 111.607 1.00 80.76  ? ? ? ? ? ? 14  DG  D "O5'" 1 
+ATOM   1007 C "C5'" . DG  B 2 14  ? 72.520  52.278 111.767 1.00 72.19  ? ? ? ? ? ? 14  DG  D "C5'" 1 
+ATOM   1008 C "C4'" . DG  B 2 14  ? 71.732  51.334 110.888 1.00 67.66  ? ? ? ? ? ? 14  DG  D "C4'" 1 
+ATOM   1009 O "O4'" . DG  B 2 14  ? 70.345  51.745 110.920 1.00 65.87  ? ? ? ? ? ? 14  DG  D "O4'" 1 
+ATOM   1010 C "C3'" . DG  B 2 14  ? 72.134  51.358 109.419 1.00 65.75  ? ? ? ? ? ? 14  DG  D "C3'" 1 
+ATOM   1011 O "O3'" . DG  B 2 14  ? 72.164  50.019 108.958 1.00 79.43  ? ? ? ? ? ? 14  DG  D "O3'" 1 
+ATOM   1012 C "C2'" . DG  B 2 14  ? 71.031  52.173 108.743 1.00 50.86  ? ? ? ? ? ? 14  DG  D "C2'" 1 
+ATOM   1013 C "C1'" . DG  B 2 14  ? 69.848  51.736 109.600 1.00 57.35  ? ? ? ? ? ? 14  DG  D "C1'" 1 
+ATOM   1014 N N9    . DG  B 2 14  ? 68.618  52.526 109.577 1.00 47.12  ? ? ? ? ? ? 14  DG  D N9    1 
+ATOM   1015 C C8    . DG  B 2 14  ? 68.412  53.841 109.906 1.00 45.25  ? ? ? ? ? ? 14  DG  D C8    1 
+ATOM   1016 N N7    . DG  B 2 14  ? 67.165  54.211 109.825 1.00 43.95  ? ? ? ? ? ? 14  DG  D N7    1 
+ATOM   1017 C C5    . DG  B 2 14  ? 66.488  53.061 109.439 1.00 45.47  ? ? ? ? ? ? 14  DG  D C5    1 
+ATOM   1018 C C6    . DG  B 2 14  ? 65.104  52.851 109.204 1.00 39.04  ? ? ? ? ? ? 14  DG  D C6    1 
+ATOM   1019 O O6    . DG  B 2 14  ? 64.175  53.667 109.285 1.00 37.96  ? ? ? ? ? ? 14  DG  D O6    1 
+ATOM   1020 N N1    . DG  B 2 14  ? 64.826  51.537 108.832 1.00 35.78  ? ? ? ? ? ? 14  DG  D N1    1 
+ATOM   1021 C C2    . DG  B 2 14  ? 65.783  50.555 108.728 1.00 54.19  ? ? ? ? ? ? 14  DG  D C2    1 
+ATOM   1022 N N2    . DG  B 2 14  ? 65.330  49.345 108.357 1.00 68.50  ? ? ? ? ? ? 14  DG  D N2    1 
+ATOM   1023 N N3    . DG  B 2 14  ? 67.084  50.730 108.943 1.00 52.29  ? ? ? ? ? ? 14  DG  D N3    1 
+ATOM   1024 C C4    . DG  B 2 14  ? 67.369  52.009 109.305 1.00 50.44  ? ? ? ? ? ? 14  DG  D C4    1 
+ATOM   1025 P P     . DC  B 2 15  ? 73.272  49.588 107.895 1.00 87.01  ? ? ? ? ? ? 15  DC  D P     1 
+ATOM   1026 O OP1   . DC  B 2 15  ? 73.068  48.158 107.572 1.00 96.13  ? ? ? ? ? ? 15  DC  D OP1   1 
+ATOM   1027 O OP2   . DC  B 2 15  ? 74.584  50.047 108.402 1.00 99.69  ? ? ? ? ? ? 15  DC  D OP2   1 
+ATOM   1028 O "O5'" . DC  B 2 15  ? 72.870  50.466 106.619 1.00 89.73  ? ? ? ? ? ? 15  DC  D "O5'" 1 
+ATOM   1029 C "C5'" . DC  B 2 15  ? 72.256  49.865 105.484 1.00 93.43  ? ? ? ? ? ? 15  DC  D "C5'" 1 
+ATOM   1030 C "C4'" . DC  B 2 15  ? 70.918  49.240 105.839 1.00 82.66  ? ? ? ? ? ? 15  DC  D "C4'" 1 
+ATOM   1031 O "O4'" . DC  B 2 15  ? 70.043  50.228 106.434 1.00 76.78  ? ? ? ? ? ? 15  DC  D "O4'" 1 
+ATOM   1032 C "C3'" . DC  B 2 15  ? 70.165  48.660 104.651 1.00 77.91  ? ? ? ? ? ? 15  DC  D "C3'" 1 
+ATOM   1033 O "O3'" . DC  B 2 15  ? 69.843  47.298 104.901 1.00 79.25  ? ? ? ? ? ? 15  DC  D "O3'" 1 
+ATOM   1034 C "C2'" . DC  B 2 15  ? 68.934  49.550 104.494 1.00 80.12  ? ? ? ? ? ? 15  DC  D "C2'" 1 
+ATOM   1035 C "C1'" . DC  B 2 15  ? 68.741  50.089 105.905 1.00 66.05  ? ? ? ? ? ? 15  DC  D "C1'" 1 
+ATOM   1036 N N1    . DC  B 2 15  ? 68.067  51.420 106.005 1.00 69.64  ? ? ? ? ? ? 15  DC  D N1    1 
+ATOM   1037 C C2    . DC  B 2 15  ? 66.790  51.605 105.461 1.00 68.56  ? ? ? ? ? ? 15  DC  D C2    1 
+ATOM   1038 O O2    . DC  B 2 15  ? 66.226  50.669 104.881 1.00 68.80  ? ? ? ? ? ? 15  DC  D O2    1 
+ATOM   1039 N N3    . DC  B 2 15  ? 66.197  52.820 105.590 1.00 64.97  ? ? ? ? ? ? 15  DC  D N3    1 
+ATOM   1040 C C4    . DC  B 2 15  ? 66.829  53.812 106.221 1.00 66.98  ? ? ? ? ? ? 15  DC  D C4    1 
+ATOM   1041 N N4    . DC  B 2 15  ? 66.207  54.994 106.317 1.00 63.92  ? ? ? ? ? ? 15  DC  D N4    1 
+ATOM   1042 C C5    . DC  B 2 15  ? 68.125  53.635 106.790 1.00 69.89  ? ? ? ? ? ? 15  DC  D C5    1 
+ATOM   1043 C C6    . DC  B 2 15  ? 68.702  52.436 106.655 1.00 70.64  ? ? ? ? ? ? 15  DC  D C6    1 
+ATOM   1044 P P     A DA  B 2 16  ? 70.318  46.211 103.825 0.73 90.84  ? ? ? ? ? ? 16  DA  D P     1 
+ATOM   1045 P P     B DA  B 2 16  ? 70.290  46.197 103.902 0.27 86.16  ? ? ? ? ? ? 16  DA  D P     1 
+ATOM   1046 O OP1   A DA  B 2 16  ? 70.494  44.910 104.513 0.73 100.00 ? ? ? ? ? ? 16  DA  D OP1   1 
+ATOM   1047 O OP1   B DA  B 2 16  ? 70.516  44.933 104.639 0.27 89.93  ? ? ? ? ? ? 16  DA  D OP1   1 
+ATOM   1048 O OP2   A DA  B 2 16  ? 71.413  46.793 103.016 0.73 88.69  ? ? ? ? ? ? 16  DA  D OP2   1 
+ATOM   1049 O OP2   B DA  B 2 16  ? 71.379  46.801 103.103 0.27 83.87  ? ? ? ? ? ? 16  DA  D OP2   1 
+ATOM   1050 O "O5'" A DA  B 2 16  ? 69.004  46.112 102.926 0.73 91.41  ? ? ? ? ? ? 16  DA  D "O5'" 1 
+ATOM   1051 O "O5'" B DA  B 2 16  ? 69.030  45.984 102.941 0.27 86.15  ? ? ? ? ? ? 16  DA  D "O5'" 1 
+ATOM   1052 C "C5'" A DA  B 2 16  ? 67.724  46.090 103.547 0.73 92.80  ? ? ? ? ? ? 16  DA  D "C5'" 1 
+ATOM   1053 C "C5'" B DA  B 2 16  ? 67.763  45.430 103.293 0.27 86.01  ? ? ? ? ? ? 16  DA  D "C5'" 1 
+ATOM   1054 C "C4'" A DA  B 2 16  ? 66.715  45.604 102.527 0.73 97.79  ? ? ? ? ? ? 16  DA  D "C4'" 1 
+ATOM   1055 C "C4'" B DA  B 2 16  ? 66.834  45.452 102.088 0.27 87.56  ? ? ? ? ? ? 16  DA  D "C4'" 1 
+ATOM   1056 O "O4'" A DA  B 2 16  ? 65.789  46.674 102.213 0.73 96.39  ? ? ? ? ? ? 16  DA  D "O4'" 1 
+ATOM   1057 O "O4'" B DA  B 2 16  ? 66.026  46.659 102.157 0.27 84.74  ? ? ? ? ? ? 16  DA  D "O4'" 1 
+ATOM   1058 C "C3'" A DA  B 2 16  ? 67.379  45.238 101.208 0.73 100.00 ? ? ? ? ? ? 16  DA  D "C3'" 1 
+ATOM   1059 C "C3'" B DA  B 2 16  ? 67.547  45.545 100.739 0.27 87.73  ? ? ? ? ? ? 16  DA  D "C3'" 1 
+ATOM   1060 O "O3'" A DA  B 2 16  ? 66.713  44.206 100.471 0.73 100.00 ? ? ? ? ? ? 16  DA  D "O3'" 1 
+ATOM   1061 O "O3'" B DA  B 2 16  ? 66.676  45.208 99.659  0.27 86.88  ? ? ? ? ? ? 16  DA  D "O3'" 1 
+ATOM   1062 C "C2'" A DA  B 2 16  ? 67.405  46.579 100.477 0.73 89.88  ? ? ? ? ? ? 16  DA  D "C2'" 1 
+ATOM   1063 C "C2'" B DA  B 2 16  ? 67.775  47.043 100.702 0.27 78.16  ? ? ? ? ? ? 16  DA  D "C2'" 1 
+ATOM   1064 C "C1'" A DA  B 2 16  ? 66.208  47.344 101.042 0.73 82.70  ? ? ? ? ? ? 16  DA  D "C1'" 1 
+ATOM   1065 C "C1'" B DA  B 2 16  ? 66.365  47.480 101.058 0.27 73.12  ? ? ? ? ? ? 16  DA  D "C1'" 1 
+ATOM   1066 N N9    A DA  B 2 16  ? 66.531  48.716 101.418 0.73 70.87  ? ? ? ? ? ? 16  DA  D N9    1 
+ATOM   1067 N N9    B DA  B 2 16  ? 66.517  48.855 101.485 0.27 63.66  ? ? ? ? ? ? 16  DA  D N9    1 
+ATOM   1068 C C8    A DA  B 2 16  ? 67.769  49.254 101.614 0.73 71.22  ? ? ? ? ? ? 16  DA  D C8    1 
+ATOM   1069 C C8    B DA  B 2 16  ? 67.732  49.405 101.781 0.27 63.13  ? ? ? ? ? ? 16  DA  D C8    1 
+ATOM   1070 N N7    A DA  B 2 16  ? 67.749  50.521 101.959 0.73 69.84  ? ? ? ? ? ? 16  DA  D N7    1 
+ATOM   1071 N N7    B DA  B 2 16  ? 67.687  50.666 102.114 0.27 61.54  ? ? ? ? ? ? 16  DA  D N7    1 
+ATOM   1072 C C5    A DA  B 2 16  ? 66.402  50.835 101.993 0.73 71.29  ? ? ? ? ? ? 16  DA  D C5    1 
+ATOM   1073 C C5    B DA  B 2 16  ? 66.341  50.966 102.019 0.27 62.98  ? ? ? ? ? ? 16  DA  D C5    1 
+ATOM   1074 C C6    A DA  B 2 16  ? 65.717  52.030 102.282 0.73 70.60  ? ? ? ? ? ? 16  DA  D C6    1 
+ATOM   1075 C C6    B DA  B 2 16  ? 65.632  52.158 102.254 0.27 61.90  ? ? ? ? ? ? 16  DA  D C6    1 
+ATOM   1076 N N6    A DA  B 2 16  ? 66.339  53.170 102.628 0.73 68.49  ? ? ? ? ? ? 16  DA  D N6    1 
+ATOM   1077 N N6    B DA  B 2 16  ? 66.214  53.297 102.638 0.27 60.31  ? ? ? ? ? ? 16  DA  D N6    1 
+ATOM   1078 N N1    A DA  B 2 16  ? 64.369  52.021 102.225 0.73 70.38  ? ? ? ? ? ? 16  DA  D N1    1 
+ATOM   1079 N N1    B DA  B 2 16  ? 64.295  52.134 102.064 0.27 61.54  ? ? ? ? ? ? 16  DA  D N1    1 
+ATOM   1080 C C2    A DA  B 2 16  ? 63.767  50.876 101.880 0.73 70.99  ? ? ? ? ? ? 16  DA  D C2    1 
+ATOM   1081 C C2    B DA  B 2 16  ? 63.718  50.993 101.683 0.27 62.12  ? ? ? ? ? ? 16  DA  D C2    1 
+ATOM   1082 N N3    A DA  B 2 16  ? 64.300  49.693 101.578 0.73 70.59  ? ? ? ? ? ? 16  DA  D N3    1 
+ATOM   1083 N N3    B DA  B 2 16  ? 64.274  49.808 101.420 0.27 61.91  ? ? ? ? ? ? 16  DA  D N3    1 
+ATOM   1084 C C4    A DA  B 2 16  ? 65.638  49.733 101.653 0.73 70.26  ? ? ? ? ? ? 16  DA  D C4    1 
+ATOM   1085 C C4    B DA  B 2 16  ? 65.601  49.868 101.623 0.27 62.12  ? ? ? ? ? ? 16  DA  D C4    1 
+ATOM   1086 P P     A DT  B 2 17  ? 65.819  43.020 101.072 0.73 100.00 ? ? ? ? ? ? 17  DT  D P     1 
+ATOM   1087 P P     B DT  B 2 17  ? 66.793  45.708 98.135  0.27 85.00  ? ? ? ? ? ? 17  DT  D P     1 
+ATOM   1088 O OP1   A DT  B 2 17  ? 65.999  42.920 102.539 0.73 99.77  ? ? ? ? ? ? 17  DT  D OP1   1 
+ATOM   1089 O OP1   B DT  B 2 17  ? 67.034  44.497 97.323  0.27 84.20  ? ? ? ? ? ? 17  DT  D OP1   1 
+ATOM   1090 O OP2   A DT  B 2 17  ? 66.027  41.811 100.249 0.73 100.00 ? ? ? ? ? ? 17  DT  D OP2   1 
+ATOM   1091 O OP2   B DT  B 2 17  ? 67.708  46.858 97.944  0.27 80.44  ? ? ? ? ? ? 17  DT  D OP2   1 
+ATOM   1092 O "O5'" A DT  B 2 17  ? 64.335  43.514 100.776 0.73 93.58  ? ? ? ? ? ? 17  DT  D "O5'" 1 
+ATOM   1093 O "O5'" B DT  B 2 17  ? 65.299  46.189 97.809  0.27 83.29  ? ? ? ? ? ? 17  DT  D "O5'" 1 
+ATOM   1094 C "C5'" A DT  B 2 17  ? 63.424  42.478 100.460 0.73 92.55  ? ? ? ? ? ? 17  DT  D "C5'" 1 
+ATOM   1095 C "C5'" B DT  B 2 17  ? 64.756  47.370 98.395  0.27 74.19  ? ? ? ? ? ? 17  DT  D "C5'" 1 
+ATOM   1096 C "C4'" A DT  B 2 17  ? 62.087  43.150 100.265 0.73 92.78  ? ? ? ? ? ? 17  DT  D "C4'" 1 
+ATOM   1097 C "C4'" B DT  B 2 17  ? 63.239  47.449 98.315  0.27 61.65  ? ? ? ? ? ? 17  DT  D "C4'" 1 
+ATOM   1098 O "O4'" A DT  B 2 17  ? 62.387  44.568 100.195 0.73 90.86  ? ? ? ? ? ? 17  DT  D "O4'" 1 
+ATOM   1099 O "O4'" B DT  B 2 17  ? 62.860  48.714 98.911  0.27 55.07  ? ? ? ? ? ? 17  DT  D "O4'" 1 
+ATOM   1100 C "C3'" A DT  B 2 17  ? 61.390  42.835 98.950  0.73 92.55  ? ? ? ? ? ? 17  DT  D "C3'" 1 
+ATOM   1101 C "C3'" B DT  B 2 17  ? 62.660  47.601 96.915  0.27 63.71  ? ? ? ? ? ? 17  DT  D "C3'" 1 
+ATOM   1102 O "O3'" A DT  B 2 17  ? 60.042  43.228 99.082  0.73 97.47  ? ? ? ? ? ? 17  DT  D "O3'" 1 
+ATOM   1103 O "O3'" B DT  B 2 17  ? 61.248  47.780 97.032  0.27 76.31  ? ? ? ? ? ? 17  DT  D "O3'" 1 
+ATOM   1104 C "C2'" A DT  B 2 17  ? 62.093  43.789 97.998  0.73 86.25  ? ? ? ? ? ? 17  DT  D "C2'" 1 
+ATOM   1105 C "C2'" B DT  B 2 17  ? 63.256  48.967 96.611  0.27 43.90  ? ? ? ? ? ? 17  DT  D "C2'" 1 
+ATOM   1106 C "C1'" A DT  B 2 17  ? 62.160  45.031 98.877  0.73 88.62  ? ? ? ? ? ? 17  DT  D "C1'" 1 
+ATOM   1107 C "C1'" B DT  B 2 17  ? 62.799  49.682 97.879  0.27 35.12  ? ? ? ? ? ? 17  DT  D "C1'" 1 
+ATOM   1108 N N1    A DT  B 2 17  ? 63.232  45.956 98.412  0.73 88.56  ? ? ? ? ? ? 17  DT  D N1    1 
+ATOM   1109 N N1    B DT  B 2 17  ? 63.653  50.843 98.240  0.27 32.02  ? ? ? ? ? ? 17  DT  D N1    1 
+ATOM   1110 C C2    A DT  B 2 17  ? 62.817  47.211 98.026  0.73 87.28  ? ? ? ? ? ? 17  DT  D C2    1 
+ATOM   1111 C C2    B DT  B 2 17  ? 63.057  52.083 98.302  0.27 30.80  ? ? ? ? ? ? 17  DT  D C2    1 
+ATOM   1112 O O2    A DT  B 2 17  ? 61.668  47.597 98.127  0.73 86.40  ? ? ? ? ? ? 17  DT  D O2    1 
+ATOM   1113 O O2    B DT  B 2 17  ? 61.871  52.270 98.161  0.27 30.71  ? ? ? ? ? ? 17  DT  D O2    1 
+ATOM   1114 N N3    A DT  B 2 17  ? 63.812  48.029 97.547  0.73 85.36  ? ? ? ? ? ? 17  DT  D N3    1 
+ATOM   1115 N N3    B DT  B 2 17  ? 63.914  53.107 98.615  0.27 26.41  ? ? ? ? ? ? 17  DT  D N3    1 
+ATOM   1116 C C4    A DT  B 2 17  ? 65.148  47.714 97.386  0.73 85.64  ? ? ? ? ? ? 17  DT  D C4    1 
+ATOM   1117 C C4    B DT  B 2 17  ? 65.270  53.015 98.857  0.27 26.27  ? ? ? ? ? ? 17  DT  D C4    1 
+ATOM   1118 O O4    A DT  B 2 17  ? 65.925  48.554 96.948  0.73 84.65  ? ? ? ? ? ? 17  DT  D O4    1 
+ATOM   1119 O O4    B DT  B 2 17  ? 65.901  54.029 99.109  0.27 25.54  ? ? ? ? ? ? 17  DT  D O4    1 
+ATOM   1120 C C5    A DT  B 2 17  ? 65.501  46.368 97.762  0.73 86.38  ? ? ? ? ? ? 17  DT  D C5    1 
+ATOM   1121 C C5    B DT  B 2 17  ? 65.825  51.686 98.735  0.27 26.49  ? ? ? ? ? ? 17  DT  D C5    1 
+ATOM   1122 C C7    A DT  B 2 17  ? 66.913  45.889 97.613  0.73 84.44  ? ? ? ? ? ? 17  DT  D C7    1 
+ATOM   1123 C C7    B DT  B 2 17  ? 67.297  51.489 98.955  0.27 27.15  ? ? ? ? ? ? 17  DT  D C7    1 
+ATOM   1124 C C6    A DT  B 2 17  ? 64.543  45.561 98.238  0.73 88.00  ? ? ? ? ? ? 17  DT  D C6    1 
+ATOM   1125 C C6    B DT  B 2 17  ? 65.003  50.684 98.468  0.27 27.18  ? ? ? ? ? ? 17  DT  D C6    1 
+ATOM   1126 P P     A DA  B 2 18  ? 58.911  42.502 98.224  0.73 100.00 ? ? ? ? ? ? 18  DA  D P     1 
+ATOM   1127 P P     B DA  B 2 18  ? 60.126  46.793 96.455  0.27 79.31  ? ? ? ? ? ? 18  DA  D P     1 
+ATOM   1128 O OP1   A DA  B 2 18  ? 58.423  41.350 99.012  0.73 100.00 ? ? ? ? ? ? 18  DA  D OP1   1 
+ATOM   1129 O OP1   B DA  B 2 18  ? 59.428  46.197 97.616  0.27 78.36  ? ? ? ? ? ? 18  DA  D OP1   1 
+ATOM   1130 O OP2   A DA  B 2 18  ? 59.441  42.300 96.854  0.73 98.90  ? ? ? ? ? ? 18  DA  D OP2   1 
+ATOM   1131 O OP2   B DA  B 2 18  ? 60.761  45.913 95.448  0.27 82.38  ? ? ? ? ? ? 18  DA  D OP2   1 
+ATOM   1132 O "O5'" A DA  B 2 18  ? 57.750  43.604 98.176  0.73 97.51  ? ? ? ? ? ? 18  DA  D "O5'" 1 
+ATOM   1133 O "O5'" B DA  B 2 18  ? 59.087  47.767 95.721  0.27 81.25  ? ? ? ? ? ? 18  DA  D "O5'" 1 
+ATOM   1134 C "C5'" A DA  B 2 18  ? 57.546  44.125 96.875  0.73 90.84  ? ? ? ? ? ? 18  DA  D "C5'" 1 
+ATOM   1135 C "C5'" B DA  B 2 18  ? 58.009  48.416 96.402  0.27 79.23  ? ? ? ? ? ? 18  DA  D "C5'" 1 
+ATOM   1136 C "C4'" A DA  B 2 18  ? 56.645  45.338 96.761  0.73 82.18  ? ? ? ? ? ? 18  DA  D "C4'" 1 
+ATOM   1137 C "C4'" B DA  B 2 18  ? 57.016  49.014 95.418  0.27 76.48  ? ? ? ? ? ? 18  DA  D "C4'" 1 
+ATOM   1138 O "O4'" A DA  B 2 18  ? 57.478  46.481 96.451  0.73 80.24  ? ? ? ? ? ? 18  DA  D "O4'" 1 
+ATOM   1139 O "O4'" B DA  B 2 18  ? 57.701  50.031 94.636  0.27 72.33  ? ? ? ? ? ? 18  DA  D "O4'" 1 
+ATOM   1140 C "C3'" A DA  B 2 18  ? 55.844  45.186 95.481  0.73 83.84  ? ? ? ? ? ? 18  DA  D "C3'" 1 
+ATOM   1141 C "C3'" B DA  B 2 18  ? 56.441  47.984 94.451  0.27 81.24  ? ? ? ? ? ? 18  DA  D "C3'" 1 
+ATOM   1142 O "O3'" A DA  B 2 18  ? 54.808  46.144 95.338  0.73 96.43  ? ? ? ? ? ? 18  DA  D "O3'" 1 
+ATOM   1143 O "O3'" B DA  B 2 18  ? 55.007  47.938 94.427  0.27 96.48  ? ? ? ? ? ? 18  DA  D "O3'" 1 
+ATOM   1144 C "C2'" A DA  B 2 18  ? 56.951  45.357 94.444  0.73 76.72  ? ? ? ? ? ? 18  DA  D "C2'" 1 
+ATOM   1145 C "C2'" B DA  B 2 18  ? 57.036  48.362 93.100  0.27 63.25  ? ? ? ? ? ? 18  DA  D "C2'" 1 
+ATOM   1146 C "C1'" A DA  B 2 18  ? 57.846  46.417 95.084  0.73 77.32  ? ? ? ? ? ? 18  DA  D "C1'" 1 
+ATOM   1147 C "C1'" B DA  B 2 18  ? 57.757  49.691 93.266  0.27 60.46  ? ? ? ? ? ? 18  DA  D "C1'" 1 
+ATOM   1148 N N9    A DA  B 2 18  ? 59.285  46.164 94.989  0.73 73.42  ? ? ? ? ? ? 18  DA  D N9    1 
+ATOM   1149 N N9    B DA  B 2 18  ? 59.140  49.563 92.815  0.27 54.08  ? ? ? ? ? ? 18  DA  D N9    1 
+ATOM   1150 C C8    A DA  B 2 18  ? 60.022  45.175 95.582  0.73 73.18  ? ? ? ? ? ? 18  DA  D C8    1 
+ATOM   1151 C C8    B DA  B 2 18  ? 60.097  48.721 93.312  0.27 54.44  ? ? ? ? ? ? 18  DA  D C8    1 
+ATOM   1152 N N7    A DA  B 2 18  ? 61.304  45.216 95.316  0.73 74.42  ? ? ? ? ? ? 18  DA  D N7    1 
+ATOM   1153 N N7    B DA  B 2 18  ? 61.254  48.773 92.692  0.27 52.56  ? ? ? ? ? ? 18  DA  D N7    1 
+ATOM   1154 C C5    A DA  B 2 18  ? 61.428  46.321 94.492  0.73 74.63  ? ? ? ? ? ? 18  DA  D C5    1 
+ATOM   1155 C C5    B DA  B 2 18  ? 61.050  49.755 91.725  0.27 48.99  ? ? ? ? ? ? 18  DA  D C5    1 
+ATOM   1156 C C6    A DA  B 2 18  ? 62.544  46.905 93.863  0.73 72.31  ? ? ? ? ? ? 18  DA  D C6    1 
+ATOM   1157 C C6    B DA  B 2 18  ? 61.848  50.236 90.689  0.27 39.10  ? ? ? ? ? ? 18  DA  D C6    1 
+ATOM   1158 N N6    A DA  B 2 18  ? 63.788  46.429 93.992  0.73 70.51  ? ? ? ? ? ? 18  DA  D N6    1 
+ATOM   1159 N N6    B DA  B 2 18  ? 63.134  49.884 90.559  0.27 32.64  ? ? ? ? ? ? 18  DA  D N6    1 
+ATOM   1160 N N1    A DA  B 2 18  ? 62.327  47.999 93.104  0.73 71.95  ? ? ? ? ? ? 18  DA  D N1    1 
+ATOM   1161 N N1    B DA  B 2 18  ? 61.341  51.156 89.864  0.27 40.98  ? ? ? ? ? ? 18  DA  D N1    1 
+ATOM   1162 C C2    A DA  B 2 18  ? 61.078  48.464 92.993  0.73 72.13  ? ? ? ? ? ? 18  DA  D C2    1 
+ATOM   1163 C C2    B DA  B 2 18  ? 60.067  51.546 90.020  0.27 44.70  ? ? ? ? ? ? 18  DA  D C2    1 
+ATOM   1164 N N3    A DA  B 2 18  ? 59.953  48.001 93.536  0.73 71.91  ? ? ? ? ? ? 18  DA  D N3    1 
+ATOM   1165 N N3    B DA  B 2 18  ? 59.191  51.120 90.936  0.27 46.20  ? ? ? ? ? ? 18  DA  D N3    1 
+ATOM   1166 C C4    A DA  B 2 18  ? 60.197  46.915 94.283  0.73 72.55  ? ? ? ? ? ? 18  DA  D C4    1 
+ATOM   1167 C C4    B DA  B 2 18  ? 59.729  50.207 91.751  0.27 48.19  ? ? ? ? ? ? 18  DA  D C4    1 
+ATOM   1168 P P     A DC  B 2 19  ? 53.799  45.912 94.116  0.73 100.00 ? ? ? ? ? ? 19  DC  D P     1 
+ATOM   1169 P P     B DC  B 2 19  ? 54.151  46.586 94.269  0.27 99.36  ? ? ? ? ? ? 19  DC  D P     1 
+ATOM   1170 O OP1   A DC  B 2 19  ? 52.424  46.168 94.601  0.73 100.00 ? ? ? ? ? ? 19  DC  D OP1   1 
+ATOM   1171 O OP1   B DC  B 2 19  ? 52.775  46.868 94.739  0.27 100.00 ? ? ? ? ? ? 19  DC  D OP1   1 
+ATOM   1172 O OP2   A DC  B 2 19  ? 54.121  44.600 93.512  0.73 100.00 ? ? ? ? ? ? 19  DC  D OP2   1 
+ATOM   1173 O OP2   B DC  B 2 19  ? 54.903  45.464 94.876  0.27 94.77  ? ? ? ? ? ? 19  DC  D OP2   1 
+ATOM   1174 O "O5'" A DC  B 2 19  ? 54.207  47.069 93.083  0.73 95.76  ? ? ? ? ? ? 19  DC  D "O5'" 1 
+ATOM   1175 O "O5'" B DC  B 2 19  ? 54.063  46.332 92.690  0.27 94.84  ? ? ? ? ? ? 19  DC  D "O5'" 1 
+ATOM   1176 C "C5'" A DC  B 2 19  ? 55.238  46.851 92.124  0.73 93.90  ? ? ? ? ? ? 19  DC  D "C5'" 1 
+ATOM   1177 C "C5'" B DC  B 2 19  ? 55.198  46.395 91.839  0.27 87.42  ? ? ? ? ? ? 19  DC  D "C5'" 1 
+ATOM   1178 C "C4'" A DC  B 2 19  ? 55.037  47.755 90.922  0.73 93.60  ? ? ? ? ? ? 19  DC  D "C4'" 1 
+ATOM   1179 C "C4'" B DC  B 2 19  ? 54.978  47.515 90.841  0.27 80.90  ? ? ? ? ? ? 19  DC  D "C4'" 1 
+ATOM   1180 O "O4'" A DC  B 2 19  ? 56.295  48.334 90.495  0.73 99.35  ? ? ? ? ? ? 19  DC  D "O4'" 1 
+ATOM   1181 O "O4'" B DC  B 2 19  ? 56.188  48.215 90.455  0.27 82.45  ? ? ? ? ? ? 19  DC  D "O4'" 1 
+ATOM   1182 C "C3'" A DC  B 2 19  ? 54.443  47.094 89.690  0.73 78.37  ? ? ? ? ? ? 19  DC  D "C3'" 1 
+ATOM   1183 C "C3'" B DC  B 2 19  ? 54.393  47.032 89.531  0.27 70.48  ? ? ? ? ? ? 19  DC  D "C3'" 1 
+ATOM   1184 O "O3'" A DC  B 2 19  ? 53.584  48.046 89.074  0.73 58.58  ? ? ? ? ? ? 19  DC  D "O3'" 1 
+ATOM   1185 O "O3'" B DC  B 2 19  ? 53.608  48.085 89.003  0.27 57.09  ? ? ? ? ? ? 19  DC  D "O3'" 1 
+ATOM   1186 C "C2'" A DC  B 2 19  ? 55.677  46.760 88.853  0.73 79.35  ? ? ? ? ? ? 19  DC  D "C2'" 1 
+ATOM   1187 C "C2'" B DC  B 2 19  ? 55.649  46.725 88.717  0.27 71.84  ? ? ? ? ? ? 19  DC  D "C2'" 1 
+ATOM   1188 C "C1'" A DC  B 2 19  ? 56.647  47.886 89.201  0.73 78.70  ? ? ? ? ? ? 19  DC  D "C1'" 1 
+ATOM   1189 C "C1'" B DC  B 2 19  ? 56.604  47.828 89.162  0.27 71.66  ? ? ? ? ? ? 19  DC  D "C1'" 1 
+ATOM   1190 N N1    A DC  B 2 19  ? 58.087  47.505 89.279  0.73 77.27  ? ? ? ? ? ? 19  DC  D N1    1 
+ATOM   1191 N N1    B DC  B 2 19  ? 58.050  47.465 89.269  0.27 71.20  ? ? ? ? ? ? 19  DC  D N1    1 
+ATOM   1192 C C2    A DC  B 2 19  ? 58.977  48.083 88.369  0.73 77.13  ? ? ? ? ? ? 19  DC  D C2    1 
+ATOM   1193 C C2    B DC  B 2 19  ? 58.935  48.144 88.425  0.27 70.52  ? ? ? ? ? ? 19  DC  D C2    1 
+ATOM   1194 O O2    A DC  B 2 19  ? 58.535  48.858 87.512  0.73 74.67  ? ? ? ? ? ? 19  DC  D O2    1 
+ATOM   1195 O O2    B DC  B 2 19  ? 58.480  48.970 87.624  0.27 68.76  ? ? ? ? ? ? 19  DC  D O2    1 
+ATOM   1196 N N3    A DC  B 2 19  ? 60.293  47.761 88.450  0.73 78.68  ? ? ? ? ? ? 19  DC  D N3    1 
+ATOM   1197 N N3    B DC  B 2 19  ? 60.262  47.871 88.495  0.27 71.57  ? ? ? ? ? ? 19  DC  D N3    1 
+ATOM   1198 C C4    A DC  B 2 19  ? 60.720  46.920 89.393  0.73 78.59  ? ? ? ? ? ? 19  DC  D C4    1 
+ATOM   1199 C C4    B DC  B 2 19  ? 60.716  46.973 89.371  0.27 71.15  ? ? ? ? ? ? 19  DC  D C4    1 
+ATOM   1200 N N4    A DC  B 2 19  ? 62.026  46.638 89.433  0.73 81.77  ? ? ? ? ? ? 19  DC  D N4    1 
+ATOM   1201 N N4    B DC  B 2 19  ? 62.032  46.737 89.403  0.27 71.68  ? ? ? ? ? ? 19  DC  D N4    1 
+ATOM   1202 C C5    A DC  B 2 19  ? 59.827  46.332 90.338  0.73 73.64  ? ? ? ? ? ? 19  DC  D C5    1 
+ATOM   1203 C C5    B DC  B 2 19  ? 59.834  46.278 90.250  0.27 68.62  ? ? ? ? ? ? 19  DC  D C5    1 
+ATOM   1204 C C6    A DC  B 2 19  ? 58.534  46.657 90.249  0.73 73.81  ? ? ? ? ? ? 19  DC  D C6    1 
+ATOM   1205 C C6    B DC  B 2 19  ? 58.528  46.559 90.172  0.27 69.31  ? ? ? ? ? ? 19  DC  D C6    1 
+ATOM   1206 P P     . DA  B 2 20  ? 52.859  47.753 87.681  1.00 57.03  ? ? ? ? ? ? 20  DA  D P     1 
+ATOM   1207 O OP1   . DA  B 2 20  ? 51.973  48.897 87.378  1.00 64.18  ? ? ? ? ? ? 20  DA  D OP1   1 
+ATOM   1208 O OP2   . DA  B 2 20  ? 52.325  46.374 87.734  1.00 60.56  ? ? ? ? ? ? 20  DA  D OP2   1 
+ATOM   1209 O "O5'" . DA  B 2 20  ? 54.083  47.789 86.655  1.00 77.11  ? ? ? ? ? ? 20  DA  D "O5'" 1 
+ATOM   1210 C "C5'" . DA  B 2 20  ? 54.227  48.772 85.646  1.00 68.39  ? ? ? ? ? ? 20  DA  D "C5'" 1 
+ATOM   1211 C "C4'" . DA  B 2 20  ? 55.277  48.261 84.681  1.00 42.40  ? ? ? ? ? ? 20  DA  D "C4'" 1 
+ATOM   1212 O "O4'" . DA  B 2 20  ? 56.343  47.649 85.450  1.00 50.30  ? ? ? ? ? ? 20  DA  D "O4'" 1 
+ATOM   1213 C "C3'" . DA  B 2 20  ? 54.748  47.155 83.780  1.00 33.58  ? ? ? ? ? ? 20  DA  D "C3'" 1 
+ATOM   1214 O "O3'" . DA  B 2 20  ? 54.950  47.483 82.428  1.00 37.70  ? ? ? ? ? ? 20  DA  D "O3'" 1 
+ATOM   1215 C "C2'" . DA  B 2 20  ? 55.519  45.901 84.165  1.00 26.84  ? ? ? ? ? ? 20  DA  D "C2'" 1 
+ATOM   1216 C "C1'" . DA  B 2 20  ? 56.783  46.499 84.760  1.00 40.17  ? ? ? ? ? ? 20  DA  D "C1'" 1 
+ATOM   1217 N N9    . DA  B 2 20  ? 57.462  45.592 85.684  1.00 40.95  ? ? ? ? ? ? 20  DA  D N9    1 
+ATOM   1218 C C8    . DA  B 2 20  ? 56.923  44.668 86.532  1.00 42.73  ? ? ? ? ? ? 20  DA  D C8    1 
+ATOM   1219 N N7    . DA  B 2 20  ? 57.813  44.001 87.227  1.00 40.61  ? ? ? ? ? ? 20  DA  D N7    1 
+ATOM   1220 C C5    . DA  B 2 20  ? 59.024  44.515 86.797  1.00 42.86  ? ? ? ? ? ? 20  DA  D C5    1 
+ATOM   1221 C C6    . DA  B 2 20  ? 60.358  44.227 87.146  1.00 43.77  ? ? ? ? ? ? 20  DA  D C6    1 
+ATOM   1222 N N6    . DA  B 2 20  ? 60.694  43.310 88.059  1.00 46.90  ? ? ? ? ? ? 20  DA  D N6    1 
+ATOM   1223 N N1    . DA  B 2 20  ? 61.334  44.926 86.529  1.00 40.24  ? ? ? ? ? ? 20  DA  D N1    1 
+ATOM   1224 C C2    . DA  B 2 20  ? 60.990  45.854 85.627  1.00 42.13  ? ? ? ? ? ? 20  DA  D C2    1 
+ATOM   1225 N N3    . DA  B 2 20  ? 59.775  46.209 85.211  1.00 42.99  ? ? ? ? ? ? 20  DA  D N3    1 
+ATOM   1226 C C4    . DA  B 2 20  ? 58.826  45.496 85.845  1.00 42.43  ? ? ? ? ? ? 20  DA  D C4    1 
+ATOM   1227 P P     . DT  B 2 21  ? 54.076  46.593 81.441  1.00 54.72  ? ? ? ? ? ? 21  DT  D P     1 
+ATOM   1228 O OP1   . DT  B 2 21  ? 53.552  47.491 80.390  1.00 58.54  ? ? ? ? ? ? 21  DT  D OP1   1 
+ATOM   1229 O OP2   . DT  B 2 21  ? 53.184  45.748 82.262  1.00 85.71  ? ? ? ? ? ? 21  DT  D OP2   1 
+ATOM   1230 O "O5'" . DT  B 2 21  ? 55.149  45.629 80.770  1.00 69.67  ? ? ? ? ? ? 21  DT  D "O5'" 1 
+ATOM   1231 C "C5'" . DT  B 2 21  ? 56.143  46.379 80.120  1.00 83.05  ? ? ? ? ? ? 21  DT  D "C5'" 1 
+ATOM   1232 C "C4'" . DT  B 2 21  ? 57.497  45.798 80.437  1.00 65.88  ? ? ? ? ? ? 21  DT  D "C4'" 1 
+ATOM   1233 O "O4'" . DT  B 2 21  ? 57.508  45.063 81.676  1.00 60.56  ? ? ? ? ? ? 21  DT  D "O4'" 1 
+ATOM   1234 C "C3'" . DT  B 2 21  ? 57.954  44.786 79.407  1.00 50.22  ? ? ? ? ? ? 21  DT  D "C3'" 1 
+ATOM   1235 O "O3'" . DT  B 2 21  ? 58.672  45.578 78.486  1.00 44.55  ? ? ? ? ? ? 21  DT  D "O3'" 1 
+ATOM   1236 C "C2'" . DT  B 2 21  ? 58.854  43.864 80.232  1.00 54.50  ? ? ? ? ? ? 21  DT  D "C2'" 1 
+ATOM   1237 C "C1'" . DT  B 2 21  ? 58.792  44.495 81.622  1.00 49.09  ? ? ? ? ? ? 21  DT  D "C1'" 1 
+ATOM   1238 N N1    . DT  B 2 21  ? 58.953  43.560 82.752  1.00 48.50  ? ? ? ? ? ? 21  DT  D N1    1 
+ATOM   1239 C C2    . DT  B 2 21  ? 60.231  43.489 83.246  1.00 47.24  ? ? ? ? ? ? 21  DT  D C2    1 
+ATOM   1240 O O2    . DT  B 2 21  ? 61.132  44.160 82.780  1.00 46.09  ? ? ? ? ? ? 21  DT  D O2    1 
+ATOM   1241 N N3    . DT  B 2 21  ? 60.403  42.621 84.294  1.00 46.09  ? ? ? ? ? ? 21  DT  D N3    1 
+ATOM   1242 C C4    . DT  B 2 21  ? 59.428  41.836 84.864  1.00 50.33  ? ? ? ? ? ? 21  DT  D C4    1 
+ATOM   1243 O O4    . DT  B 2 21  ? 59.801  41.105 85.761  1.00 49.47  ? ? ? ? ? ? 21  DT  D O4    1 
+ATOM   1244 C C5    . DT  B 2 21  ? 58.107  41.951 84.297  1.00 52.91  ? ? ? ? ? ? 21  DT  D C5    1 
+ATOM   1245 C C7    . DT  B 2 21  ? 56.951  41.141 84.817  1.00 53.21  ? ? ? ? ? ? 21  DT  D C7    1 
+ATOM   1246 C C6    . DT  B 2 21  ? 57.927  42.814 83.290  1.00 48.39  ? ? ? ? ? ? 21  DT  D C6    1 
+ATOM   1247 P P     . DT  B 2 22  ? 58.861  45.219 76.946  1.00 43.21  ? ? ? ? ? ? 22  DT  D P     1 
+ATOM   1248 O OP1   . DT  B 2 22  ? 58.694  46.478 76.193  1.00 43.61  ? ? ? ? ? ? 22  DT  D OP1   1 
+ATOM   1249 O OP2   . DT  B 2 22  ? 58.034  44.043 76.604  1.00 40.59  ? ? ? ? ? ? 22  DT  D OP2   1 
+ATOM   1250 O "O5'" . DT  B 2 22  ? 60.409  44.808 76.889  1.00 62.06  ? ? ? ? ? ? 22  DT  D "O5'" 1 
+ATOM   1251 C "C5'" . DT  B 2 22  ? 61.316  45.304 77.872  1.00 53.31  ? ? ? ? ? ? 22  DT  D "C5'" 1 
+ATOM   1252 C "C4'" . DT  B 2 22  ? 62.586  44.478 77.917  1.00 41.83  ? ? ? ? ? ? 22  DT  D "C4'" 1 
+ATOM   1253 O "O4'" . DT  B 2 22  ? 62.650  43.733 79.158  1.00 36.62  ? ? ? ? ? ? 22  DT  D "O4'" 1 
+ATOM   1254 C "C3'" . DT  B 2 22  ? 62.743  43.465 76.793  1.00 44.13  ? ? ? ? ? ? 22  DT  D "C3'" 1 
+ATOM   1255 O "O3'" . DT  B 2 22  ? 64.120  43.402 76.469  1.00 45.84  ? ? ? ? ? ? 22  DT  D "O3'" 1 
+ATOM   1256 C "C2'" . DT  B 2 22  ? 62.270  42.171 77.440  1.00 36.28  ? ? ? ? ? ? 22  DT  D "C2'" 1 
+ATOM   1257 C "C1'" . DT  B 2 22  ? 62.820  42.369 78.845  1.00 36.03  ? ? ? ? ? ? 22  DT  D "C1'" 1 
+ATOM   1258 N N1    . DT  B 2 22  ? 62.084  41.602 79.845  1.00 37.39  ? ? ? ? ? ? 22  DT  D N1    1 
+ATOM   1259 C C2    . DT  B 2 22  ? 62.882  41.143 80.851  1.00 36.50  ? ? ? ? ? ? 22  DT  D C2    1 
+ATOM   1260 O O2    . DT  B 2 22  ? 64.066  41.399 80.886  1.00 36.35  ? ? ? ? ? ? 22  DT  D O2    1 
+ATOM   1261 N N3    . DT  B 2 22  ? 62.237  40.404 81.805  1.00 33.16  ? ? ? ? ? ? 22  DT  D N3    1 
+ATOM   1262 C C4    . DT  B 2 22  ? 60.886  40.111 81.840  1.00 34.43  ? ? ? ? ? ? 22  DT  D C4    1 
+ATOM   1263 O O4    . DT  B 2 22  ? 60.447  39.434 82.758  1.00 34.29  ? ? ? ? ? ? 22  DT  D O4    1 
+ATOM   1264 C C5    . DT  B 2 22  ? 60.104  40.615 80.741  1.00 38.11  ? ? ? ? ? ? 22  DT  D C5    1 
+ATOM   1265 C C7    . DT  B 2 22  ? 58.639  40.318 80.687  1.00 36.07  ? ? ? ? ? ? 22  DT  D C7    1 
+ATOM   1266 C C6    . DT  B 2 22  ? 60.734  41.322 79.798  1.00 41.34  ? ? ? ? ? ? 22  DT  D C6    1 
+ATOM   1267 P P     . DA  B 2 23  ? 64.603  42.748 75.092  1.00 43.91  ? ? ? ? ? ? 23  DA  D P     1 
+ATOM   1268 O OP1   . DA  B 2 23  ? 65.391  43.783 74.387  1.00 57.88  ? ? ? ? ? ? 23  DA  D OP1   1 
+ATOM   1269 O OP2   . DA  B 2 23  ? 63.446  42.115 74.421  1.00 49.25  ? ? ? ? ? ? 23  DA  D OP2   1 
+ATOM   1270 O "O5'" . DA  B 2 23  ? 65.566  41.577 75.600  1.00 44.30  ? ? ? ? ? ? 23  DA  D "O5'" 1 
+ATOM   1271 C "C5'" . DA  B 2 23  ? 66.715  41.927 76.338  1.00 42.73  ? ? ? ? ? ? 23  DA  D "C5'" 1 
+ATOM   1272 C "C4'" . DA  B 2 23  ? 67.048  40.834 77.335  1.00 47.91  ? ? ? ? ? ? 23  DA  D "C4'" 1 
+ATOM   1273 O "O4'" . DA  B 2 23  ? 65.917  40.588 78.196  1.00 50.55  ? ? ? ? ? ? 23  DA  D "O4'" 1 
+ATOM   1274 C "C3'" . DA  B 2 23  ? 67.373  39.461 76.769  1.00 51.26  ? ? ? ? ? ? 23  DA  D "C3'" 1 
+ATOM   1275 O "O3'" . DA  B 2 23  ? 68.761  39.408 76.521  1.00 47.29  ? ? ? ? ? ? 23  DA  D "O3'" 1 
+ATOM   1276 C "C2'" . DA  B 2 23  ? 67.057  38.531 77.938  1.00 69.83  ? ? ? ? ? ? 23  DA  D "C2'" 1 
+ATOM   1277 C "C1'" . DA  B 2 23  ? 66.177  39.370 78.861  1.00 58.51  ? ? ? ? ? ? 23  DA  D "C1'" 1 
+ATOM   1278 N N9    . DA  B 2 23  ? 64.892  38.737 79.129  1.00 39.80  ? ? ? ? ? ? 23  DA  D N9    1 
+ATOM   1279 C C8    . DA  B 2 23  ? 63.699  38.884 78.477  1.00 36.51  ? ? ? ? ? ? 23  DA  D C8    1 
+ATOM   1280 N N7    . DA  B 2 23  ? 62.748  38.128 78.972  1.00 40.29  ? ? ? ? ? ? 23  DA  D N7    1 
+ATOM   1281 C C5    . DA  B 2 23  ? 63.364  37.446 80.007  1.00 32.34  ? ? ? ? ? ? 23  DA  D C5    1 
+ATOM   1282 C C6    . DA  B 2 23  ? 62.885  36.507 80.932  1.00 33.52  ? ? ? ? ? ? 23  DA  D C6    1 
+ATOM   1283 N N6    . DA  B 2 23  ? 61.621  36.072 80.959  1.00 36.86  ? ? ? ? ? ? 23  DA  D N6    1 
+ATOM   1284 N N1    . DA  B 2 23  ? 63.778  36.023 81.821  1.00 34.90  ? ? ? ? ? ? 23  DA  D N1    1 
+ATOM   1285 C C2    . DA  B 2 23  ? 65.051  36.450 81.788  1.00 33.73  ? ? ? ? ? ? 23  DA  D C2    1 
+ATOM   1286 N N3    . DA  B 2 23  ? 65.613  37.341 80.978  1.00 31.96  ? ? ? ? ? ? 23  DA  D N3    1 
+ATOM   1287 C C4    . DA  B 2 23  ? 64.695  37.805 80.115  1.00 32.26  ? ? ? ? ? ? 23  DA  D C4    1 
+ATOM   1288 P P     . DT  B 2 24  ? 69.507  38.147 75.885  1.00 40.23  ? ? ? ? ? ? 24  DT  D P     1 
+ATOM   1289 O OP1   . DT  B 2 24  ? 70.775  38.718 75.385  1.00 48.96  ? ? ? ? ? ? 24  DT  D OP1   1 
+ATOM   1290 O OP2   . DT  B 2 24  ? 68.598  37.421 74.971  1.00 38.02  ? ? ? ? ? ? 24  DT  D OP2   1 
+ATOM   1291 O "O5'" . DT  B 2 24  ? 69.825  37.182 77.120  1.00 42.25  ? ? ? ? ? ? 24  DT  D "O5'" 1 
+ATOM   1292 C "C5'" . DT  B 2 24  ? 70.743  37.545 78.136  1.00 28.40  ? ? ? ? ? ? 24  DT  D "C5'" 1 
+ATOM   1293 C "C4'" . DT  B 2 24  ? 70.667  36.479 79.210  1.00 32.33  ? ? ? ? ? ? 24  DT  D "C4'" 1 
+ATOM   1294 O "O4'" . DT  B 2 24  ? 69.277  36.303 79.592  1.00 39.10  ? ? ? ? ? ? 24  DT  D "O4'" 1 
+ATOM   1295 C "C3'" . DT  B 2 24  ? 71.137  35.090 78.793  1.00 34.87  ? ? ? ? ? ? 24  DT  D "C3'" 1 
+ATOM   1296 O "O3'" . DT  B 2 24  ? 71.762  34.508 79.926  1.00 29.80  ? ? ? ? ? ? 24  DT  D "O3'" 1 
+ATOM   1297 C "C2'" . DT  B 2 24  ? 69.830  34.366 78.486  1.00 32.10  ? ? ? ? ? ? 24  DT  D "C2'" 1 
+ATOM   1298 C "C1'" . DT  B 2 24  ? 68.948  34.930 79.591  1.00 31.71  ? ? ? ? ? ? 24  DT  D "C1'" 1 
+ATOM   1299 N N1    . DT  B 2 24  ? 67.490  34.770 79.300  1.00 31.48  ? ? ? ? ? ? 24  DT  D N1    1 
+ATOM   1300 C C2    . DT  B 2 24  ? 66.767  33.896 80.082  1.00 32.50  ? ? ? ? ? ? 24  DT  D C2    1 
+ATOM   1301 O O2    . DT  B 2 24  ? 67.259  33.306 81.026  1.00 33.95  ? ? ? ? ? ? 24  DT  D O2    1 
+ATOM   1302 N N3    . DT  B 2 24  ? 65.452  33.745 79.731  1.00 33.06  ? ? ? ? ? ? 24  DT  D N3    1 
+ATOM   1303 C C4    . DT  B 2 24  ? 64.808  34.383 78.686  1.00 35.36  ? ? ? ? ? ? 24  DT  D C4    1 
+ATOM   1304 O O4    . DT  B 2 24  ? 63.612  34.137 78.530  1.00 34.16  ? ? ? ? ? ? 24  DT  D O4    1 
+ATOM   1305 C C5    . DT  B 2 24  ? 65.641  35.255 77.872  1.00 29.97  ? ? ? ? ? ? 24  DT  D C5    1 
+ATOM   1306 C C7    . DT  B 2 24  ? 65.186  36.030 76.665  1.00 24.29  ? ? ? ? ? ? 24  DT  D C7    1 
+ATOM   1307 C C6    . DT  B 2 24  ? 66.923  35.411 78.217  1.00 28.90  ? ? ? ? ? ? 24  DT  D C6    1 
+ATOM   1308 P P     . DA  B 2 25  ? 72.518  33.099 79.998  1.00 34.37  ? ? ? ? ? ? 25  DA  D P     1 
+ATOM   1309 O OP1   . DA  B 2 25  ? 73.553  33.268 81.040  1.00 40.50  ? ? ? ? ? ? 25  DA  D OP1   1 
+ATOM   1310 O OP2   . DA  B 2 25  ? 72.891  32.613 78.654  1.00 40.45  ? ? ? ? ? ? 25  DA  D OP2   1 
+ATOM   1311 O "O5'" . DA  B 2 25  ? 71.390  32.108 80.539  1.00 36.01  ? ? ? ? ? ? 25  DA  D "O5'" 1 
+ATOM   1312 C "C5'" . DA  B 2 25  ? 71.076  32.116 81.918  1.00 33.43  ? ? ? ? ? ? 25  DA  D "C5'" 1 
+ATOM   1313 C "C4'" . DA  B 2 25  ? 70.821  30.696 82.377  1.00 36.12  ? ? ? ? ? ? 25  DA  D "C4'" 1 
+ATOM   1314 O "O4'" . DA  B 2 25  ? 69.453  30.337 82.061  1.00 41.08  ? ? ? ? ? ? 25  DA  D "O4'" 1 
+ATOM   1315 C "C3'" . DA  B 2 25  ? 71.665  29.639 81.682  1.00 33.90  ? ? ? ? ? ? 25  DA  D "C3'" 1 
+ATOM   1316 O "O3'" . DA  B 2 25  ? 71.876  28.538 82.549  1.00 35.36  ? ? ? ? ? ? 25  DA  D "O3'" 1 
+ATOM   1317 C "C2'" . DA  B 2 25  ? 70.789  29.239 80.499  1.00 38.73  ? ? ? ? ? ? 25  DA  D "C2'" 1 
+ATOM   1318 C "C1'" . DA  B 2 25  ? 69.392  29.295 81.106  1.00 35.35  ? ? ? ? ? ? 25  DA  D "C1'" 1 
+ATOM   1319 N N9    . DA  B 2 25  ? 68.370  29.751 80.172  1.00 27.36  ? ? ? ? ? ? 25  DA  D N9    1 
+ATOM   1320 C C8    . DA  B 2 25  ? 68.507  30.753 79.253  1.00 26.18  ? ? ? ? ? ? 25  DA  D C8    1 
+ATOM   1321 N N7    . DA  B 2 25  ? 67.428  30.988 78.547  1.00 26.25  ? ? ? ? ? ? 25  DA  D N7    1 
+ATOM   1322 C C5    . DA  B 2 25  ? 66.505  30.092 79.065  1.00 29.09  ? ? ? ? ? ? 25  DA  D C5    1 
+ATOM   1323 C C6    . DA  B 2 25  ? 65.149  29.857 78.757  1.00 31.85  ? ? ? ? ? ? 25  DA  D C6    1 
+ATOM   1324 N N6    . DA  B 2 25  ? 64.514  30.554 77.805  1.00 33.97  ? ? ? ? ? ? 25  DA  D N6    1 
+ATOM   1325 N N1    . DA  B 2 25  ? 64.494  28.888 79.437  1.00 28.70  ? ? ? ? ? ? 25  DA  D N1    1 
+ATOM   1326 C C2    . DA  B 2 25  ? 65.156  28.215 80.384  1.00 29.12  ? ? ? ? ? ? 25  DA  D C2    1 
+ATOM   1327 N N3    . DA  B 2 25  ? 66.427  28.360 80.771  1.00 29.93  ? ? ? ? ? ? 25  DA  D N3    1 
+ATOM   1328 C C4    . DA  B 2 25  ? 67.062  29.322 80.069  1.00 29.83  ? ? ? ? ? ? 25  DA  D C4    1 
+ATOM   1329 P P     . DC  B 2 26  ? 72.785  27.359 81.973  1.00 35.58  ? ? ? ? ? ? 26  DC  D P     1 
+ATOM   1330 O OP1   . DC  B 2 26  ? 73.425  26.661 83.110  1.00 32.78  ? ? ? ? ? ? 26  DC  D OP1   1 
+ATOM   1331 O OP2   . DC  B 2 26  ? 73.581  27.925 80.858  1.00 50.69  ? ? ? ? ? ? 26  DC  D OP2   1 
+ATOM   1332 O "O5'" . DC  B 2 26  ? 71.744  26.325 81.351  1.00 33.79  ? ? ? ? ? ? 26  DC  D "O5'" 1 
+ATOM   1333 C "C5'" . DC  B 2 26  ? 71.036  25.549 82.289  1.00 36.37  ? ? ? ? ? ? 26  DC  D "C5'" 1 
+ATOM   1334 C "C4'" . DC  B 2 26  ? 70.082  24.669 81.518  1.00 48.58  ? ? ? ? ? ? 26  DC  D "C4'" 1 
+ATOM   1335 O "O4'" . DC  B 2 26  ? 69.158  25.503 80.772  1.00 48.05  ? ? ? ? ? ? 26  DC  D "O4'" 1 
+ATOM   1336 C "C3'" . DC  B 2 26  ? 70.794  23.794 80.495  1.00 51.38  ? ? ? ? ? ? 26  DC  D "C3'" 1 
+ATOM   1337 O "O3'" . DC  B 2 26  ? 70.285  22.470 80.601  1.00 50.15  ? ? ? ? ? ? 26  DC  D "O3'" 1 
+ATOM   1338 C "C2'" . DC  B 2 26  ? 70.452  24.473 79.169  1.00 47.71  ? ? ? ? ? ? 26  DC  D "C2'" 1 
+ATOM   1339 C "C1'" . DC  B 2 26  ? 69.036  24.950 79.481  1.00 38.83  ? ? ? ? ? ? 26  DC  D "C1'" 1 
+ATOM   1340 N N1    . DC  B 2 26  ? 68.438  25.963 78.557  1.00 31.29  ? ? ? ? ? ? 26  DC  D N1    1 
+ATOM   1341 C C2    . DC  B 2 26  ? 67.058  25.895 78.329  1.00 32.20  ? ? ? ? ? ? 26  DC  D C2    1 
+ATOM   1342 O O2    . DC  B 2 26  ? 66.385  25.013 78.881  1.00 38.40  ? ? ? ? ? ? 26  DC  D O2    1 
+ATOM   1343 N N3    . DC  B 2 26  ? 66.486  26.804 77.500  1.00 28.06  ? ? ? ? ? ? 26  DC  D N3    1 
+ATOM   1344 C C4    . DC  B 2 26  ? 67.218  27.758 76.929  1.00 18.49  ? ? ? ? ? ? 26  DC  D C4    1 
+ATOM   1345 N N4    . DC  B 2 26  ? 66.590  28.621 76.119  1.00 18.84  ? ? ? ? ? ? 26  DC  D N4    1 
+ATOM   1346 C C5    . DC  B 2 26  ? 68.620  27.850 77.153  1.00 16.22  ? ? ? ? ? ? 26  DC  D C5    1 
+ATOM   1347 C C6    . DC  B 2 26  ? 69.177  26.941 77.962  1.00 15.07  ? ? ? ? ? ? 26  DC  D C6    1 
+ATOM   1348 P P     . DG  B 2 27  ? 71.237  21.247 80.220  1.00 50.23  ? ? ? ? ? ? 27  DG  D P     1 
+ATOM   1349 O OP1   . DG  B 2 27  ? 72.094  20.922 81.381  1.00 56.98  ? ? ? ? ? ? 27  DG  D OP1   1 
+ATOM   1350 O OP2   . DG  B 2 27  ? 71.850  21.522 78.903  1.00 51.62  ? ? ? ? ? ? 27  DG  D OP2   1 
+ATOM   1351 O "O5'" . DG  B 2 27  ? 70.180  20.066 80.049  1.00 53.91  ? ? ? ? ? ? 27  DG  D "O5'" 1 
+ATOM   1352 C "C5'" . DG  B 2 27  ? 69.076  20.044 80.927  1.00 42.52  ? ? ? ? ? ? 27  DG  D "C5'" 1 
+ATOM   1353 C "C4'" . DG  B 2 27  ? 67.841  19.651 80.148  1.00 43.21  ? ? ? ? ? ? 27  DG  D "C4'" 1 
+ATOM   1354 O "O4'" . DG  B 2 27  ? 67.421  20.789 79.361  1.00 50.29  ? ? ? ? ? ? 27  DG  D "O4'" 1 
+ATOM   1355 C "C3'" . DG  B 2 27  ? 68.014  18.498 79.168  1.00 48.66  ? ? ? ? ? ? 27  DG  D "C3'" 1 
+ATOM   1356 O "O3'" . DG  B 2 27  ? 66.992  17.543 79.433  1.00 75.62  ? ? ? ? ? ? 27  DG  D "O3'" 1 
+ATOM   1357 C "C2'" . DG  B 2 27  ? 67.887  19.129 77.778  1.00 31.55  ? ? ? ? ? ? 27  DG  D "C2'" 1 
+ATOM   1358 C "C1'" . DG  B 2 27  ? 67.072  20.388 78.053  1.00 35.19  ? ? ? ? ? ? 27  DG  D "C1'" 1 
+ATOM   1359 N N9    . DG  B 2 27  ? 67.378  21.546 77.220  1.00 34.75  ? ? ? ? ? ? 27  DG  D N9    1 
+ATOM   1360 C C8    . DG  B 2 27  ? 68.590  22.173 77.064  1.00 31.83  ? ? ? ? ? ? 27  DG  D C8    1 
+ATOM   1361 N N7    . DG  B 2 27  ? 68.532  23.237 76.315  1.00 35.68  ? ? ? ? ? ? 27  DG  D N7    1 
+ATOM   1362 C C5    . DG  B 2 27  ? 67.190  23.340 75.978  1.00 30.14  ? ? ? ? ? ? 27  DG  D C5    1 
+ATOM   1363 C C6    . DG  B 2 27  ? 66.537  24.293 75.165  1.00 30.65  ? ? ? ? ? ? 27  DG  D C6    1 
+ATOM   1364 O O6    . DG  B 2 27  ? 67.033  25.270 74.586  1.00 33.84  ? ? ? ? ? ? 27  DG  D O6    1 
+ATOM   1365 N N1    . DG  B 2 27  ? 65.174  24.048 75.062  1.00 31.89  ? ? ? ? ? ? 27  DG  D N1    1 
+ATOM   1366 C C2    . DG  B 2 27  ? 64.526  22.996 75.662  1.00 39.46  ? ? ? ? ? ? 27  DG  D C2    1 
+ATOM   1367 N N2    . DG  B 2 27  ? 63.205  22.934 75.443  1.00 42.01  ? ? ? ? ? ? 27  DG  D N2    1 
+ATOM   1368 N N3    . DG  B 2 27  ? 65.125  22.091 76.431  1.00 40.54  ? ? ? ? ? ? 27  DG  D N3    1 
+ATOM   1369 C C4    . DG  B 2 27  ? 66.460  22.318 76.539  1.00 39.41  ? ? ? ? ? ? 27  DG  D C4    1 
+ATOM   1370 P P     . DA  B 2 28  ? 66.916  16.110 78.727  1.00 77.73  ? ? ? ? ? ? 28  DA  D P     1 
+ATOM   1371 O OP1   . DA  B 2 28  ? 66.123  15.232 79.614  1.00 88.88  ? ? ? ? ? ? 28  DA  D OP1   1 
+ATOM   1372 O OP2   . DA  B 2 28  ? 68.279  15.703 78.318  1.00 100.00 ? ? ? ? ? ? 28  DA  D OP2   1 
+ATOM   1373 O "O5'" . DA  B 2 28  ? 66.038  16.397 77.425  1.00 55.11  ? ? ? ? ? ? 28  DA  D "O5'" 1 
+ATOM   1374 C "C5'" . DA  B 2 28  ? 64.717  16.861 77.645  1.00 46.47  ? ? ? ? ? ? 28  DA  D "C5'" 1 
+ATOM   1375 C "C4'" . DA  B 2 28  ? 64.099  17.260 76.320  1.00 53.87  ? ? ? ? ? ? 28  DA  D "C4'" 1 
+ATOM   1376 O "O4'" . DA  B 2 28  ? 64.677  18.520 75.885  1.00 60.29  ? ? ? ? ? ? 28  DA  D "O4'" 1 
+ATOM   1377 C "C3'" . DA  B 2 28  ? 64.356  16.281 75.179  1.00 62.07  ? ? ? ? ? ? 28  DA  D "C3'" 1 
+ATOM   1378 O "O3'" . DA  B 2 28  ? 63.209  16.223 74.330  1.00 72.95  ? ? ? ? ? ? 28  DA  D "O3'" 1 
+ATOM   1379 C "C2'" . DA  B 2 28  ? 65.529  16.941 74.460  1.00 59.03  ? ? ? ? ? ? 28  DA  D "C2'" 1 
+ATOM   1380 C "C1'" . DA  B 2 28  ? 65.060  18.387 74.532  1.00 49.96  ? ? ? ? ? ? 28  DA  D "C1'" 1 
+ATOM   1381 N N9    . DA  B 2 28  ? 66.050  19.401 74.160  1.00 41.37  ? ? ? ? ? ? 28  DA  D N9    1 
+ATOM   1382 C C8    . DA  B 2 28  ? 67.395  19.495 74.400  1.00 43.48  ? ? ? ? ? ? 28  DA  D C8    1 
+ATOM   1383 N N7    . DA  B 2 28  ? 67.953  20.569 73.887  1.00 38.43  ? ? ? ? ? ? 28  DA  D N7    1 
+ATOM   1384 C C5    . DA  B 2 28  ? 66.899  21.224 73.270  1.00 29.53  ? ? ? ? ? ? 28  DA  D C5    1 
+ATOM   1385 C C6    . DA  B 2 28  ? 66.823  22.426 72.547  1.00 32.63  ? ? ? ? ? ? 28  DA  D C6    1 
+ATOM   1386 N N6    . DA  B 2 28  ? 67.879  23.218 72.300  1.00 30.29  ? ? ? ? ? ? 28  DA  D N6    1 
+ATOM   1387 N N1    . DA  B 2 28  ? 65.612  22.771 72.058  1.00 33.17  ? ? ? ? ? ? 28  DA  D N1    1 
+ATOM   1388 C C2    . DA  B 2 28  ? 64.558  21.982 72.301  1.00 31.24  ? ? ? ? ? ? 28  DA  D C2    1 
+ATOM   1389 N N3    . DA  B 2 28  ? 64.505  20.831 72.968  1.00 31.38  ? ? ? ? ? ? 28  DA  D N3    1 
+ATOM   1390 C C4    . DA  B 2 28  ? 65.723  20.513 73.424  1.00 32.48  ? ? ? ? ? ? 28  DA  D C4    1 
+ATOM   1391 P P     . DA  B 2 29  ? 62.755  14.844 73.655  1.00 68.06  ? ? ? ? ? ? 29  DA  D P     1 
+ATOM   1392 O OP1   . DA  B 2 29  ? 62.040  14.057 74.684  1.00 66.52  ? ? ? ? ? ? 29  DA  D OP1   1 
+ATOM   1393 O OP2   . DA  B 2 29  ? 63.930  14.278 72.955  1.00 76.05  ? ? ? ? ? ? 29  DA  D OP2   1 
+ATOM   1394 O "O5'" . DA  B 2 29  ? 61.692  15.257 72.535  1.00 55.54  ? ? ? ? ? ? 29  DA  D "O5'" 1 
+ATOM   1395 C "C5'" . DA  B 2 29  ? 60.889  16.414 72.671  1.00 48.61  ? ? ? ? ? ? 29  DA  D "C5'" 1 
+ATOM   1396 C "C4'" . DA  B 2 29  ? 60.835  17.137 71.340  1.00 57.71  ? ? ? ? ? ? 29  DA  D "C4'" 1 
+ATOM   1397 O "O4'" . DA  B 2 29  ? 61.943  18.069 71.242  1.00 57.91  ? ? ? ? ? ? 29  DA  D "O4'" 1 
+ATOM   1398 C "C3'" . DA  B 2 29  ? 60.936  16.247 70.105  1.00 72.03  ? ? ? ? ? ? 29  DA  D "C3'" 1 
+ATOM   1399 O "O3'" . DA  B 2 29  ? 60.033  16.742 69.127  1.00 85.02  ? ? ? ? ? ? 29  DA  D "O3'" 1 
+ATOM   1400 C "C2'" . DA  B 2 29  ? 62.382  16.441 69.653  1.00 56.96  ? ? ? ? ? ? 29  DA  D "C2'" 1 
+ATOM   1401 C "C1'" . DA  B 2 29  ? 62.567  17.918 69.982  1.00 53.62  ? ? ? ? ? ? 29  DA  D "C1'" 1 
+ATOM   1402 N N9    . DA  B 2 29  ? 63.962  18.351 70.077  1.00 41.70  ? ? ? ? ? ? 29  DA  D N9    1 
+ATOM   1403 C C8    . DA  B 2 29  ? 65.021  17.761 70.708  1.00 40.49  ? ? ? ? ? ? 29  DA  D C8    1 
+ATOM   1404 N N7    . DA  B 2 29  ? 66.145  18.434 70.602  1.00 40.55  ? ? ? ? ? ? 29  DA  D N7    1 
+ATOM   1405 C C5    . DA  B 2 29  ? 65.792  19.549 69.861  1.00 36.59  ? ? ? ? ? ? 29  DA  D C5    1 
+ATOM   1406 C C6    . DA  B 2 29  ? 66.523  20.652 69.394  1.00 31.44  ? ? ? ? ? ? 29  DA  D C6    1 
+ATOM   1407 N N6    . DA  B 2 29  ? 67.828  20.801 69.639  1.00 32.90  ? ? ? ? ? ? 29  DA  D N6    1 
+ATOM   1408 N N1    . DA  B 2 29  ? 65.881  21.595 68.675  1.00 32.64  ? ? ? ? ? ? 29  DA  D N1    1 
+ATOM   1409 C C2    . DA  B 2 29  ? 64.578  21.425 68.445  1.00 36.07  ? ? ? ? ? ? 29  DA  D C2    1 
+ATOM   1410 N N3    . DA  B 2 29  ? 63.781  20.424 68.818  1.00 37.26  ? ? ? ? ? ? 29  DA  D N3    1 
+ATOM   1411 C C4    . DA  B 2 29  ? 64.456  19.510 69.529  1.00 35.70  ? ? ? ? ? ? 29  DA  D C4    1 
+ATOM   1412 P P     . DC  B 2 30  ? 59.583  15.903 67.842  1.00 81.38  ? ? ? ? ? ? 30  DC  D P     1 
+ATOM   1413 O OP1   . DC  B 2 30  ? 58.111  16.026 67.738  1.00 88.42  ? ? ? ? ? ? 30  DC  D OP1   1 
+ATOM   1414 O OP2   . DC  B 2 30  ? 60.231  14.572 67.864  1.00 68.08  ? ? ? ? ? ? 30  DC  D OP2   1 
+ATOM   1415 O "O5'" . DC  B 2 30  ? 60.235  16.750 66.659  1.00 85.76  ? ? ? ? ? ? 30  DC  D "O5'" 1 
+ATOM   1416 C "C5'" . DC  B 2 30  ? 59.844  18.107 66.557  1.00 87.82  ? ? ? ? ? ? 30  DC  D "C5'" 1 
+ATOM   1417 C "C4'" . DC  B 2 30  ? 60.880  18.878 65.767  1.00 80.45  ? ? ? ? ? ? 30  DC  D "C4'" 1 
+ATOM   1418 O "O4'" . DC  B 2 30  ? 62.157  18.824 66.449  1.00 77.22  ? ? ? ? ? ? 30  DC  D "O4'" 1 
+ATOM   1419 C "C3'" . DC  B 2 30  ? 61.123  18.352 64.356  1.00 74.83  ? ? ? ? ? ? 30  DC  D "C3'" 1 
+ATOM   1420 O "O3'" . DC  B 2 30  ? 60.687  19.331 63.422  1.00 62.36  ? ? ? ? ? ? 30  DC  D "O3'" 1 
+ATOM   1421 C "C2'" . DC  B 2 30  ? 62.630  18.093 64.306  1.00 67.98  ? ? ? ? ? ? 30  DC  D "C2'" 1 
+ATOM   1422 C "C1'" . DC  B 2 30  ? 63.146  18.953 65.454  1.00 55.26  ? ? ? ? ? ? 30  DC  D "C1'" 1 
+ATOM   1423 N N1    . DC  B 2 30  ? 64.479  18.568 66.003  1.00 48.65  ? ? ? ? ? ? 30  DC  D N1    1 
+ATOM   1424 C C2    . DC  B 2 30  ? 65.533  19.432 65.691  1.00 48.07  ? ? ? ? ? ? 30  DC  D C2    1 
+ATOM   1425 O O2    . DC  B 2 30  ? 65.294  20.431 65.001  1.00 52.94  ? ? ? ? ? ? 30  DC  D O2    1 
+ATOM   1426 N N3    . DC  B 2 30  ? 66.778  19.157 66.150  1.00 49.19  ? ? ? ? ? ? 30  DC  D N3    1 
+ATOM   1427 C C4    . DC  B 2 30  ? 66.991  18.066 66.885  1.00 54.57  ? ? ? ? ? ? 30  DC  D C4    1 
+ATOM   1428 N N4    . DC  B 2 30  ? 68.236  17.833 67.314  1.00 53.86  ? ? ? ? ? ? 30  DC  D N4    1 
+ATOM   1429 C C5    . DC  B 2 30  ? 65.933  17.168 67.216  1.00 51.99  ? ? ? ? ? ? 30  DC  D C5    1 
+ATOM   1430 C C6    . DC  B 2 30  ? 64.709  17.461 66.761  1.00 51.93  ? ? ? ? ? ? 30  DC  D C6    1 
+ATOM   1431 P P     . DT  B 2 31  ? 61.031  19.219 61.869  1.00 60.04  ? ? ? ? ? ? 31  DT  D P     1 
+ATOM   1432 O OP1   . DT  B 2 31  ? 60.080  20.101 61.160  1.00 64.05  ? ? ? ? ? ? 31  DT  D OP1   1 
+ATOM   1433 O OP2   . DT  B 2 31  ? 61.153  17.784 61.531  1.00 47.44  ? ? ? ? ? ? 31  DT  D OP2   1 
+ATOM   1434 O "O5'" . DT  B 2 31  ? 62.474  19.895 61.781  1.00 62.91  ? ? ? ? ? ? 31  DT  D "O5'" 1 
+ATOM   1435 C "C5'" . DT  B 2 31  ? 62.534  21.312 61.702  1.00 65.65  ? ? ? ? ? ? 31  DT  D "C5'" 1 
+ATOM   1436 C "C4'" . DT  B 2 31  ? 63.713  21.749 60.857  1.00 70.12  ? ? ? ? ? ? 31  DT  D "C4'" 1 
+ATOM   1437 O "O4'" . DT  B 2 31  ? 64.948  21.371 61.516  1.00 71.57  ? ? ? ? ? ? 31  DT  D "O4'" 1 
+ATOM   1438 C "C3'" . DT  B 2 31  ? 63.791  21.087 59.490  1.00 75.28  ? ? ? ? ? ? 31  DT  D "C3'" 1 
+ATOM   1439 O "O3'" . DT  B 2 31  ? 64.473  21.987 58.641  1.00 69.08  ? ? ? ? ? ? 31  DT  D "O3'" 1 
+ATOM   1440 C "C2'" . DT  B 2 31  ? 64.645  19.855 59.778  1.00 64.55  ? ? ? ? ? ? 31  DT  D "C2'" 1 
+ATOM   1441 C "C1'" . DT  B 2 31  ? 65.686  20.509 60.674  1.00 49.24  ? ? ? ? ? ? 31  DT  D "C1'" 1 
+ATOM   1442 N N1    . DT  B 2 31  ? 66.443  19.577 61.542  1.00 45.45  ? ? ? ? ? ? 31  DT  D N1    1 
+ATOM   1443 C C2    . DT  B 2 31  ? 67.773  19.881 61.754  1.00 41.26  ? ? ? ? ? ? 31  DT  D C2    1 
+ATOM   1444 O O2    . DT  B 2 31  ? 68.344  20.836 61.252  1.00 40.55  ? ? ? ? ? ? 31  DT  D O2    1 
+ATOM   1445 N N3    . DT  B 2 31  ? 68.427  19.004 62.574  1.00 33.63  ? ? ? ? ? ? 31  DT  D N3    1 
+ATOM   1446 C C4    . DT  B 2 31  ? 67.875  17.909 63.214  1.00 39.39  ? ? ? ? ? ? 31  DT  D C4    1 
+ATOM   1447 O O4    . DT  B 2 31  ? 68.571  17.221 63.956  1.00 38.88  ? ? ? ? ? ? 31  DT  D O4    1 
+ATOM   1448 C C5    . DT  B 2 31  ? 66.480  17.664 62.959  1.00 35.20  ? ? ? ? ? ? 31  DT  D C5    1 
+ATOM   1449 C C7    . DT  B 2 31  ? 65.849  16.470 63.617  1.00 31.52  ? ? ? ? ? ? 31  DT  D C7    1 
+ATOM   1450 C C6    . DT  B 2 31  ? 65.822  18.508 62.158  1.00 37.50  ? ? ? ? ? ? 31  DT  D C6    1 
+ATOM   1451 P P     . DT  B 2 32  ? 64.381  21.833 57.056  1.00 67.37  ? ? ? ? ? ? 32  DT  D P     1 
+ATOM   1452 O OP1   . DT  B 2 32  ? 63.908  23.147 56.563  1.00 52.42  ? ? ? ? ? ? 32  DT  D OP1   1 
+ATOM   1453 O OP2   . DT  B 2 32  ? 63.660  20.578 56.739  1.00 63.36  ? ? ? ? ? ? 32  DT  D OP2   1 
+ATOM   1454 O "O5'" . DT  B 2 32  ? 65.916  21.681 56.641  1.00 79.26  ? ? ? ? ? ? 32  DT  D "O5'" 1 
+ATOM   1455 C "C5'" . DT  B 2 32  ? 66.779  22.791 56.851  1.00 76.23  ? ? ? ? ? ? 32  DT  D "C5'" 1 
+ATOM   1456 C "C4'" . DT  B 2 32  ? 68.203  22.396 56.517  1.00 69.40  ? ? ? ? ? ? 32  DT  D "C4'" 1 
+ATOM   1457 O "O4'" . DT  B 2 32  ? 68.707  21.514 57.554  1.00 68.66  ? ? ? ? ? ? 32  DT  D "O4'" 1 
+ATOM   1458 C "C3'" . DT  B 2 32  ? 68.308  21.586 55.233  1.00 61.56  ? ? ? ? ? ? 32  DT  D "C3'" 1 
+ATOM   1459 O "O3'" . DT  B 2 32  ? 69.483  21.975 54.552  1.00 64.89  ? ? ? ? ? ? 32  DT  D "O3'" 1 
+ATOM   1460 C "C2'" . DT  B 2 32  ? 68.403  20.153 55.740  1.00 48.02  ? ? ? ? ? ? 32  DT  D "C2'" 1 
+ATOM   1461 C "C1'" . DT  B 2 32  ? 69.307  20.400 56.935  1.00 47.11  ? ? ? ? ? ? 32  DT  D "C1'" 1 
+ATOM   1462 N N1    . DT  B 2 32  ? 69.333  19.284 57.904  1.00 48.31  ? ? ? ? ? ? 32  DT  D N1    1 
+ATOM   1463 C C2    . DT  B 2 32  ? 70.493  19.163 58.642  1.00 52.97  ? ? ? ? ? ? 32  DT  D C2    1 
+ATOM   1464 O O2    . DT  B 2 32  ? 71.436  19.928 58.518  1.00 54.31  ? ? ? ? ? ? 32  DT  D O2    1 
+ATOM   1465 N N3    . DT  B 2 32  ? 70.490  18.130 59.544  1.00 43.82  ? ? ? ? ? ? 32  DT  D N3    1 
+ATOM   1466 C C4    . DT  B 2 32  ? 69.464  17.223 59.744  1.00 41.70  ? ? ? ? ? ? 32  DT  D C4    1 
+ATOM   1467 O O4    . DT  B 2 32  ? 69.590  16.330 60.572  1.00 40.92  ? ? ? ? ? ? 32  DT  D O4    1 
+ATOM   1468 C C5    . DT  B 2 32  ? 68.295  17.412 58.927  1.00 44.24  ? ? ? ? ? ? 32  DT  D C5    1 
+ATOM   1469 C C7    . DT  B 2 32  ? 67.169  16.445 59.126  1.00 43.15  ? ? ? ? ? ? 32  DT  D C7    1 
+ATOM   1470 C C6    . DT  B 2 32  ? 68.267  18.421 58.051  1.00 43.05  ? ? ? ? ? ? 32  DT  D C6    1 
+ATOM   1471 P P     . DA  B 2 33  ? 69.319  22.615 53.099  1.00 66.53  ? ? ? ? ? ? 33  DA  D P     1 
+ATOM   1472 O OP1   . DA  B 2 33  ? 69.003  24.056 53.228  1.00 64.54  ? ? ? ? ? ? 33  DA  D OP1   1 
+ATOM   1473 O OP2   . DA  B 2 33  ? 68.417  21.729 52.330  1.00 78.33  ? ? ? ? ? ? 33  DA  D OP2   1 
+ATOM   1474 O "O5'" . DA  B 2 33  ? 70.815  22.506 52.545  1.00 69.82  ? ? ? ? ? ? 33  DA  D "O5'" 1 
+ATOM   1475 C "C5'" . DA  B 2 33  ? 71.847  23.334 53.084  1.00 52.21  ? ? ? ? ? ? 33  DA  D "C5'" 1 
+ATOM   1476 C "C4'" . DA  B 2 33  ? 72.977  22.479 53.632  1.00 56.87  ? ? ? ? ? ? 33  DA  D "C4'" 1 
+ATOM   1477 O "O4'" . DA  B 2 33  ? 72.406  21.520 54.558  1.00 64.08  ? ? ? ? ? ? 33  DA  D "O4'" 1 
+ATOM   1478 C "C3'" . DA  B 2 33  ? 73.745  21.659 52.598  1.00 61.16  ? ? ? ? ? ? 33  DA  D "C3'" 1 
+ATOM   1479 O "O3'" . DA  B 2 33  ? 75.145  21.870 52.730  1.00 63.16  ? ? ? ? ? ? 33  DA  D "O3'" 1 
+ATOM   1480 C "C2'" . DA  B 2 33  ? 73.381  20.207 52.896  1.00 57.96  ? ? ? ? ? ? 33  DA  D "C2'" 1 
+ATOM   1481 C "C1'" . DA  B 2 33  ? 73.027  20.266 54.374  1.00 55.34  ? ? ? ? ? ? 33  DA  D "C1'" 1 
+ATOM   1482 N N9    . DA  B 2 33  ? 72.104  19.210 54.776  1.00 48.16  ? ? ? ? ? ? 33  DA  D N9    1 
+ATOM   1483 C C8    . DA  B 2 33  ? 70.857  18.921 54.302  1.00 50.12  ? ? ? ? ? ? 33  DA  D C8    1 
+ATOM   1484 N N7    . DA  B 2 33  ? 70.307  17.884 54.891  1.00 54.34  ? ? ? ? ? ? 33  DA  D N7    1 
+ATOM   1485 C C5    . DA  B 2 33  ? 71.257  17.466 55.807  1.00 47.24  ? ? ? ? ? ? 33  DA  D C5    1 
+ATOM   1486 C C6    . DA  B 2 33  ? 71.290  16.410 56.736  1.00 46.07  ? ? ? ? ? ? 33  DA  D C6    1 
+ATOM   1487 N N6    . DA  B 2 33  ? 70.269  15.561 56.866  1.00 47.83  ? ? ? ? ? ? 33  DA  D N6    1 
+ATOM   1488 N N1    . DA  B 2 33  ? 72.388  16.249 57.501  1.00 46.19  ? ? ? ? ? ? 33  DA  D N1    1 
+ATOM   1489 C C2    . DA  B 2 33  ? 73.393  17.113 57.331  1.00 48.76  ? ? ? ? ? ? 33  DA  D C2    1 
+ATOM   1490 N N3    . DA  B 2 33  ? 73.487  18.140 56.483  1.00 48.72  ? ? ? ? ? ? 33  DA  D N3    1 
+ATOM   1491 C C4    . DA  B 2 33  ? 72.373  18.270 55.746  1.00 47.25  ? ? ? ? ? ? 33  DA  D C4    1 
+ATOM   1492 P P     . DT  B 2 34  ? 76.071  22.167 51.457  1.00 62.48  ? ? ? ? ? ? 34  DT  D P     1 
+ATOM   1493 O OP1   . DT  B 2 34  ? 77.343  22.712 51.974  1.00 92.48  ? ? ? ? ? ? 34  DT  D OP1   1 
+ATOM   1494 O OP2   . DT  B 2 34  ? 75.302  22.949 50.458  1.00 77.17  ? ? ? ? ? ? 34  DT  D OP2   1 
+ATOM   1495 O "O5'" . DT  B 2 34  ? 76.380  20.711 50.868  1.00 51.43  ? ? ? ? ? ? 34  DT  D "O5'" 1 
+ATOM   1496 C "C5'" . DT  B 2 34  ? 76.004  19.534 51.570  1.00 45.38  ? ? ? ? ? ? 34  DT  D "C5'" 1 
+ATOM   1497 C "C4'" . DT  B 2 34  ? 76.806  19.408 52.850  1.00 38.65  ? ? ? ? ? ? 34  DT  D "C4'" 1 
+ATOM   1498 O "O4'" . DT  B 2 34  ? 75.966  18.780 53.848  1.00 98.59  ? ? ? ? ? ? 34  DT  D "O4'" 1 
+ATOM   1499 C "C3'" . DT  B 2 34  ? 78.016  18.491 52.769  1.00 72.65  ? ? ? ? ? ? 34  DT  D "C3'" 1 
+ATOM   1500 O "O3'" . DT  B 2 34  ? 78.871  18.753 53.878  1.00 100.00 ? ? ? ? ? ? 34  DT  D "O3'" 1 
+ATOM   1501 C "C2'" . DT  B 2 34  ? 77.348  17.125 52.890  1.00 65.93  ? ? ? ? ? ? 34  DT  D "C2'" 1 
+ATOM   1502 C "C1'" . DT  B 2 34  ? 76.309  17.415 53.969  1.00 56.27  ? ? ? ? ? ? 34  DT  D "C1'" 1 
+ATOM   1503 N N1    . DT  B 2 34  ? 75.057  16.642 53.815  1.00 56.05  ? ? ? ? ? ? 34  DT  D N1    1 
+ATOM   1504 C C2    . DT  B 2 34  ? 74.830  15.618 54.705  1.00 57.97  ? ? ? ? ? ? 34  DT  D C2    1 
+ATOM   1505 O O2    . DT  B 2 34  ? 75.601  15.339 55.606  1.00 57.88  ? ? ? ? ? ? 34  DT  D O2    1 
+ATOM   1506 N N3    . DT  B 2 34  ? 73.658  14.936 54.503  1.00 60.51  ? ? ? ? ? ? 34  DT  D N3    1 
+ATOM   1507 C C4    . DT  B 2 34  ? 72.721  15.183 53.516  1.00 61.83  ? ? ? ? ? ? 34  DT  D C4    1 
+ATOM   1508 O O4    . DT  B 2 34  ? 71.706  14.496 53.465  1.00 61.30  ? ? ? ? ? ? 34  DT  D O4    1 
+ATOM   1509 C C5    . DT  B 2 34  ? 73.041  16.259 52.611  1.00 55.85  ? ? ? ? ? ? 34  DT  D C5    1 
+ATOM   1510 C C7    . DT  B 2 34  ? 72.121  16.644 51.493  1.00 55.73  ? ? ? ? ? ? 34  DT  D C7    1 
+ATOM   1511 C C6    . DT  B 2 34  ? 74.174  16.939 52.801  1.00 54.92  ? ? ? ? ? ? 34  DT  D C6    1 
+ATOM   1512 N N     . ALA C 3 24  ? 34.728  52.682 104.426 1.00 91.61  ? ? ? ? ? ? 18  ALA A N     1 
+ATOM   1513 C CA    . ALA C 3 24  ? 35.288  51.642 103.568 1.00 90.68  ? ? ? ? ? ? 18  ALA A CA    1 
+ATOM   1514 C C     . ALA C 3 24  ? 34.664  50.291 103.895 1.00 91.22  ? ? ? ? ? ? 18  ALA A C     1 
+ATOM   1515 O O     . ALA C 3 24  ? 35.264  49.249 103.639 1.00 92.64  ? ? ? ? ? ? 18  ALA A O     1 
+ATOM   1516 C CB    . ALA C 3 24  ? 36.806  51.581 103.715 1.00 91.48  ? ? ? ? ? ? 18  ALA A CB    1 
+ATOM   1517 N N     . THR C 3 25  ? 33.458  50.321 104.458 1.00 82.64  ? ? ? ? ? ? 19  THR A N     1 
+ATOM   1518 C CA    . THR C 3 25  ? 32.717  49.118 104.852 1.00 79.67  ? ? ? ? ? ? 19  THR A CA    1 
+ATOM   1519 C C     . THR C 3 25  ? 33.383  48.131 105.813 1.00 73.74  ? ? ? ? ? ? 19  THR A C     1 
+ATOM   1520 O O     . THR C 3 25  ? 34.440  47.564 105.533 1.00 75.80  ? ? ? ? ? ? 19  THR A O     1 
+ATOM   1521 C CB    . THR C 3 25  ? 31.977  48.466 103.684 1.00 86.22  ? ? ? ? ? ? 19  THR A CB    1 
+ATOM   1522 O OG1   . THR C 3 25  ? 32.383  47.092 103.522 1.00 68.78  ? ? ? ? ? ? 19  THR A OG1   1 
+ATOM   1523 C CG2   . THR C 3 25  ? 32.176  49.314 102.424 1.00 90.23  ? ? ? ? ? ? 19  THR A CG2   1 
+ATOM   1524 N N     . SER C 3 26  ? 32.766  47.964 106.972 1.00 59.36  ? ? ? ? ? ? 20  SER A N     1 
+ATOM   1525 C CA    . SER C 3 26  ? 33.333  47.105 107.986 1.00 55.14  ? ? ? ? ? ? 20  SER A CA    1 
+ATOM   1526 C C     . SER C 3 26  ? 33.527  45.661 107.562 1.00 55.44  ? ? ? ? ? ? 20  SER A C     1 
+ATOM   1527 O O     . SER C 3 26  ? 34.275  44.934 108.205 1.00 55.94  ? ? ? ? ? ? 20  SER A O     1 
+ATOM   1528 C CB    . SER C 3 26  ? 32.538  47.213 109.284 1.00 59.20  ? ? ? ? ? ? 20  SER A CB    1 
+ATOM   1529 O OG    . SER C 3 26  ? 32.425  45.953 109.919 1.00 77.81  ? ? ? ? ? ? 20  SER A OG    1 
+ATOM   1530 N N     . ASP C 3 27  ? 32.868  45.224 106.492 1.00 53.23  ? ? ? ? ? ? 21  ASP A N     1 
+ATOM   1531 C CA    . ASP C 3 27  ? 33.023  43.840 106.038 1.00 53.56  ? ? ? ? ? ? 21  ASP A CA    1 
+ATOM   1532 C C     . ASP C 3 27  ? 34.318  43.763 105.234 1.00 54.63  ? ? ? ? ? ? 21  ASP A C     1 
+ATOM   1533 O O     . ASP C 3 27  ? 35.023  42.752 105.247 1.00 53.22  ? ? ? ? ? ? 21  ASP A O     1 
+ATOM   1534 C CB    . ASP C 3 27  ? 31.825  43.402 105.174 1.00 57.45  ? ? ? ? ? ? 21  ASP A CB    1 
+ATOM   1535 C CG    . ASP C 3 27  ? 30.695  42.771 105.995 1.00 73.89  ? ? ? ? ? ? 21  ASP A CG    1 
+ATOM   1536 O OD1   . ASP C 3 27  ? 31.008  42.034 106.955 1.00 80.31  ? ? ? ? ? ? 21  ASP A OD1   1 
+ATOM   1537 O OD2   . ASP C 3 27  ? 29.503  43.013 105.688 1.00 75.91  ? ? ? ? ? ? 21  ASP A OD2   1 
+ATOM   1538 N N     . GLU C 3 28  ? 34.622  44.844 104.525 1.00 51.32  ? ? ? ? ? ? 22  GLU A N     1 
+ATOM   1539 C CA    . GLU C 3 28  ? 35.842  44.910 103.732 1.00 51.32  ? ? ? ? ? ? 22  GLU A CA    1 
+ATOM   1540 C C     . GLU C 3 28  ? 37.015  44.952 104.697 1.00 53.41  ? ? ? ? ? ? 22  GLU A C     1 
+ATOM   1541 O O     . GLU C 3 28  ? 38.011  44.249 104.528 1.00 53.68  ? ? ? ? ? ? 22  GLU A O     1 
+ATOM   1542 C CB    . GLU C 3 28  ? 35.855  46.195 102.919 1.00 52.98  ? ? ? ? ? ? 22  GLU A CB    1 
+ATOM   1543 C CG    . GLU C 3 28  ? 35.724  45.980 101.432 1.00 76.05  ? ? ? ? ? ? 22  GLU A CG    1 
+ATOM   1544 C CD    . GLU C 3 28  ? 34.863  47.045 100.809 1.00 100.00 ? ? ? ? ? ? 22  GLU A CD    1 
+ATOM   1545 O OE1   . GLU C 3 28  ? 33.801  47.310 101.400 1.00 68.90  ? ? ? ? ? ? 22  GLU A OE1   1 
+ATOM   1546 O OE2   . GLU C 3 28  ? 35.225  47.620 99.762  1.00 100.00 ? ? ? ? ? ? 22  GLU A OE2   1 
+ATOM   1547 N N     . VAL C 3 29  ? 36.871  45.804 105.707 1.00 45.99  ? ? ? ? ? ? 23  VAL A N     1 
+ATOM   1548 C CA    . VAL C 3 29  ? 37.879  45.968 106.746 1.00 43.26  ? ? ? ? ? ? 23  VAL A CA    1 
+ATOM   1549 C C     . VAL C 3 29  ? 38.160  44.642 107.455 1.00 45.58  ? ? ? ? ? ? 23  VAL A C     1 
+ATOM   1550 O O     . VAL C 3 29  ? 39.311  44.233 107.596 1.00 45.55  ? ? ? ? ? ? 23  VAL A O     1 
+ATOM   1551 C CB    . VAL C 3 29  ? 37.489  47.076 107.744 1.00 44.82  ? ? ? ? ? ? 23  VAL A CB    1 
+ATOM   1552 C CG1   . VAL C 3 29  ? 38.534  47.202 108.850 1.00 43.86  ? ? ? ? ? ? 23  VAL A CG1   1 
+ATOM   1553 C CG2   . VAL C 3 29  ? 37.297  48.397 106.998 1.00 43.15  ? ? ? ? ? ? 23  VAL A CG2   1 
+ATOM   1554 N N     . ARG C 3 30  ? 37.106  43.956 107.876 1.00 40.33  ? ? ? ? ? ? 24  ARG A N     1 
+ATOM   1555 C CA    . ARG C 3 30  ? 37.250  42.671 108.557 1.00 39.48  ? ? ? ? ? ? 24  ARG A CA    1 
+ATOM   1556 C C     . ARG C 3 30  ? 37.961  41.661 107.660 1.00 40.24  ? ? ? ? ? ? 24  ARG A C     1 
+ATOM   1557 O O     . ARG C 3 30  ? 38.738  40.841 108.143 1.00 42.23  ? ? ? ? ? ? 24  ARG A O     1 
+ATOM   1558 C CB    . ARG C 3 30  ? 35.877  42.159 109.006 1.00 45.98  ? ? ? ? ? ? 24  ARG A CB    1 
+ATOM   1559 C CG    . ARG C 3 30  ? 35.853  40.790 109.681 1.00 59.01  ? ? ? ? ? ? 24  ARG A CG    1 
+ATOM   1560 C CD    . ARG C 3 30  ? 34.422  40.263 109.825 1.00 79.19  ? ? ? ? ? ? 24  ARG A CD    1 
+ATOM   1561 N NE    . ARG C 3 30  ? 33.611  41.040 110.765 1.00 96.29  ? ? ? ? ? ? 24  ARG A NE    1 
+ATOM   1562 C CZ    . ARG C 3 30  ? 33.897  41.187 112.057 1.00 100.00 ? ? ? ? ? ? 24  ARG A CZ    1 
+ATOM   1563 N NH1   . ARG C 3 30  ? 34.976  40.613 112.568 1.00 82.14  ? ? ? ? ? ? 24  ARG A NH1   1 
+ATOM   1564 N NH2   . ARG C 3 30  ? 33.111  41.910 112.845 1.00 90.30  ? ? ? ? ? ? 24  ARG A NH2   1 
+ATOM   1565 N N     . LYS C 3 31  ? 37.715  41.725 106.354 1.00 34.81  ? ? ? ? ? ? 25  LYS A N     1 
+ATOM   1566 C CA    . LYS C 3 31  ? 38.385  40.839 105.397 1.00 32.66  ? ? ? ? ? ? 25  LYS A CA    1 
+ATOM   1567 C C     . LYS C 3 31  ? 39.874  41.245 105.304 1.00 37.34  ? ? ? ? ? ? 25  LYS A C     1 
+ATOM   1568 O O     . LYS C 3 31  ? 40.780  40.405 105.295 1.00 34.01  ? ? ? ? ? ? 25  LYS A O     1 
+ATOM   1569 C CB    . LYS C 3 31  ? 37.688  40.945 104.036 1.00 29.45  ? ? ? ? ? ? 25  LYS A CB    1 
+ATOM   1570 C CG    . LYS C 3 31  ? 38.476  40.372 102.860 1.00 26.07  ? ? ? ? ? ? 25  LYS A CG    1 
+ATOM   1571 C CD    . LYS C 3 31  ? 38.838  38.905 103.052 1.00 31.72  ? ? ? ? ? ? 25  LYS A CD    1 
+ATOM   1572 C CE    . LYS C 3 31  ? 39.092  38.246 101.704 1.00 35.39  ? ? ? ? ? ? 25  LYS A CE    1 
+ATOM   1573 N NZ    . LYS C 3 31  ? 40.478  38.413 101.201 1.00 41.51  ? ? ? ? ? ? 25  LYS A NZ    1 
+ATOM   1574 N N     . ASN C 3 32  ? 40.117  42.551 105.217 1.00 35.03  ? ? ? ? ? ? 26  ASN A N     1 
+ATOM   1575 C CA    . ASN C 3 32  ? 41.472  43.099 105.178 1.00 35.05  ? ? ? ? ? ? 26  ASN A CA    1 
+ATOM   1576 C C     . ASN C 3 32  ? 42.280  42.709 106.432 1.00 38.34  ? ? ? ? ? ? 26  ASN A C     1 
+ATOM   1577 O O     . ASN C 3 32  ? 43.432  42.298 106.316 1.00 40.08  ? ? ? ? ? ? 26  ASN A O     1 
+ATOM   1578 C CB    . ASN C 3 32  ? 41.422  44.620 105.055 1.00 31.00  ? ? ? ? ? ? 26  ASN A CB    1 
+ATOM   1579 C CG    . ASN C 3 32  ? 41.097  45.068 103.659 1.00 46.11  ? ? ? ? ? ? 26  ASN A CG    1 
+ATOM   1580 O OD1   . ASN C 3 32  ? 41.324  44.336 102.701 1.00 52.70  ? ? ? ? ? ? 26  ASN A OD1   1 
+ATOM   1581 N ND2   . ASN C 3 32  ? 40.567  46.275 103.528 1.00 45.50  ? ? ? ? ? ? 26  ASN A ND2   1 
+ATOM   1582 N N     . LEU C 3 33  ? 41.687  42.816 107.622 1.00 32.52  ? ? ? ? ? ? 27  LEU A N     1 
+ATOM   1583 C CA    . LEU C 3 33  ? 42.375  42.444 108.858 1.00 31.84  ? ? ? ? ? ? 27  LEU A CA    1 
+ATOM   1584 C C     . LEU C 3 33  ? 42.669  40.944 108.955 1.00 35.25  ? ? ? ? ? ? 27  LEU A C     1 
+ATOM   1585 O O     . LEU C 3 33  ? 43.721  40.562 109.461 1.00 36.65  ? ? ? ? ? ? 27  LEU A O     1 
+ATOM   1586 C CB    . LEU C 3 33  ? 41.676  42.999 110.103 1.00 33.01  ? ? ? ? ? ? 27  LEU A CB    1 
+ATOM   1587 C CG    . LEU C 3 33  ? 41.490  44.527 110.107 1.00 40.66  ? ? ? ? ? ? 27  LEU A CG    1 
+ATOM   1588 C CD1   . LEU C 3 33  ? 40.580  45.020 111.229 1.00 41.18  ? ? ? ? ? ? 27  LEU A CD1   1 
+ATOM   1589 C CD2   . LEU C 3 33  ? 42.794  45.316 110.079 1.00 45.29  ? ? ? ? ? ? 27  LEU A CD2   1 
+ATOM   1590 N N     . MET C 3 34  ? 41.783  40.090 108.434 1.00 33.15  ? ? ? ? ? ? 28  MET A N     1 
+ATOM   1591 C CA    . MET C 3 34  ? 42.044  38.642 108.413 1.00 34.67  ? ? ? ? ? ? 28  MET A CA    1 
+ATOM   1592 C C     . MET C 3 34  ? 43.180  38.348 107.395 1.00 41.13  ? ? ? ? ? ? 28  MET A C     1 
+ATOM   1593 O O     . MET C 3 34  ? 43.992  37.428 107.581 1.00 37.66  ? ? ? ? ? ? 28  MET A O     1 
+ATOM   1594 C CB    . MET C 3 34  ? 40.777  37.876 108.006 1.00 37.36  ? ? ? ? ? ? 28  MET A CB    1 
+ATOM   1595 C CG    . MET C 3 34  ? 39.528  38.150 108.845 1.00 42.17  ? ? ? ? ? ? 28  MET A CG    1 
+ATOM   1596 S SD    . MET C 3 34  ? 38.123  37.151 108.285 1.00 46.80  ? ? ? ? ? ? 28  MET A SD    1 
+ATOM   1597 C CE    . MET C 3 34  ? 37.449  36.541 109.839 1.00 44.41  ? ? ? ? ? ? 28  MET A CE    1 
+ATOM   1598 N N     . ASP C 3 35  ? 43.213  39.132 106.315 1.00 38.66  ? ? ? ? ? ? 29  ASP A N     1 
+ATOM   1599 C CA    . ASP C 3 35  ? 44.242  39.005 105.283 1.00 37.55  ? ? ? ? ? ? 29  ASP A CA    1 
+ATOM   1600 C C     . ASP C 3 35  ? 45.575  39.251 106.005 1.00 43.21  ? ? ? ? ? ? 29  ASP A C     1 
+ATOM   1601 O O     . ASP C 3 35  ? 46.523  38.481 105.848 1.00 42.00  ? ? ? ? ? ? 29  ASP A O     1 
+ATOM   1602 C CB    . ASP C 3 35  ? 44.057  40.094 104.215 1.00 37.59  ? ? ? ? ? ? 29  ASP A CB    1 
+ATOM   1603 C CG    . ASP C 3 35  ? 43.114  39.698 103.093 1.00 37.01  ? ? ? ? ? ? 29  ASP A CG    1 
+ATOM   1604 O OD1   . ASP C 3 35  ? 42.602  38.562 103.080 1.00 40.70  ? ? ? ? ? ? 29  ASP A OD1   1 
+ATOM   1605 O OD2   . ASP C 3 35  ? 42.882  40.555 102.217 1.00 35.81  ? ? ? ? ? ? 29  ASP A OD2   1 
+ATOM   1606 N N     . MET C 3 36  ? 45.632  40.326 106.794 1.00 41.68  ? ? ? ? ? ? 30  MET A N     1 
+ATOM   1607 C CA    . MET C 3 36  ? 46.822  40.715 107.553 1.00 42.49  ? ? ? ? ? ? 30  MET A CA    1 
+ATOM   1608 C C     . MET C 3 36  ? 47.296  39.617 108.497 1.00 42.47  ? ? ? ? ? ? 30  MET A C     1 
+ATOM   1609 O O     . MET C 3 36  ? 48.479  39.289 108.545 1.00 40.85  ? ? ? ? ? ? 30  MET A O     1 
+ATOM   1610 C CB    . MET C 3 36  ? 46.505  41.955 108.384 1.00 46.85  ? ? ? ? ? ? 30  MET A CB    1 
+ATOM   1611 C CG    . MET C 3 36  ? 47.385  43.146 108.114 1.00 55.88  ? ? ? ? ? ? 30  MET A CG    1 
+ATOM   1612 S SD    . MET C 3 36  ? 46.545  44.685 108.549 1.00 66.17  ? ? ? ? ? ? 30  MET A SD    1 
+ATOM   1613 C CE    . MET C 3 36  ? 47.164  44.948 110.224 1.00 63.15  ? ? ? ? ? ? 30  MET A CE    1 
+ATOM   1614 N N     . PHE C 3 37  ? 46.368  39.031 109.241 1.00 37.87  ? ? ? ? ? ? 31  PHE A N     1 
+ATOM   1615 C CA    . PHE C 3 37  ? 46.757  38.003 110.182 1.00 37.09  ? ? ? ? ? ? 31  PHE A CA    1 
+ATOM   1616 C C     . PHE C 3 37  ? 47.146  36.692 109.517 1.00 41.21  ? ? ? ? ? ? 31  PHE A C     1 
+ATOM   1617 O O     . PHE C 3 37  ? 48.004  35.962 110.023 1.00 39.80  ? ? ? ? ? ? 31  PHE A O     1 
+ATOM   1618 C CB    . PHE C 3 37  ? 45.683  37.800 111.251 1.00 40.15  ? ? ? ? ? ? 31  PHE A CB    1 
+ATOM   1619 C CG    . PHE C 3 37  ? 46.093  36.845 112.331 1.00 44.38  ? ? ? ? ? ? 31  PHE A CG    1 
+ATOM   1620 C CD1   . PHE C 3 37  ? 46.525  37.312 113.552 1.00 46.97  ? ? ? ? ? ? 31  PHE A CD1   1 
+ATOM   1621 C CD2   . PHE C 3 37  ? 46.095  35.476 112.090 1.00 49.38  ? ? ? ? ? ? 31  PHE A CD2   1 
+ATOM   1622 C CE1   . PHE C 3 37  ? 46.940  36.429 114.527 1.00 50.90  ? ? ? ? ? ? 31  PHE A CE1   1 
+ATOM   1623 C CE2   . PHE C 3 37  ? 46.504  34.585 113.061 1.00 50.33  ? ? ? ? ? ? 31  PHE A CE2   1 
+ATOM   1624 C CZ    . PHE C 3 37  ? 46.902  35.062 114.277 1.00 49.87  ? ? ? ? ? ? 31  PHE A CZ    1 
+ATOM   1625 N N     . ARG C 3 38  ? 46.506  36.401 108.386 1.00 35.42  ? ? ? ? ? ? 32  ARG A N     1 
+ATOM   1626 C CA    . ARG C 3 38  ? 46.743  35.155 107.666 1.00 31.76  ? ? ? ? ? ? 32  ARG A CA    1 
+ATOM   1627 C C     . ARG C 3 38  ? 48.141  35.119 107.077 1.00 31.72  ? ? ? ? ? ? 32  ARG A C     1 
+ATOM   1628 O O     . ARG C 3 38  ? 48.799  34.077 107.035 1.00 29.56  ? ? ? ? ? ? 32  ARG A O     1 
+ATOM   1629 C CB    . ARG C 3 38  ? 45.744  34.953 106.530 1.00 30.96  ? ? ? ? ? ? 32  ARG A CB    1 
+ATOM   1630 C CG    . ARG C 3 38  ? 46.038  33.668 105.774 1.00 21.87  ? ? ? ? ? ? 32  ARG A CG    1 
+ATOM   1631 C CD    . ARG C 3 38  ? 45.055  33.427 104.658 1.00 21.43  ? ? ? ? ? ? 32  ARG A CD    1 
+ATOM   1632 N NE    . ARG C 3 38  ? 44.797  34.618 103.850 1.00 30.70  ? ? ? ? ? ? 32  ARG A NE    1 
+ATOM   1633 C CZ    . ARG C 3 38  ? 43.890  34.644 102.878 1.00 39.02  ? ? ? ? ? ? 32  ARG A CZ    1 
+ATOM   1634 N NH1   . ARG C 3 38  ? 43.180  33.556 102.615 1.00 29.95  ? ? ? ? ? ? 32  ARG A NH1   1 
+ATOM   1635 N NH2   . ARG C 3 38  ? 43.681  35.738 102.162 1.00 23.93  ? ? ? ? ? ? 32  ARG A NH2   1 
+ATOM   1636 N N     . ASP C 3 39  ? 48.556  36.275 106.578 1.00 27.63  ? ? ? ? ? ? 33  ASP A N     1 
+ATOM   1637 C CA    . ASP C 3 39  ? 49.877  36.413 105.990 1.00 27.48  ? ? ? ? ? ? 33  ASP A CA    1 
+ATOM   1638 C C     . ASP C 3 39  ? 50.684  37.380 106.855 1.00 34.95  ? ? ? ? ? ? 33  ASP A C     1 
+ATOM   1639 O O     . ASP C 3 39  ? 51.229  38.374 106.372 1.00 33.52  ? ? ? ? ? ? 33  ASP A O     1 
+ATOM   1640 C CB    . ASP C 3 39  ? 49.781  36.903 104.544 1.00 26.28  ? ? ? ? ? ? 33  ASP A CB    1 
+ATOM   1641 C CG    . ASP C 3 39  ? 49.330  35.807 103.584 1.00 30.48  ? ? ? ? ? ? 33  ASP A CG    1 
+ATOM   1642 O OD1   . ASP C 3 39  ? 49.605  34.613 103.827 1.00 30.05  ? ? ? ? ? ? 33  ASP A OD1   1 
+ATOM   1643 O OD2   . ASP C 3 39  ? 48.663  36.136 102.583 1.00 27.81  ? ? ? ? ? ? 33  ASP A OD2   1 
+ATOM   1644 N N     . ARG C 3 40  ? 50.714  37.101 108.156 1.00 36.00  ? ? ? ? ? ? 34  ARG A N     1 
+ATOM   1645 C CA    . ARG C 3 40  ? 51.460  37.938 109.093 1.00 36.46  ? ? ? ? ? ? 34  ARG A CA    1 
+ATOM   1646 C C     . ARG C 3 40  ? 52.963  37.737 108.907 1.00 35.89  ? ? ? ? ? ? 34  ARG A C     1 
+ATOM   1647 O O     . ARG C 3 40  ? 53.748  38.631 109.226 1.00 35.30  ? ? ? ? ? ? 34  ARG A O     1 
+ATOM   1648 C CB    . ARG C 3 40  ? 51.055  37.652 110.541 1.00 36.48  ? ? ? ? ? ? 34  ARG A CB    1 
+ATOM   1649 C CG    . ARG C 3 40  ? 51.067  36.178 110.906 1.00 38.38  ? ? ? ? ? ? 34  ARG A CG    1 
+ATOM   1650 C CD    . ARG C 3 40  ? 50.155  35.878 112.098 1.00 43.57  ? ? ? ? ? ? 34  ARG A CD    1 
+ATOM   1651 N NE    . ARG C 3 40  ? 50.368  34.533 112.620 1.00 53.53  ? ? ? ? ? ? 34  ARG A NE    1 
+ATOM   1652 C CZ    . ARG C 3 40  ? 49.953  33.435 112.007 1.00 73.83  ? ? ? ? ? ? 34  ARG A CZ    1 
+ATOM   1653 N NH1   . ARG C 3 40  ? 49.274  33.538 110.874 1.00 64.08  ? ? ? ? ? ? 34  ARG A NH1   1 
+ATOM   1654 N NH2   . ARG C 3 40  ? 50.184  32.249 112.537 1.00 73.52  ? ? ? ? ? ? 34  ARG A NH2   1 
+ATOM   1655 N N     . GLN C 3 41  ? 53.334  36.562 108.399 1.00 29.25  ? ? ? ? ? ? 35  GLN A N     1 
+ATOM   1656 C CA    . GLN C 3 41  ? 54.713  36.195 108.098 1.00 30.17  ? ? ? ? ? ? 35  GLN A CA    1 
+ATOM   1657 C C     . GLN C 3 41  ? 55.254  37.002 106.930 1.00 40.23  ? ? ? ? ? ? 35  GLN A C     1 
+ATOM   1658 O O     . GLN C 3 41  ? 56.294  36.678 106.363 1.00 46.24  ? ? ? ? ? ? 35  GLN A O     1 
+ATOM   1659 C CB    . GLN C 3 41  ? 54.753  34.739 107.668 1.00 32.19  ? ? ? ? ? ? 35  GLN A CB    1 
+ATOM   1660 C CG    . GLN C 3 41  ? 54.730  33.775 108.813 1.00 62.79  ? ? ? ? ? ? 35  GLN A CG    1 
+ATOM   1661 C CD    . GLN C 3 41  ? 55.656  32.617 108.573 1.00 98.68  ? ? ? ? ? ? 35  GLN A CD    1 
+ATOM   1662 O OE1   . GLN C 3 41  ? 56.739  32.780 108.016 1.00 100.00 ? ? ? ? ? ? 35  GLN A OE1   1 
+ATOM   1663 N NE2   . GLN C 3 41  ? 55.235  31.428 108.976 1.00 98.74  ? ? ? ? ? ? 35  GLN A NE2   1 
+ATOM   1664 N N     . ALA C 3 42  ? 54.509  38.030 106.553 1.00 35.68  ? ? ? ? ? ? 36  ALA A N     1 
+ATOM   1665 C CA    . ALA C 3 42  ? 54.880  38.914 105.458 1.00 35.30  ? ? ? ? ? ? 36  ALA A CA    1 
+ATOM   1666 C C     . ALA C 3 42  ? 55.827  39.954 106.040 1.00 41.40  ? ? ? ? ? ? 36  ALA A C     1 
+ATOM   1667 O O     . ALA C 3 42  ? 56.600  40.597 105.331 1.00 39.60  ? ? ? ? ? ? 36  ALA A O     1 
+ATOM   1668 C CB    . ALA C 3 42  ? 53.632  39.591 104.898 1.00 35.75  ? ? ? ? ? ? 36  ALA A CB    1 
+ATOM   1669 N N     . PHE C 3 43  ? 55.759  40.087 107.359 1.00 40.69  ? ? ? ? ? ? 37  PHE A N     1 
+ATOM   1670 C CA    . PHE C 3 43  ? 56.595  41.015 108.098 1.00 39.55  ? ? ? ? ? ? 37  PHE A CA    1 
+ATOM   1671 C C     . PHE C 3 43  ? 57.435  40.342 109.164 1.00 42.86  ? ? ? ? ? ? 37  PHE A C     1 
+ATOM   1672 O O     . PHE C 3 43  ? 57.192  39.199 109.563 1.00 41.10  ? ? ? ? ? ? 37  PHE A O     1 
+ATOM   1673 C CB    . PHE C 3 43  ? 55.751  42.148 108.666 1.00 41.83  ? ? ? ? ? ? 37  PHE A CB    1 
+ATOM   1674 C CG    . PHE C 3 43  ? 54.962  42.846 107.612 1.00 46.32  ? ? ? ? ? ? 37  PHE A CG    1 
+ATOM   1675 C CD1   . PHE C 3 43  ? 53.628  42.523 107.394 1.00 51.17  ? ? ? ? ? ? 37  PHE A CD1   1 
+ATOM   1676 C CD2   . PHE C 3 43  ? 55.594  43.706 106.736 1.00 51.56  ? ? ? ? ? ? 37  PHE A CD2   1 
+ATOM   1677 C CE1   . PHE C 3 43  ? 52.910  43.106 106.369 1.00 54.17  ? ? ? ? ? ? 37  PHE A CE1   1 
+ATOM   1678 C CE2   . PHE C 3 43  ? 54.882  44.302 105.719 1.00 54.87  ? ? ? ? ? ? 37  PHE A CE2   1 
+ATOM   1679 C CZ    . PHE C 3 43  ? 53.536  44.003 105.534 1.00 53.35  ? ? ? ? ? ? 37  PHE A CZ    1 
+ATOM   1680 N N     . SER C 3 44  ? 58.463  41.069 109.576 1.00 42.26  ? ? ? ? ? ? 38  SER A N     1 
+ATOM   1681 C CA    . SER C 3 44  ? 59.361  40.586 110.604 1.00 42.20  ? ? ? ? ? ? 38  SER A CA    1 
+ATOM   1682 C C     . SER C 3 44  ? 58.548  40.738 111.890 1.00 42.55  ? ? ? ? ? ? 38  SER A C     1 
+ATOM   1683 O O     . SER C 3 44  ? 57.651  41.579 111.964 1.00 35.71  ? ? ? ? ? ? 38  SER A O     1 
+ATOM   1684 C CB    . SER C 3 44  ? 60.630  41.452 110.636 1.00 44.40  ? ? ? ? ? ? 38  SER A CB    1 
+ATOM   1685 O OG    . SER C 3 44  ? 60.355  42.757 111.103 1.00 57.01  ? ? ? ? ? ? 38  SER A OG    1 
+ATOM   1686 N N     . GLU C 3 45  ? 58.861  39.926 112.886 1.00 41.09  ? ? ? ? ? ? 39  GLU A N     1 
+ATOM   1687 C CA    . GLU C 3 45  ? 58.178  40.021 114.163 1.00 41.44  ? ? ? ? ? ? 39  GLU A CA    1 
+ATOM   1688 C C     . GLU C 3 45  ? 58.559  41.333 114.856 1.00 42.62  ? ? ? ? ? ? 39  GLU A C     1 
+ATOM   1689 O O     . GLU C 3 45  ? 57.770  41.861 115.635 1.00 43.29  ? ? ? ? ? ? 39  GLU A O     1 
+ATOM   1690 C CB    . GLU C 3 45  ? 58.410  38.783 115.034 1.00 44.21  ? ? ? ? ? ? 39  GLU A CB    1 
+ATOM   1691 C CG    . GLU C 3 45  ? 59.869  38.427 115.277 1.00 70.07  ? ? ? ? ? ? 39  GLU A CG    1 
+ATOM   1692 C CD    . GLU C 3 45  ? 60.047  37.347 116.337 1.00 100.00 ? ? ? ? ? ? 39  GLU A CD    1 
+ATOM   1693 O OE1   . GLU C 3 45  ? 59.680  37.594 117.505 1.00 100.00 ? ? ? ? ? ? 39  GLU A OE1   1 
+ATOM   1694 O OE2   . GLU C 3 45  ? 60.556  36.251 116.008 1.00 100.00 ? ? ? ? ? ? 39  GLU A OE2   1 
+ATOM   1695 N N     . HIS C 3 46  ? 59.711  41.905 114.510 1.00 36.38  ? ? ? ? ? ? 40  HIS A N     1 
+ATOM   1696 C CA    . HIS C 3 46  ? 60.126  43.188 115.083 1.00 37.29  ? ? ? ? ? ? 40  HIS A CA    1 
+ATOM   1697 C C     . HIS C 3 46  ? 59.148  44.257 114.606 1.00 40.02  ? ? ? ? ? ? 40  HIS A C     1 
+ATOM   1698 O O     . HIS C 3 46  ? 58.830  45.203 115.327 1.00 43.45  ? ? ? ? ? ? 40  HIS A O     1 
+ATOM   1699 C CB    . HIS C 3 46  ? 61.508  43.620 114.531 1.00 41.32  ? ? ? ? ? ? 40  HIS A CB    1 
+ATOM   1700 C CG    . HIS C 3 46  ? 62.690  42.972 115.186 1.00 46.50  ? ? ? ? ? ? 40  HIS A CG    1 
+ATOM   1701 N ND1   . HIS C 3 46  ? 63.010  43.148 116.516 1.00 48.62  ? ? ? ? ? ? 40  HIS A ND1   1 
+ATOM   1702 C CD2   . HIS C 3 46  ? 63.674  42.201 114.666 1.00 49.46  ? ? ? ? ? ? 40  HIS A CD2   1 
+ATOM   1703 C CE1   . HIS C 3 46  ? 64.125  42.493 116.789 1.00 48.88  ? ? ? ? ? ? 40  HIS A CE1   1 
+ATOM   1704 N NE2   . HIS C 3 46  ? 64.544  41.903 115.684 1.00 49.61  ? ? ? ? ? ? 40  HIS A NE2   1 
+ATOM   1705 N N     . THR C 3 47  ? 58.738  44.127 113.346 1.00 35.37  ? ? ? ? ? ? 41  THR A N     1 
+ATOM   1706 C CA    . THR C 3 47  ? 57.835  45.074 112.689 1.00 34.43  ? ? ? ? ? ? 41  THR A CA    1 
+ATOM   1707 C C     . THR C 3 47  ? 56.479  45.043 113.362 1.00 37.57  ? ? ? ? ? ? 41  THR A C     1 
+ATOM   1708 O O     . THR C 3 47  ? 55.890  46.083 113.659 1.00 39.27  ? ? ? ? ? ? 41  THR A O     1 
+ATOM   1709 C CB    . THR C 3 47  ? 57.620  44.737 111.198 1.00 42.89  ? ? ? ? ? ? 41  THR A CB    1 
+ATOM   1710 O OG1   . THR C 3 47  ? 58.875  44.435 110.576 1.00 37.68  ? ? ? ? ? ? 41  THR A OG1   1 
+ATOM   1711 C CG2   . THR C 3 47  ? 56.979  45.918 110.485 1.00 36.48  ? ? ? ? ? ? 41  THR A CG2   1 
+ATOM   1712 N N     . TRP C 3 48  ? 55.998  43.827 113.598 1.00 36.10  ? ? ? ? ? ? 42  TRP A N     1 
+ATOM   1713 C CA    . TRP C 3 48  ? 54.718  43.610 114.265 1.00 37.08  ? ? ? ? ? ? 42  TRP A CA    1 
+ATOM   1714 C C     . TRP C 3 48  ? 54.770  44.200 115.662 1.00 35.45  ? ? ? ? ? ? 42  TRP A C     1 
+ATOM   1715 O O     . TRP C 3 48  ? 53.836  44.854 116.113 1.00 35.26  ? ? ? ? ? ? 42  TRP A O     1 
+ATOM   1716 C CB    . TRP C 3 48  ? 54.406  42.117 114.360 1.00 37.55  ? ? ? ? ? ? 42  TRP A CB    1 
+ATOM   1717 C CG    . TRP C 3 48  ? 53.801  41.577 113.108 1.00 39.95  ? ? ? ? ? ? 42  TRP A CG    1 
+ATOM   1718 C CD1   . TRP C 3 48  ? 54.342  40.647 112.264 1.00 43.36  ? ? ? ? ? ? 42  TRP A CD1   1 
+ATOM   1719 C CD2   . TRP C 3 48  ? 52.556  41.966 112.527 1.00 40.39  ? ? ? ? ? ? 42  TRP A CD2   1 
+ATOM   1720 N NE1   . TRP C 3 48  ? 53.500  40.421 111.204 1.00 42.68  ? ? ? ? ? ? 42  TRP A NE1   1 
+ATOM   1721 C CE2   . TRP C 3 48  ? 52.397  41.224 111.343 1.00 44.55  ? ? ? ? ? ? 42  TRP A CE2   1 
+ATOM   1722 C CE3   . TRP C 3 48  ? 51.558  42.874 112.892 1.00 42.97  ? ? ? ? ? ? 42  TRP A CE3   1 
+ATOM   1723 C CZ2   . TRP C 3 48  ? 51.270  41.343 110.537 1.00 44.04  ? ? ? ? ? ? 42  TRP A CZ2   1 
+ATOM   1724 C CZ3   . TRP C 3 48  ? 50.450  43.004 112.079 1.00 44.36  ? ? ? ? ? ? 42  TRP A CZ3   1 
+ATOM   1725 C CH2   . TRP C 3 48  ? 50.311  42.240 110.921 1.00 44.73  ? ? ? ? ? ? 42  TRP A CH2   1 
+ATOM   1726 N N     . LYS C 3 49  ? 55.884  43.962 116.338 1.00 33.30  ? ? ? ? ? ? 43  LYS A N     1 
+ATOM   1727 C CA    . LYS C 3 49  ? 56.100  44.488 117.678 1.00 34.56  ? ? ? ? ? ? 43  LYS A CA    1 
+ATOM   1728 C C     . LYS C 3 49  ? 55.943  46.014 117.664 1.00 36.41  ? ? ? ? ? ? 43  LYS A C     1 
+ATOM   1729 O O     . LYS C 3 49  ? 55.216  46.599 118.473 1.00 37.57  ? ? ? ? ? ? 43  LYS A O     1 
+ATOM   1730 C CB    . LYS C 3 49  ? 57.471  44.039 118.202 1.00 37.98  ? ? ? ? ? ? 43  LYS A CB    1 
+ATOM   1731 C CG    . LYS C 3 49  ? 57.575  42.521 118.381 1.00 49.63  ? ? ? ? ? ? 43  LYS A CG    1 
+ATOM   1732 C CD    . LYS C 3 49  ? 56.798  42.069 119.605 1.00 60.43  ? ? ? ? ? ? 43  LYS A CD    1 
+ATOM   1733 C CE    . LYS C 3 49  ? 55.704  41.069 119.275 1.00 74.75  ? ? ? ? ? ? 43  LYS A CE    1 
+ATOM   1734 N NZ    . LYS C 3 49  ? 54.852  40.863 120.482 1.00 99.28  ? ? ? ? ? ? 43  LYS A NZ    1 
+ATOM   1735 N N     . MET C 3 50  ? 56.598  46.660 116.714 1.00 29.03  ? ? ? ? ? ? 44  MET A N     1 
+ATOM   1736 C CA    . MET C 3 50  ? 56.454  48.106 116.612 1.00 29.91  ? ? ? ? ? ? 44  MET A CA    1 
+ATOM   1737 C C     . MET C 3 50  ? 55.009  48.530 116.277 1.00 37.85  ? ? ? ? ? ? 44  MET A C     1 
+ATOM   1738 O O     . MET C 3 50  ? 54.488  49.482 116.860 1.00 37.67  ? ? ? ? ? ? 44  MET A O     1 
+ATOM   1739 C CB    . MET C 3 50  ? 57.489  48.710 115.657 1.00 32.51  ? ? ? ? ? ? 44  MET A CB    1 
+ATOM   1740 C CG    . MET C 3 50  ? 58.892  48.816 116.253 1.00 36.81  ? ? ? ? ? ? 44  MET A CG    1 
+ATOM   1741 S SD    . MET C 3 50  ? 58.883  49.292 118.003 1.00 41.81  ? ? ? ? ? ? 44  MET A SD    1 
+ATOM   1742 C CE    . MET C 3 50  ? 58.542  50.993 117.901 1.00 37.27  ? ? ? ? ? ? 44  MET A CE    1 
+ATOM   1743 N N     . LEU C 3 51  ? 54.358  47.822 115.351 1.00 33.75  ? ? ? ? ? ? 45  LEU A N     1 
+ATOM   1744 C CA    . LEU C 3 51  ? 52.965  48.125 115.009 1.00 31.84  ? ? ? ? ? ? 45  LEU A CA    1 
+ATOM   1745 C C     . LEU C 3 51  ? 52.090  48.026 116.260 1.00 31.52  ? ? ? ? ? ? 45  LEU A C     1 
+ATOM   1746 O O     . LEU C 3 51  ? 51.363  48.958 116.604 1.00 31.78  ? ? ? ? ? ? 45  LEU A O     1 
+ATOM   1747 C CB    . LEU C 3 51  ? 52.431  47.163 113.937 1.00 33.19  ? ? ? ? ? ? 45  LEU A CB    1 
+ATOM   1748 C CG    . LEU C 3 51  ? 50.922  47.188 113.645 1.00 35.20  ? ? ? ? ? ? 45  LEU A CG    1 
+ATOM   1749 C CD1   . LEU C 3 51  ? 50.530  48.449 112.891 1.00 31.34  ? ? ? ? ? ? 45  LEU A CD1   1 
+ATOM   1750 C CD2   . LEU C 3 51  ? 50.460  45.927 112.918 1.00 34.47  ? ? ? ? ? ? 45  LEU A CD2   1 
+ATOM   1751 N N     . LEU C 3 52  ? 52.149  46.890 116.940 1.00 28.50  ? ? ? ? ? ? 46  LEU A N     1 
+ATOM   1752 C CA    . LEU C 3 52  ? 51.356  46.723 118.152 1.00 32.69  ? ? ? ? ? ? 46  LEU A CA    1 
+ATOM   1753 C C     . LEU C 3 52  ? 51.599  47.863 119.154 1.00 40.33  ? ? ? ? ? ? 46  LEU A C     1 
+ATOM   1754 O O     . LEU C 3 52  ? 50.669  48.427 119.754 1.00 38.77  ? ? ? ? ? ? 46  LEU A O     1 
+ATOM   1755 C CB    . LEU C 3 52  ? 51.675  45.361 118.781 1.00 34.34  ? ? ? ? ? ? 46  LEU A CB    1 
+ATOM   1756 C CG    . LEU C 3 52  ? 50.804  44.136 118.466 1.00 40.22  ? ? ? ? ? ? 46  LEU A CG    1 
+ATOM   1757 C CD1   . LEU C 3 52  ? 50.103  44.241 117.119 1.00 40.35  ? ? ? ? ? ? 46  LEU A CD1   1 
+ATOM   1758 C CD2   . LEU C 3 52  ? 51.649  42.875 118.525 1.00 41.01  ? ? ? ? ? ? 46  LEU A CD2   1 
+ATOM   1759 N N     . SER C 3 53  ? 52.874  48.194 119.336 1.00 37.56  ? ? ? ? ? ? 47  SER A N     1 
+ATOM   1760 C CA    . SER C 3 53  ? 53.282  49.232 120.269 1.00 35.51  ? ? ? ? ? ? 47  SER A CA    1 
+ATOM   1761 C C     . SER C 3 53  ? 52.644  50.580 119.924 1.00 38.58  ? ? ? ? ? ? 47  SER A C     1 
+ATOM   1762 O O     . SER C 3 53  ? 52.134  51.279 120.802 1.00 39.18  ? ? ? ? ? ? 47  SER A O     1 
+ATOM   1763 C CB    . SER C 3 53  ? 54.819  49.304 120.326 1.00 37.62  ? ? ? ? ? ? 47  SER A CB    1 
+ATOM   1764 O OG    . SER C 3 53  ? 55.300  50.371 121.149 1.00 39.11  ? ? ? ? ? ? 47  SER A OG    1 
+ATOM   1765 N N     . VAL C 3 54  ? 52.688  50.964 118.653 1.00 36.17  ? ? ? ? ? ? 48  VAL A N     1 
+ATOM   1766 C CA    . VAL C 3 54  ? 52.130  52.259 118.273 1.00 35.79  ? ? ? ? ? ? 48  VAL A CA    1 
+ATOM   1767 C C     . VAL C 3 54  ? 50.625  52.327 118.491 1.00 41.79  ? ? ? ? ? ? 48  VAL A C     1 
+ATOM   1768 O O     . VAL C 3 54  ? 50.089  53.354 118.909 1.00 40.95  ? ? ? ? ? ? 48  VAL A O     1 
+ATOM   1769 C CB    . VAL C 3 54  ? 52.402  52.590 116.811 1.00 37.29  ? ? ? ? ? ? 48  VAL A CB    1 
+ATOM   1770 C CG1   . VAL C 3 54  ? 51.587  53.819 116.385 1.00 35.31  ? ? ? ? ? ? 48  VAL A CG1   1 
+ATOM   1771 C CG2   . VAL C 3 54  ? 53.900  52.750 116.565 1.00 35.42  ? ? ? ? ? ? 48  VAL A CG2   1 
+ATOM   1772 N N     . CYS C 3 55  ? 49.958  51.215 118.189 1.00 40.65  ? ? ? ? ? ? 49  CYS A N     1 
+ATOM   1773 C CA    . CYS C 3 55  ? 48.512  51.103 118.337 1.00 44.33  ? ? ? ? ? ? 49  CYS A CA    1 
+ATOM   1774 C C     . CYS C 3 55  ? 48.124  51.248 119.802 1.00 48.47  ? ? ? ? ? ? 49  CYS A C     1 
+ATOM   1775 O O     . CYS C 3 55  ? 47.211  51.999 120.147 1.00 47.45  ? ? ? ? ? ? 49  CYS A O     1 
+ATOM   1776 C CB    . CYS C 3 55  ? 48.018  49.766 117.781 1.00 46.11  ? ? ? ? ? ? 49  CYS A CB    1 
+ATOM   1777 S SG    . CYS C 3 55  ? 48.161  49.641 115.965 1.00 50.23  ? ? ? ? ? ? 49  CYS A SG    1 
+ATOM   1778 N N     . ARG C 3 56  ? 48.840  50.534 120.667 1.00 47.21  ? ? ? ? ? ? 50  ARG A N     1 
+ATOM   1779 C CA    . ARG C 3 56  ? 48.581  50.613 122.102 1.00 46.03  ? ? ? ? ? ? 50  ARG A CA    1 
+ATOM   1780 C C     . ARG C 3 56  ? 48.694  52.058 122.548 1.00 45.94  ? ? ? ? ? ? 50  ARG A C     1 
+ATOM   1781 O O     . ARG C 3 56  ? 47.836  52.565 123.266 1.00 46.26  ? ? ? ? ? ? 50  ARG A O     1 
+ATOM   1782 C CB    . ARG C 3 56  ? 49.581  49.759 122.888 1.00 41.78  ? ? ? ? ? ? 50  ARG A CB    1 
+ATOM   1783 C CG    . ARG C 3 56  ? 49.235  48.282 122.960 1.00 39.22  ? ? ? ? ? ? 50  ARG A CG    1 
+ATOM   1784 C CD    . ARG C 3 56  ? 49.993  47.626 124.102 1.00 52.63  ? ? ? ? ? ? 50  ARG A CD    1 
+ATOM   1785 N NE    . ARG C 3 56  ? 51.423  47.543 123.821 1.00 52.41  ? ? ? ? ? ? 50  ARG A NE    1 
+ATOM   1786 C CZ    . ARG C 3 56  ? 51.984  46.536 123.162 1.00 63.80  ? ? ? ? ? ? 50  ARG A CZ    1 
+ATOM   1787 N NH1   . ARG C 3 56  ? 51.238  45.538 122.707 1.00 58.82  ? ? ? ? ? ? 50  ARG A NH1   1 
+ATOM   1788 N NH2   . ARG C 3 56  ? 53.286  46.549 122.929 1.00 41.95  ? ? ? ? ? ? 50  ARG A NH2   1 
+ATOM   1789 N N     . SER C 3 57  ? 49.751  52.724 122.105 1.00 42.45  ? ? ? ? ? ? 51  SER A N     1 
+ATOM   1790 C CA    . SER C 3 57  ? 49.951  54.112 122.488 1.00 43.02  ? ? ? ? ? ? 51  SER A CA    1 
+ATOM   1791 C C     . SER C 3 57  ? 48.846  55.011 121.926 1.00 45.00  ? ? ? ? ? ? 51  SER A C     1 
+ATOM   1792 O O     . SER C 3 57  ? 48.324  55.896 122.619 1.00 41.22  ? ? ? ? ? ? 51  SER A O     1 
+ATOM   1793 C CB    . SER C 3 57  ? 51.331  54.586 122.031 1.00 47.77  ? ? ? ? ? ? 51  SER A CB    1 
+ATOM   1794 O OG    . SER C 3 57  ? 51.261  55.909 121.529 1.00 67.75  ? ? ? ? ? ? 51  SER A OG    1 
+ATOM   1795 N N     . TRP C 3 58  ? 48.511  54.778 120.663 1.00 41.21  ? ? ? ? ? ? 52  TRP A N     1 
+ATOM   1796 C CA    . TRP C 3 58  ? 47.478  55.552 120.001 1.00 39.70  ? ? ? ? ? ? 52  TRP A CA    1 
+ATOM   1797 C C     . TRP C 3 58  ? 46.097  55.322 120.638 1.00 47.60  ? ? ? ? ? ? 52  TRP A C     1 
+ATOM   1798 O O     . TRP C 3 58  ? 45.348  56.273 120.830 1.00 49.80  ? ? ? ? ? ? 52  TRP A O     1 
+ATOM   1799 C CB    . TRP C 3 58  ? 47.504  55.279 118.489 1.00 36.53  ? ? ? ? ? ? 52  TRP A CB    1 
+ATOM   1800 C CG    . TRP C 3 58  ? 46.247  55.629 117.769 1.00 36.10  ? ? ? ? ? ? 52  TRP A CG    1 
+ATOM   1801 C CD1   . TRP C 3 58  ? 45.362  54.759 117.216 1.00 38.21  ? ? ? ? ? ? 52  TRP A CD1   1 
+ATOM   1802 C CD2   . TRP C 3 58  ? 45.733  56.943 117.517 1.00 35.66  ? ? ? ? ? ? 52  TRP A CD2   1 
+ATOM   1803 N NE1   . TRP C 3 58  ? 44.307  55.442 116.660 1.00 37.54  ? ? ? ? ? ? 52  TRP A NE1   1 
+ATOM   1804 C CE2   . TRP C 3 58  ? 44.511  56.786 116.831 1.00 39.39  ? ? ? ? ? ? 52  TRP A CE2   1 
+ATOM   1805 C CE3   . TRP C 3 58  ? 46.179  58.231 117.808 1.00 36.37  ? ? ? ? ? ? 52  TRP A CE3   1 
+ATOM   1806 C CZ2   . TRP C 3 58  ? 43.732  57.870 116.429 1.00 38.89  ? ? ? ? ? ? 52  TRP A CZ2   1 
+ATOM   1807 C CZ3   . TRP C 3 58  ? 45.404  59.302 117.420 1.00 38.57  ? ? ? ? ? ? 52  TRP A CZ3   1 
+ATOM   1808 C CH2   . TRP C 3 58  ? 44.197  59.119 116.734 1.00 39.56  ? ? ? ? ? ? 52  TRP A CH2   1 
+ATOM   1809 N N     . ALA C 3 59  ? 45.779  54.064 120.967 1.00 45.78  ? ? ? ? ? ? 53  ALA A N     1 
+ATOM   1810 C CA    . ALA C 3 59  ? 44.518  53.637 121.592 1.00 45.97  ? ? ? ? ? ? 53  ALA A CA    1 
+ATOM   1811 C C     . ALA C 3 59  ? 44.295  54.250 122.985 1.00 50.37  ? ? ? ? ? ? 53  ALA A C     1 
+ATOM   1812 O O     . ALA C 3 59  ? 43.205  54.753 123.300 1.00 48.36  ? ? ? ? ? ? 53  ALA A O     1 
+ATOM   1813 C CB    . ALA C 3 59  ? 44.485  52.105 121.699 1.00 46.61  ? ? ? ? ? ? 53  ALA A CB    1 
+ATOM   1814 N N     . ALA C 3 60  ? 45.355  54.218 123.790 1.00 45.09  ? ? ? ? ? ? 54  ALA A N     1 
+ATOM   1815 C CA    . ALA C 3 60  ? 45.328  54.729 125.153 1.00 45.16  ? ? ? ? ? ? 54  ALA A CA    1 
+ATOM   1816 C C     . ALA C 3 60  ? 45.121  56.239 125.240 1.00 52.87  ? ? ? ? ? ? 54  ALA A C     1 
+ATOM   1817 O O     . ALA C 3 60  ? 44.432  56.748 126.125 1.00 54.96  ? ? ? ? ? ? 54  ALA A O     1 
+ATOM   1818 C CB    . ALA C 3 60  ? 46.594  54.319 125.859 1.00 45.45  ? ? ? ? ? ? 54  ALA A CB    1 
+ATOM   1819 N N     . TRP C 3 61  ? 45.707  56.929 124.261 1.00 48.86  ? ? ? ? ? ? 55  TRP A N     1 
+ATOM   1820 C CA    . TRP C 3 61  ? 45.634  58.386 124.112 1.00 46.24  ? ? ? ? ? ? 55  TRP A CA    1 
+ATOM   1821 C C     . TRP C 3 61  ? 44.268  58.793 123.584 1.00 46.62  ? ? ? ? ? ? 55  TRP A C     1 
+ATOM   1822 O O     . TRP C 3 61  ? 43.745  59.858 123.909 1.00 44.10  ? ? ? ? ? ? 55  TRP A O     1 
+ATOM   1823 C CB    . TRP C 3 61  ? 46.692  58.899 123.133 1.00 43.94  ? ? ? ? ? ? 55  TRP A CB    1 
+ATOM   1824 C CG    . TRP C 3 61  ? 46.543  60.365 122.879 1.00 43.98  ? ? ? ? ? ? 55  TRP A CG    1 
+ATOM   1825 C CD1   . TRP C 3 61  ? 47.204  61.360 123.532 1.00 46.78  ? ? ? ? ? ? 55  TRP A CD1   1 
+ATOM   1826 C CD2   . TRP C 3 61  ? 45.656  61.009 121.951 1.00 43.78  ? ? ? ? ? ? 55  TRP A CD2   1 
+ATOM   1827 N NE1   . TRP C 3 61  ? 46.821  62.581 123.048 1.00 45.72  ? ? ? ? ? ? 55  TRP A NE1   1 
+ATOM   1828 C CE2   . TRP C 3 61  ? 45.870  62.398 122.074 1.00 47.28  ? ? ? ? ? ? 55  TRP A CE2   1 
+ATOM   1829 C CE3   . TRP C 3 61  ? 44.731  60.553 121.007 1.00 45.65  ? ? ? ? ? ? 55  TRP A CE3   1 
+ATOM   1830 C CZ2   . TRP C 3 61  ? 45.186  63.341 121.296 1.00 46.61  ? ? ? ? ? ? 55  TRP A CZ2   1 
+ATOM   1831 C CZ3   . TRP C 3 61  ? 44.049  61.500 120.228 1.00 47.38  ? ? ? ? ? ? 55  TRP A CZ3   1 
+ATOM   1832 C CH2   . TRP C 3 61  ? 44.279  62.877 120.383 1.00 47.60  ? ? ? ? ? ? 55  TRP A CH2   1 
+ATOM   1833 N N     . CYS C 3 62  ? 43.689  57.929 122.761 1.00 43.56  ? ? ? ? ? ? 56  CYS A N     1 
+ATOM   1834 C CA    . CYS C 3 62  ? 42.368  58.192 122.228 1.00 43.73  ? ? ? ? ? ? 56  CYS A CA    1 
+ATOM   1835 C C     . CYS C 3 62  ? 41.354  58.042 123.352 1.00 50.60  ? ? ? ? ? ? 56  CYS A C     1 
+ATOM   1836 O O     . CYS C 3 62  ? 40.405  58.821 123.446 1.00 50.39  ? ? ? ? ? ? 56  CYS A O     1 
+ATOM   1837 C CB    . CYS C 3 62  ? 42.056  57.204 121.112 1.00 42.94  ? ? ? ? ? ? 56  CYS A CB    1 
+ATOM   1838 S SG    . CYS C 3 62  ? 42.769  57.707 119.519 1.00 46.57  ? ? ? ? ? ? 56  CYS A SG    1 
+ATOM   1839 N N     . LYS C 3 63  ? 41.559  57.022 124.189 1.00 49.99  ? ? ? ? ? ? 57  LYS A N     1 
+ATOM   1840 C CA    . LYS C 3 63  ? 40.683  56.743 125.331 1.00 50.59  ? ? ? ? ? ? 57  LYS A CA    1 
+ATOM   1841 C C     . LYS C 3 63  ? 40.753  57.968 126.211 1.00 58.02  ? ? ? ? ? ? 57  LYS A C     1 
+ATOM   1842 O O     . LYS C 3 63  ? 39.792  58.723 126.364 1.00 57.36  ? ? ? ? ? ? 57  LYS A O     1 
+ATOM   1843 C CB    . LYS C 3 63  ? 41.188  55.554 126.152 1.00 52.54  ? ? ? ? ? ? 57  LYS A CB    1 
+ATOM   1844 C CG    . LYS C 3 63  ? 40.190  55.132 127.232 1.00 77.08  ? ? ? ? ? ? 57  LYS A CG    1 
+ATOM   1845 C CD    . LYS C 3 63  ? 40.594  53.861 127.963 1.00 89.65  ? ? ? ? ? ? 57  LYS A CD    1 
+ATOM   1846 C CE    . LYS C 3 63  ? 39.510  53.412 128.931 1.00 99.62  ? ? ? ? ? ? 57  LYS A CE    1 
+ATOM   1847 N NZ    . LYS C 3 63  ? 39.157  51.982 128.714 1.00 100.00 ? ? ? ? ? ? 57  LYS A NZ    1 
+ATOM   1848 N N     . LEU C 3 64  ? 41.955  58.168 126.730 1.00 56.67  ? ? ? ? ? ? 58  LEU A N     1 
+ATOM   1849 C CA    . LEU C 3 64  ? 42.295  59.304 127.562 1.00 56.04  ? ? ? ? ? ? 58  LEU A CA    1 
+ATOM   1850 C C     . LEU C 3 64  ? 41.686  60.588 127.021 1.00 59.04  ? ? ? ? ? ? 58  LEU A C     1 
+ATOM   1851 O O     . LEU C 3 64  ? 41.101  61.358 127.777 1.00 61.04  ? ? ? ? ? ? 58  LEU A O     1 
+ATOM   1852 C CB    . LEU C 3 64  ? 43.812  59.447 127.580 1.00 56.13  ? ? ? ? ? ? 58  LEU A CB    1 
+ATOM   1853 C CG    . LEU C 3 64  ? 44.438  60.419 128.570 1.00 61.71  ? ? ? ? ? ? 58  LEU A CG    1 
+ATOM   1854 C CD1   . LEU C 3 64  ? 43.930  60.166 129.988 1.00 61.41  ? ? ? ? ? ? 58  LEU A CD1   1 
+ATOM   1855 C CD2   . LEU C 3 64  ? 45.927  60.182 128.514 1.00 67.06  ? ? ? ? ? ? 58  LEU A CD2   1 
+ATOM   1856 N N     . ASN C 3 65  ? 41.835  60.837 125.725 1.00 54.47  ? ? ? ? ? ? 59  ASN A N     1 
+ATOM   1857 C CA    . ASN C 3 65  ? 41.317  62.076 125.164 1.00 53.75  ? ? ? ? ? ? 59  ASN A CA    1 
+ATOM   1858 C C     . ASN C 3 65  ? 39.922  62.006 124.578 1.00 58.96  ? ? ? ? ? ? 59  ASN A C     1 
+ATOM   1859 O O     . ASN C 3 65  ? 39.442  62.987 124.007 1.00 60.40  ? ? ? ? ? ? 59  ASN A O     1 
+ATOM   1860 C CB    . ASN C 3 65  ? 42.289  62.672 124.158 1.00 51.06  ? ? ? ? ? ? 59  ASN A CB    1 
+ATOM   1861 C CG    . ASN C 3 65  ? 43.591  63.076 124.799 1.00 60.51  ? ? ? ? ? ? 59  ASN A CG    1 
+ATOM   1862 O OD1   . ASN C 3 65  ? 43.744  64.214 125.221 1.00 67.61  ? ? ? ? ? ? 59  ASN A OD1   1 
+ATOM   1863 N ND2   . ASN C 3 65  ? 44.525  62.139 124.884 1.00 51.42  ? ? ? ? ? ? 59  ASN A ND2   1 
+ATOM   1864 N N     . ASN C 3 66  ? 39.278  60.850 124.727 1.00 53.67  ? ? ? ? ? ? 60  ASN A N     1 
+ATOM   1865 C CA    . ASN C 3 66  ? 37.915  60.658 124.245 1.00 53.32  ? ? ? ? ? ? 60  ASN A CA    1 
+ATOM   1866 C C     . ASN C 3 66  ? 37.791  60.769 122.723 1.00 57.66  ? ? ? ? ? ? 60  ASN A C     1 
+ATOM   1867 O O     . ASN C 3 66  ? 36.965  61.526 122.220 1.00 57.98  ? ? ? ? ? ? 60  ASN A O     1 
+ATOM   1868 C CB    . ASN C 3 66  ? 36.965  61.642 124.943 1.00 56.50  ? ? ? ? ? ? 60  ASN A CB    1 
+ATOM   1869 C CG    . ASN C 3 66  ? 37.135  61.655 126.463 1.00 92.80  ? ? ? ? ? ? 60  ASN A CG    1 
+ATOM   1870 O OD1   . ASN C 3 66  ? 36.880  60.651 127.124 1.00 100.00 ? ? ? ? ? ? 60  ASN A OD1   1 
+ATOM   1871 N ND2   . ASN C 3 66  ? 37.562  62.788 127.019 1.00 72.08  ? ? ? ? ? ? 60  ASN A ND2   1 
+ATOM   1872 N N     . ARG C 3 67  ? 38.618  60.014 122.003 1.00 51.32  ? ? ? ? ? ? 61  ARG A N     1 
+ATOM   1873 C CA    . ARG C 3 67  ? 38.580  59.981 120.538 1.00 47.42  ? ? ? ? ? ? 61  ARG A CA    1 
+ATOM   1874 C C     . ARG C 3 67  ? 38.459  58.533 120.110 1.00 46.84  ? ? ? ? ? ? 61  ARG A C     1 
+ATOM   1875 O O     . ARG C 3 67  ? 38.787  57.629 120.887 1.00 45.14  ? ? ? ? ? ? 61  ARG A O     1 
+ATOM   1876 C CB    . ARG C 3 67  ? 39.876  60.509 119.921 1.00 45.83  ? ? ? ? ? ? 61  ARG A CB    1 
+ATOM   1877 C CG    . ARG C 3 67  ? 40.441  61.724 120.594 1.00 47.26  ? ? ? ? ? ? 61  ARG A CG    1 
+ATOM   1878 C CD    . ARG C 3 67  ? 39.506  62.887 120.386 1.00 52.46  ? ? ? ? ? ? 61  ARG A CD    1 
+ATOM   1879 N NE    . ARG C 3 67  ? 40.067  64.089 120.975 1.00 55.05  ? ? ? ? ? ? 61  ARG A NE    1 
+ATOM   1880 C CZ    . ARG C 3 67  ? 40.946  64.873 120.363 1.00 79.02  ? ? ? ? ? ? 61  ARG A CZ    1 
+ATOM   1881 N NH1   . ARG C 3 67  ? 41.354  64.598 119.132 1.00 60.76  ? ? ? ? ? ? 61  ARG A NH1   1 
+ATOM   1882 N NH2   . ARG C 3 67  ? 41.414  65.947 120.980 1.00 86.85  ? ? ? ? ? ? 61  ARG A NH2   1 
+ATOM   1883 N N     . LYS C 3 68  ? 38.036  58.312 118.867 1.00 42.75  ? ? ? ? ? ? 62  LYS A N     1 
+ATOM   1884 C CA    . LYS C 3 68  ? 37.916  56.956 118.328 1.00 43.79  ? ? ? ? ? ? 62  LYS A CA    1 
+ATOM   1885 C C     . LYS C 3 68  ? 39.246  56.561 117.703 1.00 47.44  ? ? ? ? ? ? 62  LYS A C     1 
+ATOM   1886 O O     . LYS C 3 68  ? 39.858  57.343 116.980 1.00 46.15  ? ? ? ? ? ? 62  LYS A O     1 
+ATOM   1887 C CB    . LYS C 3 68  ? 36.810  56.874 117.283 1.00 49.68  ? ? ? ? ? ? 62  LYS A CB    1 
+ATOM   1888 C CG    . LYS C 3 68  ? 35.431  56.676 117.891 1.00 90.14  ? ? ? ? ? ? 62  LYS A CG    1 
+ATOM   1889 C CD    . LYS C 3 68  ? 35.307  55.328 118.590 1.00 100.00 ? ? ? ? ? ? 62  LYS A CD    1 
+ATOM   1890 C CE    . LYS C 3 68  ? 35.849  55.344 120.012 1.00 96.03  ? ? ? ? ? ? 62  LYS A CE    1 
+ATOM   1891 N NZ    . LYS C 3 68  ? 35.600  54.039 120.688 1.00 91.68  ? ? ? ? ? ? 62  LYS A NZ    1 
+ATOM   1892 N N     . TRP C 3 69  ? 39.723  55.360 117.984 1.00 47.67  ? ? ? ? ? ? 63  TRP A N     1 
+ATOM   1893 C CA    . TRP C 3 69  ? 41.028  54.996 117.452 1.00 49.83  ? ? ? ? ? ? 63  TRP A CA    1 
+ATOM   1894 C C     . TRP C 3 69  ? 41.045  54.244 116.118 1.00 55.92  ? ? ? ? ? ? 63  TRP A C     1 
+ATOM   1895 O O     . TRP C 3 69  ? 42.110  54.060 115.528 1.00 55.42  ? ? ? ? ? ? 63  TRP A O     1 
+ATOM   1896 C CB    . TRP C 3 69  ? 41.867  54.295 118.526 1.00 48.35  ? ? ? ? ? ? 63  TRP A CB    1 
+ATOM   1897 C CG    . TRP C 3 69  ? 41.515  52.867 118.660 1.00 48.94  ? ? ? ? ? ? 63  TRP A CG    1 
+ATOM   1898 C CD1   . TRP C 3 69  ? 40.418  52.354 119.281 1.00 52.67  ? ? ? ? ? ? 63  TRP A CD1   1 
+ATOM   1899 C CD2   . TRP C 3 69  ? 42.191  51.765 118.049 1.00 48.12  ? ? ? ? ? ? 63  TRP A CD2   1 
+ATOM   1900 N NE1   . TRP C 3 69  ? 40.382  50.989 119.123 1.00 53.14  ? ? ? ? ? ? 63  TRP A NE1   1 
+ATOM   1901 C CE2   . TRP C 3 69  ? 41.465  50.601 118.374 1.00 53.29  ? ? ? ? ? ? 63  TRP A CE2   1 
+ATOM   1902 C CE3   . TRP C 3 69  ? 43.339  51.651 117.256 1.00 47.55  ? ? ? ? ? ? 63  TRP A CE3   1 
+ATOM   1903 C CZ2   . TRP C 3 69  ? 41.866  49.336 117.953 1.00 51.24  ? ? ? ? ? ? 63  TRP A CZ2   1 
+ATOM   1904 C CZ3   . TRP C 3 69  ? 43.724  50.401 116.832 1.00 48.09  ? ? ? ? ? ? 63  TRP A CZ3   1 
+ATOM   1905 C CH2   . TRP C 3 69  ? 42.997  49.259 117.185 1.00 49.18  ? ? ? ? ? ? 63  TRP A CH2   1 
+ATOM   1906 N N     . PHE C 3 70  ? 39.881  53.811 115.647 1.00 53.95  ? ? ? ? ? ? 64  PHE A N     1 
+ATOM   1907 C CA    . PHE C 3 70  ? 39.788  53.091 114.381 1.00 54.54  ? ? ? ? ? ? 64  PHE A CA    1 
+ATOM   1908 C C     . PHE C 3 70  ? 38.406  53.250 113.742 1.00 62.20  ? ? ? ? ? ? 64  PHE A C     1 
+ATOM   1909 O O     . PHE C 3 70  ? 37.409  52.785 114.294 1.00 67.77  ? ? ? ? ? ? 64  PHE A O     1 
+ATOM   1910 C CB    . PHE C 3 70  ? 40.116  51.611 114.567 1.00 56.33  ? ? ? ? ? ? 64  PHE A CB    1 
+ATOM   1911 C CG    . PHE C 3 70  ? 40.297  50.875 113.273 1.00 61.39  ? ? ? ? ? ? 64  PHE A CG    1 
+ATOM   1912 C CD1   . PHE C 3 70  ? 41.300  51.248 112.387 1.00 67.79  ? ? ? ? ? ? 64  PHE A CD1   1 
+ATOM   1913 C CD2   . PHE C 3 70  ? 39.453  49.831 112.925 1.00 66.50  ? ? ? ? ? ? 64  PHE A CD2   1 
+ATOM   1914 C CE1   . PHE C 3 70  ? 41.472  50.584 111.179 1.00 69.74  ? ? ? ? ? ? 64  PHE A CE1   1 
+ATOM   1915 C CE2   . PHE C 3 70  ? 39.625  49.152 111.724 1.00 70.98  ? ? ? ? ? ? 64  PHE A CE2   1 
+ATOM   1916 C CZ    . PHE C 3 70  ? 40.632  49.535 110.846 1.00 69.69  ? ? ? ? ? ? 64  PHE A CZ    1 
+ATOM   1917 N N     . PRO C 3 71  ? 38.329  53.913 112.593 1.00 53.17  ? ? ? ? ? ? 65  PRO A N     1 
+ATOM   1918 C CA    . PRO C 3 71  ? 39.482  54.458 111.901 1.00 51.42  ? ? ? ? ? ? 65  PRO A CA    1 
+ATOM   1919 C C     . PRO C 3 71  ? 39.917  55.783 112.492 1.00 51.00  ? ? ? ? ? ? 65  PRO A C     1 
+ATOM   1920 O O     . PRO C 3 71  ? 39.124  56.476 113.121 1.00 52.33  ? ? ? ? ? ? 65  PRO A O     1 
+ATOM   1921 C CB    . PRO C 3 71  ? 38.954  54.691 110.478 1.00 54.06  ? ? ? ? ? ? 65  PRO A CB    1 
+ATOM   1922 C CG    . PRO C 3 71  ? 37.513  54.232 110.470 1.00 58.71  ? ? ? ? ? ? 65  PRO A CG    1 
+ATOM   1923 C CD    . PRO C 3 71  ? 37.374  53.327 111.645 1.00 53.88  ? ? ? ? ? ? 65  PRO A CD    1 
+ATOM   1924 N N     . ALA C 3 72  ? 41.174  56.143 112.258 1.00 44.60  ? ? ? ? ? ? 66  ALA A N     1 
+ATOM   1925 C CA    . ALA C 3 72  ? 41.728  57.386 112.776 1.00 44.65  ? ? ? ? ? ? 66  ALA A CA    1 
+ATOM   1926 C C     . ALA C 3 72  ? 41.332  58.640 111.992 1.00 52.61  ? ? ? ? ? ? 66  ALA A C     1 
+ATOM   1927 O O     . ALA C 3 72  ? 41.478  58.683 110.774 1.00 52.75  ? ? ? ? ? ? 66  ALA A O     1 
+ATOM   1928 C CB    . ALA C 3 72  ? 43.247  57.269 112.877 1.00 44.92  ? ? ? ? ? ? 66  ALA A CB    1 
+ATOM   1929 N N     . GLU C 3 73  ? 40.840  59.658 112.694 1.00 54.72  ? ? ? ? ? ? 67  GLU A N     1 
+ATOM   1930 C CA    . GLU C 3 73  ? 40.455  60.901 112.043 1.00 56.52  ? ? ? ? ? ? 67  GLU A CA    1 
+ATOM   1931 C C     . GLU C 3 73  ? 41.677  61.823 111.994 1.00 58.27  ? ? ? ? ? ? 67  GLU A C     1 
+ATOM   1932 O O     . GLU C 3 73  ? 42.419  61.936 112.973 1.00 56.59  ? ? ? ? ? ? 67  GLU A O     1 
+ATOM   1933 C CB    . GLU C 3 73  ? 39.269  61.538 112.786 1.00 58.72  ? ? ? ? ? ? 67  GLU A CB    1 
+ATOM   1934 C CG    . GLU C 3 73  ? 38.164  62.097 111.896 1.00 74.27  ? ? ? ? ? ? 67  GLU A CG    1 
+ATOM   1935 C CD    . GLU C 3 73  ? 38.136  63.619 111.914 1.00 100.00 ? ? ? ? ? ? 67  GLU A CD    1 
+ATOM   1936 O OE1   . GLU C 3 73  ? 37.494  64.191 112.818 1.00 100.00 ? ? ? ? ? ? 67  GLU A OE1   1 
+ATOM   1937 O OE2   . GLU C 3 73  ? 38.794  64.242 111.049 1.00 100.00 ? ? ? ? ? ? 67  GLU A OE2   1 
+ATOM   1938 N N     . PRO C 3 74  ? 41.885  62.467 110.847 1.00 55.23  ? ? ? ? ? ? 68  PRO A N     1 
+ATOM   1939 C CA    . PRO C 3 74  ? 42.992  63.389 110.688 1.00 53.58  ? ? ? ? ? ? 68  PRO A CA    1 
+ATOM   1940 C C     . PRO C 3 74  ? 43.171  64.392 111.817 1.00 55.05  ? ? ? ? ? ? 68  PRO A C     1 
+ATOM   1941 O O     . PRO C 3 74  ? 44.284  64.549 112.314 1.00 56.68  ? ? ? ? ? ? 68  PRO A O     1 
+ATOM   1942 C CB    . PRO C 3 74  ? 42.643  64.110 109.386 1.00 55.68  ? ? ? ? ? ? 68  PRO A CB    1 
+ATOM   1943 C CG    . PRO C 3 74  ? 41.859  63.106 108.595 1.00 61.81  ? ? ? ? ? ? 68  PRO A CG    1 
+ATOM   1944 C CD    . PRO C 3 74  ? 41.442  61.988 109.525 1.00 57.51  ? ? ? ? ? ? 68  PRO A CD    1 
+ATOM   1945 N N     . GLU C 3 75  ? 42.121  65.091 112.226 1.00 47.75  ? ? ? ? ? ? 69  GLU A N     1 
+ATOM   1946 C CA    . GLU C 3 75  ? 42.332  66.055 113.296 1.00 46.59  ? ? ? ? ? ? 69  GLU A CA    1 
+ATOM   1947 C C     . GLU C 3 75  ? 42.841  65.372 114.562 1.00 53.68  ? ? ? ? ? ? 69  GLU A C     1 
+ATOM   1948 O O     . GLU C 3 75  ? 43.631  65.949 115.308 1.00 54.56  ? ? ? ? ? ? 69  GLU A O     1 
+ATOM   1949 C CB    . GLU C 3 75  ? 41.053  66.828 113.595 1.00 46.97  ? ? ? ? ? ? 69  GLU A CB    1 
+ATOM   1950 C CG    . GLU C 3 75  ? 40.539  67.611 112.405 1.00 59.28  ? ? ? ? ? ? 69  GLU A CG    1 
+ATOM   1951 C CD    . GLU C 3 75  ? 41.509  68.688 111.957 1.00 72.64  ? ? ? ? ? ? 69  GLU A CD    1 
+ATOM   1952 O OE1   . GLU C 3 75  ? 42.104  69.338 112.845 1.00 47.94  ? ? ? ? ? ? 69  GLU A OE1   1 
+ATOM   1953 O OE2   . GLU C 3 75  ? 41.665  68.885 110.729 1.00 54.76  ? ? ? ? ? ? 69  GLU A OE2   1 
+ATOM   1954 N N     . ASP C 3 76  ? 42.365  64.151 114.801 1.00 50.64  ? ? ? ? ? ? 70  ASP A N     1 
+ATOM   1955 C CA    . ASP C 3 76  ? 42.726  63.378 115.986 1.00 48.41  ? ? ? ? ? ? 70  ASP A CA    1 
+ATOM   1956 C C     . ASP C 3 76  ? 44.154  62.899 115.889 1.00 47.69  ? ? ? ? ? ? 70  ASP A C     1 
+ATOM   1957 O O     . ASP C 3 76  ? 44.881  62.893 116.876 1.00 48.94  ? ? ? ? ? ? 70  ASP A O     1 
+ATOM   1958 C CB    . ASP C 3 76  ? 41.812  62.164 116.144 1.00 50.09  ? ? ? ? ? ? 70  ASP A CB    1 
+ATOM   1959 C CG    . ASP C 3 76  ? 40.401  62.544 116.534 1.00 60.08  ? ? ? ? ? ? 70  ASP A CG    1 
+ATOM   1960 O OD1   . ASP C 3 76  ? 40.192  63.633 117.108 1.00 62.65  ? ? ? ? ? ? 70  ASP A OD1   1 
+ATOM   1961 O OD2   . ASP C 3 76  ? 39.499  61.731 116.274 1.00 58.08  ? ? ? ? ? ? 70  ASP A OD2   1 
+ATOM   1962 N N     . VAL C 3 77  ? 44.561  62.487 114.697 1.00 42.13  ? ? ? ? ? ? 71  VAL A N     1 
+ATOM   1963 C CA    . VAL C 3 77  ? 45.926  62.026 114.523 1.00 41.82  ? ? ? ? ? ? 71  VAL A CA    1 
+ATOM   1964 C C     . VAL C 3 77  ? 46.866  63.216 114.630 1.00 45.24  ? ? ? ? ? ? 71  VAL A C     1 
+ATOM   1965 O O     . VAL C 3 77  ? 47.983  63.058 115.104 1.00 48.69  ? ? ? ? ? ? 71  VAL A O     1 
+ATOM   1966 C CB    . VAL C 3 77  ? 46.167  61.262 113.187 1.00 45.66  ? ? ? ? ? ? 71  VAL A CB    1 
+ATOM   1967 C CG1   . VAL C 3 77  ? 47.597  60.739 113.114 1.00 45.37  ? ? ? ? ? ? 71  VAL A CG1   1 
+ATOM   1968 C CG2   . VAL C 3 77  ? 45.172  60.114 113.020 1.00 44.71  ? ? ? ? ? ? 71  VAL A CG2   1 
+ATOM   1969 N N     . ARG C 3 78  ? 46.415  64.398 114.219 1.00 40.13  ? ? ? ? ? ? 72  ARG A N     1 
+ATOM   1970 C CA    . ARG C 3 78  ? 47.250  65.595 114.277 1.00 41.64  ? ? ? ? ? ? 72  ARG A CA    1 
+ATOM   1971 C C     . ARG C 3 78  ? 47.482  65.993 115.729 1.00 46.93  ? ? ? ? ? ? 72  ARG A C     1 
+ATOM   1972 O O     . ARG C 3 78  ? 48.576  66.398 116.126 1.00 46.08  ? ? ? ? ? ? 72  ARG A O     1 
+ATOM   1973 C CB    . ARG C 3 78  ? 46.594  66.744 113.503 1.00 47.51  ? ? ? ? ? ? 72  ARG A CB    1 
+ATOM   1974 C CG    . ARG C 3 78  ? 46.932  68.147 114.016 1.00 54.11  ? ? ? ? ? ? 72  ARG A CG    1 
+ATOM   1975 C CD    . ARG C 3 78  ? 46.772  69.204 112.931 1.00 49.00  ? ? ? ? ? ? 72  ARG A CD    1 
+ATOM   1976 N NE    . ARG C 3 78  ? 47.392  70.468 113.312 1.00 48.42  ? ? ? ? ? ? 72  ARG A NE    1 
+ATOM   1977 C CZ    . ARG C 3 78  ? 47.037  71.158 114.388 1.00 62.26  ? ? ? ? ? ? 72  ARG A CZ    1 
+ATOM   1978 N NH1   . ARG C 3 78  ? 46.069  70.687 115.159 1.00 61.41  ? ? ? ? ? ? 72  ARG A NH1   1 
+ATOM   1979 N NH2   . ARG C 3 78  ? 47.641  72.302 114.689 1.00 50.81  ? ? ? ? ? ? 72  ARG A NH2   1 
+ATOM   1980 N N     . ASP C 3 79  ? 46.434  65.867 116.530 1.00 44.18  ? ? ? ? ? ? 73  ASP A N     1 
+ATOM   1981 C CA    . ASP C 3 79  ? 46.522  66.200 117.946 1.00 43.35  ? ? ? ? ? ? 73  ASP A CA    1 
+ATOM   1982 C C     . ASP C 3 79  ? 47.473  65.235 118.653 1.00 47.19  ? ? ? ? ? ? 73  ASP A C     1 
+ATOM   1983 O O     . ASP C 3 79  ? 48.166  65.607 119.601 1.00 46.57  ? ? ? ? ? ? 73  ASP A O     1 
+ATOM   1984 C CB    . ASP C 3 79  ? 45.143  66.133 118.615 1.00 44.90  ? ? ? ? ? ? 73  ASP A CB    1 
+ATOM   1985 C CG    . ASP C 3 79  ? 44.259  67.280 118.188 1.00 63.52  ? ? ? ? ? ? 73  ASP A CG    1 
+ATOM   1986 O OD1   . ASP C 3 79  ? 44.803  68.321 117.804 1.00 67.43  ? ? ? ? ? ? 73  ASP A OD1   1 
+ATOM   1987 O OD2   . ASP C 3 79  ? 43.019  67.117 118.271 1.00 70.31  ? ? ? ? ? ? 73  ASP A OD2   1 
+ATOM   1988 N N     . TYR C 3 80  ? 47.500  63.995 118.177 1.00 44.09  ? ? ? ? ? ? 74  TYR A N     1 
+ATOM   1989 C CA    . TYR C 3 80  ? 48.356  62.951 118.736 1.00 42.38  ? ? ? ? ? ? 74  TYR A CA    1 
+ATOM   1990 C C     . TYR C 3 80  ? 49.821  63.172 118.373 1.00 47.21  ? ? ? ? ? ? 74  TYR A C     1 
+ATOM   1991 O O     . TYR C 3 80  ? 50.702  62.941 119.202 1.00 49.16  ? ? ? ? ? ? 74  TYR A O     1 
+ATOM   1992 C CB    . TYR C 3 80  ? 47.871  61.568 118.273 1.00 40.74  ? ? ? ? ? ? 74  TYR A CB    1 
+ATOM   1993 C CG    . TYR C 3 80  ? 48.770  60.399 118.641 1.00 37.77  ? ? ? ? ? ? 74  TYR A CG    1 
+ATOM   1994 C CD1   . TYR C 3 80  ? 48.941  60.012 119.966 1.00 37.75  ? ? ? ? ? ? 74  TYR A CD1   1 
+ATOM   1995 C CD2   . TYR C 3 80  ? 49.421  59.663 117.654 1.00 38.13  ? ? ? ? ? ? 74  TYR A CD2   1 
+ATOM   1996 C CE1   . TYR C 3 80  ? 49.756  58.923 120.293 1.00 36.06  ? ? ? ? ? ? 74  TYR A CE1   1 
+ATOM   1997 C CE2   . TYR C 3 80  ? 50.243  58.587 117.974 1.00 38.19  ? ? ? ? ? ? 74  TYR A CE2   1 
+ATOM   1998 C CZ    . TYR C 3 80  ? 50.404  58.220 119.293 1.00 37.84  ? ? ? ? ? ? 74  TYR A CZ    1 
+ATOM   1999 O OH    . TYR C 3 80  ? 51.224  57.157 119.588 1.00 37.59  ? ? ? ? ? ? 74  TYR A OH    1 
+ATOM   2000 N N     . LEU C 3 81  ? 50.083  63.622 117.149 1.00 43.44  ? ? ? ? ? ? 75  LEU A N     1 
+ATOM   2001 C CA    . LEU C 3 81  ? 51.455  63.857 116.717 1.00 42.57  ? ? ? ? ? ? 75  LEU A CA    1 
+ATOM   2002 C C     . LEU C 3 81  ? 52.021  65.035 117.494 1.00 51.56  ? ? ? ? ? ? 75  LEU A C     1 
+ATOM   2003 O O     . LEU C 3 81  ? 53.220  65.086 117.770 1.00 53.44  ? ? ? ? ? ? 75  LEU A O     1 
+ATOM   2004 C CB    . LEU C 3 81  ? 51.530  64.108 115.211 1.00 40.71  ? ? ? ? ? ? 75  LEU A CB    1 
+ATOM   2005 C CG    . LEU C 3 81  ? 51.177  62.909 114.323 1.00 43.24  ? ? ? ? ? ? 75  LEU A CG    1 
+ATOM   2006 C CD1   . LEU C 3 81  ? 51.392  63.232 112.849 1.00 43.68  ? ? ? ? ? ? 75  LEU A CD1   1 
+ATOM   2007 C CD2   . LEU C 3 81  ? 51.896  61.624 114.718 1.00 39.79  ? ? ? ? ? ? 75  LEU A CD2   1 
+ATOM   2008 N N     . LEU C 3 82  ? 51.160  65.978 117.861 1.00 45.85  ? ? ? ? ? ? 76  LEU A N     1 
+ATOM   2009 C CA    . LEU C 3 82  ? 51.624  67.126 118.624 1.00 45.10  ? ? ? ? ? ? 76  LEU A CA    1 
+ATOM   2010 C C     . LEU C 3 82  ? 51.888  66.672 120.057 1.00 53.55  ? ? ? ? ? ? 76  LEU A C     1 
+ATOM   2011 O O     . LEU C 3 82  ? 52.808  67.154 120.717 1.00 56.86  ? ? ? ? ? ? 76  LEU A O     1 
+ATOM   2012 C CB    . LEU C 3 82  ? 50.568  68.225 118.616 1.00 44.21  ? ? ? ? ? ? 76  LEU A CB    1 
+ATOM   2013 C CG    . LEU C 3 82  ? 50.461  69.048 117.337 1.00 47.67  ? ? ? ? ? ? 76  LEU A CG    1 
+ATOM   2014 C CD1   . LEU C 3 82  ? 49.169  69.863 117.350 1.00 45.22  ? ? ? ? ? ? 76  LEU A CD1   1 
+ATOM   2015 C CD2   . LEU C 3 82  ? 51.708  69.916 117.130 1.00 51.72  ? ? ? ? ? ? 76  LEU A CD2   1 
+ATOM   2016 N N     . TYR C 3 83  ? 51.059  65.745 120.529 1.00 47.82  ? ? ? ? ? ? 77  TYR A N     1 
+ATOM   2017 C CA    . TYR C 3 83  ? 51.177  65.189 121.870 1.00 45.06  ? ? ? ? ? ? 77  TYR A CA    1 
+ATOM   2018 C C     . TYR C 3 83  ? 52.523  64.467 121.953 1.00 46.18  ? ? ? ? ? ? 77  TYR A C     1 
+ATOM   2019 O O     . TYR C 3 83  ? 53.253  64.601 122.935 1.00 46.10  ? ? ? ? ? ? 77  TYR A O     1 
+ATOM   2020 C CB    . TYR C 3 83  ? 49.993  64.248 122.159 1.00 44.09  ? ? ? ? ? ? 77  TYR A CB    1 
+ATOM   2021 C CG    . TYR C 3 83  ? 50.258  63.269 123.284 1.00 42.14  ? ? ? ? ? ? 77  TYR A CG    1 
+ATOM   2022 C CD1   . TYR C 3 83  ? 50.244  63.690 124.592 1.00 41.54  ? ? ? ? ? ? 77  TYR A CD1   1 
+ATOM   2023 C CD2   . TYR C 3 83  ? 50.536  61.928 123.030 1.00 43.10  ? ? ? ? ? ? 77  TYR A CD2   1 
+ATOM   2024 C CE1   . TYR C 3 83  ? 50.540  62.794 125.608 1.00 40.32  ? ? ? ? ? ? 77  TYR A CE1   1 
+ATOM   2025 C CE2   . TYR C 3 83  ? 50.834  61.041 124.040 1.00 43.16  ? ? ? ? ? ? 77  TYR A CE2   1 
+ATOM   2026 C CZ    . TYR C 3 83  ? 50.773  61.480 125.324 1.00 42.90  ? ? ? ? ? ? 77  TYR A CZ    1 
+ATOM   2027 O OH    . TYR C 3 83  ? 50.983  60.565 126.314 1.00 53.35  ? ? ? ? ? ? 77  TYR A OH    1 
+ATOM   2028 N N     . LEU C 3 84  ? 52.871  63.761 120.884 1.00 41.93  ? ? ? ? ? ? 78  LEU A N     1 
+ATOM   2029 C CA    . LEU C 3 84  ? 54.141  63.049 120.812 1.00 41.68  ? ? ? ? ? ? 78  LEU A CA    1 
+ATOM   2030 C C     . LEU C 3 84  ? 55.326  64.024 120.816 1.00 52.20  ? ? ? ? ? ? 78  LEU A C     1 
+ATOM   2031 O O     . LEU C 3 84  ? 56.361  63.750 121.422 1.00 54.52  ? ? ? ? ? ? 78  LEU A O     1 
+ATOM   2032 C CB    . LEU C 3 84  ? 54.188  62.181 119.549 1.00 40.32  ? ? ? ? ? ? 78  LEU A CB    1 
+ATOM   2033 C CG    . LEU C 3 84  ? 53.253  60.984 119.379 1.00 41.03  ? ? ? ? ? ? 78  LEU A CG    1 
+ATOM   2034 C CD1   . LEU C 3 84  ? 53.666  60.237 118.132 1.00 40.25  ? ? ? ? ? ? 78  LEU A CD1   1 
+ATOM   2035 C CD2   . LEU C 3 84  ? 53.331  60.054 120.563 1.00 43.10  ? ? ? ? ? ? 78  LEU A CD2   1 
+ATOM   2036 N N     . GLN C 3 85  ? 55.183  65.154 120.133 1.00 49.04  ? ? ? ? ? ? 79  GLN A N     1 
+ATOM   2037 C CA    . GLN C 3 85  ? 56.251  66.146 120.098 1.00 49.93  ? ? ? ? ? ? 79  GLN A CA    1 
+ATOM   2038 C C     . GLN C 3 85  ? 56.409  66.823 121.451 1.00 55.10  ? ? ? ? ? ? 79  GLN A C     1 
+ATOM   2039 O O     . GLN C 3 85  ? 57.528  67.054 121.912 1.00 58.43  ? ? ? ? ? ? 79  GLN A O     1 
+ATOM   2040 C CB    . GLN C 3 85  ? 55.965  67.211 119.047 1.00 51.36  ? ? ? ? ? ? 79  GLN A CB    1 
+ATOM   2041 C CG    . GLN C 3 85  ? 56.700  68.509 119.287 1.00 49.41  ? ? ? ? ? ? 79  GLN A CG    1 
+ATOM   2042 C CD    . GLN C 3 85  ? 56.344  69.535 118.240 1.00 62.80  ? ? ? ? ? ? 79  GLN A CD    1 
+ATOM   2043 O OE1   . GLN C 3 85  ? 55.223  70.033 118.224 1.00 72.41  ? ? ? ? ? ? 79  GLN A OE1   1 
+ATOM   2044 N NE2   . GLN C 3 85  ? 57.290  69.817 117.358 1.00 47.83  ? ? ? ? ? ? 79  GLN A NE2   1 
+ATOM   2045 N N     . ALA C 3 86  ? 55.282  67.157 122.066 1.00 46.30  ? ? ? ? ? ? 80  ALA A N     1 
+ATOM   2046 C CA    . ALA C 3 86  ? 55.263  67.804 123.372 1.00 45.65  ? ? ? ? ? ? 80  ALA A CA    1 
+ATOM   2047 C C     . ALA C 3 86  ? 55.896  66.849 124.371 1.00 53.71  ? ? ? ? ? ? 80  ALA A C     1 
+ATOM   2048 O O     . ALA C 3 86  ? 56.406  67.250 125.416 1.00 55.54  ? ? ? ? ? ? 80  ALA A O     1 
+ATOM   2049 C CB    . ALA C 3 86  ? 53.833  68.104 123.776 1.00 46.37  ? ? ? ? ? ? 80  ALA A CB    1 
+ATOM   2050 N N     . ARG C 3 87  ? 55.850  65.568 124.045 1.00 50.60  ? ? ? ? ? ? 81  ARG A N     1 
+ATOM   2051 C CA    . ARG C 3 87  ? 56.430  64.567 124.922 1.00 49.19  ? ? ? ? ? ? 81  ARG A CA    1 
+ATOM   2052 C C     . ARG C 3 87  ? 57.944  64.585 124.751 1.00 49.18  ? ? ? ? ? ? 81  ARG A C     1 
+ATOM   2053 O O     . ARG C 3 87  ? 58.654  63.834 125.416 1.00 50.79  ? ? ? ? ? ? 81  ARG A O     1 
+ATOM   2054 C CB    . ARG C 3 87  ? 55.920  63.179 124.525 1.00 51.09  ? ? ? ? ? ? 81  ARG A CB    1 
+ATOM   2055 C CG    . ARG C 3 87  ? 54.702  62.662 125.286 1.00 62.01  ? ? ? ? ? ? 81  ARG A CG    1 
+ATOM   2056 C CD    . ARG C 3 87  ? 54.533  61.155 125.088 1.00 63.14  ? ? ? ? ? ? 81  ARG A CD    1 
+ATOM   2057 N NE    . ARG C 3 87  ? 55.596  60.401 125.743 1.00 65.33  ? ? ? ? ? ? 81  ARG A NE    1 
+ATOM   2058 C CZ    . ARG C 3 87  ? 56.054  59.228 125.325 1.00 80.44  ? ? ? ? ? ? 81  ARG A CZ    1 
+ATOM   2059 N NH1   . ARG C 3 87  ? 55.550  58.654 124.241 1.00 67.71  ? ? ? ? ? ? 81  ARG A NH1   1 
+ATOM   2060 N NH2   . ARG C 3 87  ? 57.027  58.635 125.996 1.00 80.33  ? ? ? ? ? ? 81  ARG A NH2   1 
+ATOM   2061 N N     . GLY C 3 88  ? 58.445  65.380 123.815 1.00 43.13  ? ? ? ? ? ? 82  GLY A N     1 
+ATOM   2062 C CA    . GLY C 3 88  ? 59.877  65.420 123.582 1.00 42.86  ? ? ? ? ? ? 82  GLY A CA    1 
+ATOM   2063 C C     . GLY C 3 88  ? 60.395  64.201 122.829 1.00 51.19  ? ? ? ? ? ? 82  GLY A C     1 
+ATOM   2064 O O     . GLY C 3 88  ? 61.554  63.828 122.991 1.00 55.41  ? ? ? ? ? ? 82  GLY A O     1 
+ATOM   2065 N N     . LEU C 3 89  ? 59.575  63.590 121.981 1.00 45.81  ? ? ? ? ? ? 83  LEU A N     1 
+ATOM   2066 C CA    . LEU C 3 89  ? 60.069  62.441 121.230 1.00 46.05  ? ? ? ? ? ? 83  LEU A CA    1 
+ATOM   2067 C C     . LEU C 3 89  ? 60.789  62.924 119.969 1.00 46.50  ? ? ? ? ? ? 83  LEU A C     1 
+ATOM   2068 O O     . LEU C 3 89  ? 60.547  64.028 119.488 1.00 46.65  ? ? ? ? ? ? 83  LEU A O     1 
+ATOM   2069 C CB    . LEU C 3 89  ? 58.936  61.467 120.886 1.00 47.57  ? ? ? ? ? ? 83  LEU A CB    1 
+ATOM   2070 C CG    . LEU C 3 89  ? 58.319  60.549 121.952 1.00 52.74  ? ? ? ? ? ? 83  LEU A CG    1 
+ATOM   2071 C CD1   . LEU C 3 89  ? 57.111  59.824 121.379 1.00 52.43  ? ? ? ? ? ? 83  LEU A CD1   1 
+ATOM   2072 C CD2   . LEU C 3 89  ? 59.351  59.536 122.422 1.00 54.47  ? ? ? ? ? ? 83  LEU A CD2   1 
+ATOM   2073 N N     . ALA C 3 90  ? 61.676  62.092 119.439 1.00 39.09  ? ? ? ? ? ? 84  ALA A N     1 
+ATOM   2074 C CA    . ALA C 3 90  ? 62.441  62.430 118.246 1.00 38.23  ? ? ? ? ? ? 84  ALA A CA    1 
+ATOM   2075 C C     . ALA C 3 90  ? 61.604  62.507 116.973 1.00 47.67  ? ? ? ? ? ? 84  ALA A C     1 
+ATOM   2076 O O     . ALA C 3 90  ? 60.723  61.679 116.746 1.00 49.90  ? ? ? ? ? ? 84  ALA A O     1 
+ATOM   2077 C CB    . ALA C 3 90  ? 63.548  61.416 118.057 1.00 38.68  ? ? ? ? ? ? 84  ALA A CB    1 
+ATOM   2078 N N     . VAL C 3 91  ? 61.915  63.465 116.112 1.00 45.65  ? ? ? ? ? ? 85  VAL A N     1 
+ATOM   2079 C CA    . VAL C 3 91  ? 61.175  63.564 114.861 1.00 46.83  ? ? ? ? ? ? 85  VAL A CA    1 
+ATOM   2080 C C     . VAL C 3 91  ? 61.069  62.221 114.134 1.00 55.76  ? ? ? ? ? ? 85  VAL A C     1 
+ATOM   2081 O O     . VAL C 3 91  ? 60.123  61.981 113.386 1.00 57.98  ? ? ? ? ? ? 85  VAL A O     1 
+ATOM   2082 C CB    . VAL C 3 91  ? 61.826  64.558 113.899 1.00 49.94  ? ? ? ? ? ? 85  VAL A CB    1 
+ATOM   2083 C CG1   . VAL C 3 91  ? 61.246  64.404 112.494 1.00 48.39  ? ? ? ? ? ? 85  VAL A CG1   1 
+ATOM   2084 C CG2   . VAL C 3 91  ? 61.664  65.979 114.423 1.00 50.15  ? ? ? ? ? ? 85  VAL A CG2   1 
+ATOM   2085 N N     . LYS C 3 92  ? 62.051  61.352 114.334 1.00 52.96  ? ? ? ? ? ? 86  LYS A N     1 
+ATOM   2086 C CA    . LYS C 3 92  ? 62.052  60.060 113.664 1.00 52.40  ? ? ? ? ? ? 86  LYS A CA    1 
+ATOM   2087 C C     . LYS C 3 92  ? 61.137  59.096 114.389 1.00 57.29  ? ? ? ? ? ? 86  LYS A C     1 
+ATOM   2088 O O     . LYS C 3 92  ? 60.738  58.071 113.845 1.00 59.46  ? ? ? ? ? ? 86  LYS A O     1 
+ATOM   2089 C CB    . LYS C 3 92  ? 63.464  59.480 113.591 1.00 56.10  ? ? ? ? ? ? 86  LYS A CB    1 
+ATOM   2090 C CG    . LYS C 3 92  ? 64.245  59.908 112.348 1.00 95.58  ? ? ? ? ? ? 86  LYS A CG    1 
+ATOM   2091 C CD    . LYS C 3 92  ? 64.256  61.436 112.198 1.00 100.00 ? ? ? ? ? ? 86  LYS A CD    1 
+ATOM   2092 C CE    . LYS C 3 92  ? 65.315  61.935 111.214 1.00 100.00 ? ? ? ? ? ? 86  LYS A CE    1 
+ATOM   2093 N NZ    . LYS C 3 92  ? 65.224  63.410 110.978 1.00 100.00 ? ? ? ? ? ? 86  LYS A NZ    1 
+ATOM   2094 N N     . THR C 3 93  ? 60.814  59.417 115.631 1.00 50.94  ? ? ? ? ? ? 87  THR A N     1 
+ATOM   2095 C CA    . THR C 3 93  ? 59.941  58.562 116.402 1.00 49.32  ? ? ? ? ? ? 87  THR A CA    1 
+ATOM   2096 C C     . THR C 3 93  ? 58.509  58.922 116.054 1.00 54.77  ? ? ? ? ? ? 87  THR A C     1 
+ATOM   2097 O O     . THR C 3 93  ? 57.678  58.038 115.823 1.00 57.71  ? ? ? ? ? ? 87  THR A O     1 
+ATOM   2098 C CB    . THR C 3 93  ? 60.243  58.729 117.881 1.00 45.91  ? ? ? ? ? ? 87  THR A CB    1 
+ATOM   2099 O OG1   . THR C 3 93  ? 61.499  58.103 118.150 1.00 57.05  ? ? ? ? ? ? 87  THR A OG1   1 
+ATOM   2100 C CG2   . THR C 3 93  ? 59.181  58.082 118.742 1.00 40.72  ? ? ? ? ? ? 87  THR A CG2   1 
+ATOM   2101 N N     . ILE C 3 94  ? 58.227  60.219 115.943 1.00 45.51  ? ? ? ? ? ? 88  ILE A N     1 
+ATOM   2102 C CA    . ILE C 3 94  ? 56.888  60.642 115.559 1.00 44.46  ? ? ? ? ? ? 88  ILE A CA    1 
+ATOM   2103 C C     . ILE C 3 94  ? 56.598  60.063 114.169 1.00 50.37  ? ? ? ? ? ? 88  ILE A C     1 
+ATOM   2104 O O     . ILE C 3 94  ? 55.488  59.642 113.868 1.00 48.79  ? ? ? ? ? ? 88  ILE A O     1 
+ATOM   2105 C CB    . ILE C 3 94  ? 56.758  62.171 115.561 1.00 46.76  ? ? ? ? ? ? 88  ILE A CB    1 
+ATOM   2106 C CG1   . ILE C 3 94  ? 56.627  62.696 116.995 1.00 47.10  ? ? ? ? ? ? 88  ILE A CG1   1 
+ATOM   2107 C CG2   . ILE C 3 94  ? 55.602  62.614 114.684 1.00 45.46  ? ? ? ? ? ? 88  ILE A CG2   1 
+ATOM   2108 C CD1   . ILE C 3 94  ? 57.611  63.804 117.345 1.00 41.26  ? ? ? ? ? ? 88  ILE A CD1   1 
+ATOM   2109 N N     . GLN C 3 95  ? 57.633  59.997 113.345 1.00 50.45  ? ? ? ? ? ? 89  GLN A N     1 
+ATOM   2110 C CA    . GLN C 3 95  ? 57.518  59.418 112.016 1.00 51.00  ? ? ? ? ? ? 89  GLN A CA    1 
+ATOM   2111 C C     . GLN C 3 95  ? 57.061  57.958 112.122 1.00 52.71  ? ? ? ? ? ? 89  GLN A C     1 
+ATOM   2112 O O     . GLN C 3 95  ? 56.145  57.536 111.416 1.00 52.61  ? ? ? ? ? ? 89  GLN A O     1 
+ATOM   2113 C CB    . GLN C 3 95  ? 58.877  59.487 111.309 1.00 53.33  ? ? ? ? ? ? 89  GLN A CB    1 
+ATOM   2114 C CG    . GLN C 3 95  ? 58.848  60.182 109.945 1.00 66.88  ? ? ? ? ? ? 89  GLN A CG    1 
+ATOM   2115 C CD    . GLN C 3 95  ? 60.003  61.156 109.745 1.00 100.00 ? ? ? ? ? ? 89  GLN A CD    1 
+ATOM   2116 O OE1   . GLN C 3 95  ? 59.793  62.357 109.505 1.00 100.00 ? ? ? ? ? ? 89  GLN A OE1   1 
+ATOM   2117 N NE2   . GLN C 3 95  ? 61.232  60.651 109.772 1.00 94.79  ? ? ? ? ? ? 89  GLN A NE2   1 
+ATOM   2118 N N     . GLN C 3 96  ? 57.726  57.180 112.975 1.00 47.58  ? ? ? ? ? ? 90  GLN A N     1 
+ATOM   2119 C CA    . GLN C 3 96  ? 57.371  55.770 113.136 1.00 45.62  ? ? ? ? ? ? 90  GLN A CA    1 
+ATOM   2120 C C     . GLN C 3 96  ? 55.890  55.625 113.495 1.00 47.41  ? ? ? ? ? ? 90  GLN A C     1 
+ATOM   2121 O O     . GLN C 3 96  ? 55.197  54.754 112.974 1.00 46.32  ? ? ? ? ? ? 90  GLN A O     1 
+ATOM   2122 C CB    . GLN C 3 96  ? 58.269  55.054 114.162 1.00 45.22  ? ? ? ? ? ? 90  GLN A CB    1 
+ATOM   2123 C CG    . GLN C 3 96  ? 57.868  53.595 114.508 1.00 34.26  ? ? ? ? ? ? 90  GLN A CG    1 
+ATOM   2124 C CD    . GLN C 3 96  ? 58.457  52.526 113.588 1.00 57.52  ? ? ? ? ? ? 90  GLN A CD    1 
+ATOM   2125 O OE1   . GLN C 3 96  ? 59.615  52.127 113.725 1.00 58.01  ? ? ? ? ? ? 90  GLN A OE1   1 
+ATOM   2126 N NE2   . GLN C 3 96  ? 57.648  52.053 112.646 1.00 57.13  ? ? ? ? ? ? 90  GLN A NE2   1 
+ATOM   2127 N N     . HIS C 3 97  ? 55.404  56.472 114.394 1.00 40.24  ? ? ? ? ? ? 91  HIS A N     1 
+ATOM   2128 C CA    . HIS C 3 97  ? 54.012  56.384 114.792 1.00 39.04  ? ? ? ? ? ? 91  HIS A CA    1 
+ATOM   2129 C C     . HIS C 3 97  ? 53.078  56.615 113.608 1.00 42.95  ? ? ? ? ? ? 91  HIS A C     1 
+ATOM   2130 O O     . HIS C 3 97  ? 52.335  55.717 113.221 1.00 42.20  ? ? ? ? ? ? 91  HIS A O     1 
+ATOM   2131 C CB    . HIS C 3 97  ? 53.733  57.354 115.932 1.00 39.75  ? ? ? ? ? ? 91  HIS A CB    1 
+ATOM   2132 C CG    . HIS C 3 97  ? 54.209  56.860 117.265 1.00 43.98  ? ? ? ? ? ? 91  HIS A CG    1 
+ATOM   2133 N ND1   . HIS C 3 97  ? 53.415  56.876 118.393 1.00 45.94  ? ? ? ? ? ? 91  HIS A ND1   1 
+ATOM   2134 C CD2   . HIS C 3 97  ? 55.399  56.343 117.651 1.00 43.40  ? ? ? ? ? ? 91  HIS A CD2   1 
+ATOM   2135 C CE1   . HIS C 3 97  ? 54.097  56.393 119.416 1.00 43.64  ? ? ? ? ? ? 91  HIS A CE1   1 
+ATOM   2136 N NE2   . HIS C 3 97  ? 55.301  56.053 118.991 1.00 42.96  ? ? ? ? ? ? 91  HIS A NE2   1 
+ATOM   2137 N N     . LEU C 3 98  ? 53.145  57.809 113.023 1.00 42.06  ? ? ? ? ? ? 92  LEU A N     1 
+ATOM   2138 C CA    . LEU C 3 98  ? 52.332  58.155 111.859 1.00 42.25  ? ? ? ? ? ? 92  LEU A CA    1 
+ATOM   2139 C C     . LEU C 3 98  ? 52.489  57.017 110.864 1.00 47.73  ? ? ? ? ? ? 92  LEU A C     1 
+ATOM   2140 O O     . LEU C 3 98  ? 51.526  56.535 110.269 1.00 49.51  ? ? ? ? ? ? 92  LEU A O     1 
+ATOM   2141 C CB    . LEU C 3 98  ? 52.853  59.444 111.212 1.00 41.15  ? ? ? ? ? ? 92  LEU A CB    1 
+ATOM   2142 C CG    . LEU C 3 98  ? 51.888  60.400 110.503 1.00 43.39  ? ? ? ? ? ? 92  LEU A CG    1 
+ATOM   2143 C CD1   . LEU C 3 98  ? 52.672  61.374 109.638 1.00 40.45  ? ? ? ? ? ? 92  LEU A CD1   1 
+ATOM   2144 C CD2   . LEU C 3 98  ? 50.805  59.679 109.701 1.00 41.65  ? ? ? ? ? ? 92  LEU A CD2   1 
+ATOM   2145 N N     . GLY C 3 99  ? 53.732  56.588 110.696 1.00 41.61  ? ? ? ? ? ? 93  GLY A N     1 
+ATOM   2146 C CA    . GLY C 3 99  ? 54.065  55.524 109.767 1.00 38.81  ? ? ? ? ? ? 93  GLY A CA    1 
+ATOM   2147 C C     . GLY C 3 99  ? 53.276  54.248 110.008 1.00 42.53  ? ? ? ? ? ? 93  GLY A C     1 
+ATOM   2148 O O     . GLY C 3 99  ? 52.679  53.708 109.084 1.00 42.42  ? ? ? ? ? ? 93  GLY A O     1 
+ATOM   2149 N N     . GLN C 3 100 ? 53.307  53.724 111.228 1.00 40.96  ? ? ? ? ? ? 94  GLN A N     1 
+ATOM   2150 C CA    . GLN C 3 100 ? 52.589  52.484 111.501 1.00 40.77  ? ? ? ? ? ? 94  GLN A CA    1 
+ATOM   2151 C C     . GLN C 3 100 ? 51.079  52.713 111.336 1.00 46.31  ? ? ? ? ? ? 94  GLN A C     1 
+ATOM   2152 O O     . GLN C 3 100 ? 50.381  51.878 110.755 1.00 47.71  ? ? ? ? ? ? 94  GLN A O     1 
+ATOM   2153 C CB    . GLN C 3 100 ? 52.960  51.897 112.874 1.00 41.36  ? ? ? ? ? ? 94  GLN A CB    1 
+ATOM   2154 C CG    . GLN C 3 100 ? 54.455  51.571 113.086 1.00 44.78  ? ? ? ? ? ? 94  GLN A CG    1 
+ATOM   2155 C CD    . GLN C 3 100 ? 54.960  50.301 112.365 1.00 68.14  ? ? ? ? ? ? 94  GLN A CD    1 
+ATOM   2156 O OE1   . GLN C 3 100 ? 54.207  49.606 111.695 1.00 59.17  ? ? ? ? ? ? 94  GLN A OE1   1 
+ATOM   2157 N NE2   . GLN C 3 100 ? 56.256  50.030 112.529 1.00 57.53  ? ? ? ? ? ? 94  GLN A NE2   1 
+ATOM   2158 N N     . LEU C 3 101 ? 50.582  53.855 111.808 1.00 38.85  ? ? ? ? ? ? 95  LEU A N     1 
+ATOM   2159 C CA    . LEU C 3 101 ? 49.163  54.182 111.658 1.00 37.09  ? ? ? ? ? ? 95  LEU A CA    1 
+ATOM   2160 C C     . LEU C 3 101 ? 48.802  54.160 110.182 1.00 47.45  ? ? ? ? ? ? 95  LEU A C     1 
+ATOM   2161 O O     . LEU C 3 101 ? 47.846  53.504 109.782 1.00 47.77  ? ? ? ? ? ? 95  LEU A O     1 
+ATOM   2162 C CB    . LEU C 3 101 ? 48.840  55.548 112.250 1.00 35.65  ? ? ? ? ? ? 95  LEU A CB    1 
+ATOM   2163 C CG    . LEU C 3 101 ? 48.672  55.470 113.766 1.00 40.41  ? ? ? ? ? ? 95  LEU A CG    1 
+ATOM   2164 C CD1   . LEU C 3 101 ? 48.398  56.835 114.359 1.00 40.95  ? ? ? ? ? ? 95  LEU A CD1   1 
+ATOM   2165 C CD2   . LEU C 3 101 ? 47.593  54.473 114.156 1.00 43.95  ? ? ? ? ? ? 95  LEU A CD2   1 
+ATOM   2166 N N     . ASN C 3 102 ? 49.598  54.855 109.376 1.00 46.87  ? ? ? ? ? ? 96  ASN A N     1 
+ATOM   2167 C CA    . ASN C 3 102 ? 49.394  54.909 107.937 1.00 46.60  ? ? ? ? ? ? 96  ASN A CA    1 
+ATOM   2168 C C     . ASN C 3 102 ? 49.299  53.503 107.340 1.00 54.25  ? ? ? ? ? ? 96  ASN A C     1 
+ATOM   2169 O O     . ASN C 3 102 ? 48.536  53.274 106.405 1.00 56.60  ? ? ? ? ? ? 96  ASN A O     1 
+ATOM   2170 C CB    . ASN C 3 102 ? 50.552  55.659 107.278 1.00 40.47  ? ? ? ? ? ? 96  ASN A CB    1 
+ATOM   2171 C CG    . ASN C 3 102 ? 50.370  57.157 107.307 1.00 57.61  ? ? ? ? ? ? 96  ASN A CG    1 
+ATOM   2172 O OD1   . ASN C 3 102 ? 49.270  57.665 107.508 1.00 48.08  ? ? ? ? ? ? 96  ASN A OD1   1 
+ATOM   2173 N ND2   . ASN C 3 102 ? 51.464  57.873 107.092 1.00 69.63  ? ? ? ? ? ? 96  ASN A ND2   1 
+ATOM   2174 N N     . MET C 3 103 ? 50.090  52.567 107.854 1.00 53.12  ? ? ? ? ? ? 97  MET A N     1 
+ATOM   2175 C CA    . MET C 3 103 ? 50.075  51.194 107.347 1.00 55.33  ? ? ? ? ? ? 97  MET A CA    1 
+ATOM   2176 C C     . MET C 3 103 ? 48.828  50.453 107.843 1.00 57.76  ? ? ? ? ? ? 97  MET A C     1 
+ATOM   2177 O O     . MET C 3 103 ? 48.134  49.776 107.080 1.00 57.08  ? ? ? ? ? ? 97  MET A O     1 
+ATOM   2178 C CB    . MET C 3 103 ? 51.358  50.448 107.752 1.00 59.22  ? ? ? ? ? ? 97  MET A CB    1 
+ATOM   2179 C CG    . MET C 3 103 ? 51.123  49.147 108.532 1.00 65.02  ? ? ? ? ? ? 97  MET A CG    1 
+ATOM   2180 S SD    . MET C 3 103 ? 52.545  48.026 108.708 1.00 70.76  ? ? ? ? ? ? 97  MET A SD    1 
+ATOM   2181 C CE    . MET C 3 103 ? 51.802  46.447 108.216 1.00 66.41  ? ? ? ? ? ? 97  MET A CE    1 
+ATOM   2182 N N     . LEU C 3 104 ? 48.533  50.595 109.129 1.00 50.09  ? ? ? ? ? ? 98  LEU A N     1 
+ATOM   2183 C CA    . LEU C 3 104 ? 47.356  49.949 109.677 1.00 47.04  ? ? ? ? ? ? 98  LEU A CA    1 
+ATOM   2184 C C     . LEU C 3 104 ? 46.156  50.308 108.801 1.00 51.44  ? ? ? ? ? ? 98  LEU A C     1 
+ATOM   2185 O O     . LEU C 3 104 ? 45.344  49.448 108.476 1.00 54.79  ? ? ? ? ? ? 98  LEU A O     1 
+ATOM   2186 C CB    . LEU C 3 104 ? 47.107  50.379 111.125 1.00 45.83  ? ? ? ? ? ? 98  LEU A CB    1 
+ATOM   2187 C CG    . LEU C 3 104 ? 45.860  49.754 111.754 1.00 47.53  ? ? ? ? ? ? 98  LEU A CG    1 
+ATOM   2188 C CD1   . LEU C 3 104 ? 45.919  48.236 111.727 1.00 46.95  ? ? ? ? ? ? 98  LEU A CD1   1 
+ATOM   2189 C CD2   . LEU C 3 104 ? 45.650  50.264 113.160 1.00 44.58  ? ? ? ? ? ? 98  LEU A CD2   1 
+ATOM   2190 N N     . HIS C 3 105 ? 46.041  51.566 108.395 1.00 45.21  ? ? ? ? ? ? 99  HIS A N     1 
+ATOM   2191 C CA    . HIS C 3 105 ? 44.899  51.994 107.587 1.00 45.75  ? ? ? ? ? ? 99  HIS A CA    1 
+ATOM   2192 C C     . HIS C 3 105 ? 45.003  51.638 106.099 1.00 56.53  ? ? ? ? ? ? 99  HIS A C     1 
+ATOM   2193 O O     . HIS C 3 105 ? 43.993  51.372 105.419 1.00 55.52  ? ? ? ? ? ? 99  HIS A O     1 
+ATOM   2194 C CB    . HIS C 3 105 ? 44.666  53.519 107.763 1.00 46.40  ? ? ? ? ? ? 99  HIS A CB    1 
+ATOM   2195 C CG    . HIS C 3 105 ? 44.298  53.933 109.160 1.00 51.82  ? ? ? ? ? ? 99  HIS A CG    1 
+ATOM   2196 N ND1   . HIS C 3 105 ? 44.953  53.481 110.286 1.00 55.42  ? ? ? ? ? ? 99  HIS A ND1   1 
+ATOM   2197 C CD2   . HIS C 3 105 ? 43.337  54.776 109.613 1.00 55.81  ? ? ? ? ? ? 99  HIS A CD2   1 
+ATOM   2198 C CE1   . HIS C 3 105 ? 44.415  54.020 111.368 1.00 56.28  ? ? ? ? ? ? 99  HIS A CE1   1 
+ATOM   2199 N NE2   . HIS C 3 105 ? 43.433  54.815 110.985 1.00 56.69  ? ? ? ? ? ? 99  HIS A NE2   1 
+ATOM   2200 N N     . ARG C 3 106 ? 46.235  51.642 105.594 1.00 54.91  ? ? ? ? ? ? 100 ARG A N     1 
+ATOM   2201 C CA    . ARG C 3 106 ? 46.510  51.357 104.190 1.00 53.31  ? ? ? ? ? ? 100 ARG A CA    1 
+ATOM   2202 C C     . ARG C 3 106 ? 46.214  49.891 103.895 1.00 60.71  ? ? ? ? ? ? 100 ARG A C     1 
+ATOM   2203 O O     . ARG C 3 106 ? 45.658  49.542 102.855 1.00 61.54  ? ? ? ? ? ? 100 ARG A O     1 
+ATOM   2204 C CB    . ARG C 3 106 ? 47.965  51.694 103.848 1.00 46.10  ? ? ? ? ? ? 100 ARG A CB    1 
+ATOM   2205 C CG    . ARG C 3 106 ? 48.280  51.672 102.359 1.00 65.10  ? ? ? ? ? ? 100 ARG A CG    1 
+ATOM   2206 C CD    . ARG C 3 106 ? 49.771  51.426 102.089 1.00 98.41  ? ? ? ? ? ? 100 ARG A CD    1 
+ATOM   2207 N NE    . ARG C 3 106 ? 50.641  52.374 102.793 1.00 100.00 ? ? ? ? ? ? 100 ARG A NE    1 
+ATOM   2208 C CZ    . ARG C 3 106 ? 51.651  52.041 103.591 1.00 100.00 ? ? ? ? ? ? 100 ARG A CZ    1 
+ATOM   2209 N NH1   . ARG C 3 106 ? 51.943  50.767 103.832 1.00 83.34  ? ? ? ? ? ? 100 ARG A NH1   1 
+ATOM   2210 N NH2   . ARG C 3 106 ? 52.355  52.997 104.191 1.00 87.09  ? ? ? ? ? ? 100 ARG A NH2   1 
+ATOM   2211 N N     . ARG C 3 107 ? 46.574  49.047 104.856 1.00 57.63  ? ? ? ? ? ? 101 ARG A N     1 
+ATOM   2212 C CA    . ARG C 3 107 ? 46.393  47.605 104.775 1.00 57.19  ? ? ? ? ? ? 101 ARG A CA    1 
+ATOM   2213 C C     . ARG C 3 107 ? 45.102  47.174 105.414 1.00 65.96  ? ? ? ? ? ? 101 ARG A C     1 
+ATOM   2214 O O     . ARG C 3 107 ? 44.945  46.020 105.807 1.00 68.27  ? ? ? ? ? ? 101 ARG A O     1 
+ATOM   2215 C CB    . ARG C 3 107 ? 47.488  46.924 105.560 1.00 50.01  ? ? ? ? ? ? 101 ARG A CB    1 
+ATOM   2216 C CG    . ARG C 3 107 ? 48.789  47.045 104.911 1.00 53.11  ? ? ? ? ? ? 101 ARG A CG    1 
+ATOM   2217 C CD    . ARG C 3 107 ? 48.885  45.898 103.997 1.00 42.07  ? ? ? ? ? ? 101 ARG A CD    1 
+ATOM   2218 N NE    . ARG C 3 107 ? 50.257  45.760 103.557 1.00 65.07  ? ? ? ? ? ? 101 ARG A NE    1 
+ATOM   2219 C CZ    . ARG C 3 107 ? 50.585  45.349 102.342 1.00 69.15  ? ? ? ? ? ? 101 ARG A CZ    1 
+ATOM   2220 N NH1   . ARG C 3 107 ? 49.629  45.042 101.473 1.00 38.39  ? ? ? ? ? ? 101 ARG A NH1   1 
+ATOM   2221 N NH2   . ARG C 3 107 ? 51.860  45.235 101.988 1.00 48.85  ? ? ? ? ? ? 101 ARG A NH2   1 
+ATOM   2222 N N     . SER C 3 108 ? 44.169  48.097 105.555 1.00 59.14  ? ? ? ? ? ? 102 SER A N     1 
+ATOM   2223 C CA    . SER C 3 108 ? 42.878  47.707 106.082 1.00 56.16  ? ? ? ? ? ? 102 SER A CA    1 
+ATOM   2224 C C     . SER C 3 108 ? 41.833  48.259 105.114 1.00 55.51  ? ? ? ? ? ? 102 SER A C     1 
+ATOM   2225 O O     . SER C 3 108 ? 40.667  47.881 105.161 1.00 58.07  ? ? ? ? ? ? 102 SER A O     1 
+ATOM   2226 C CB    . SER C 3 108 ? 42.654  48.064 107.555 1.00 54.17  ? ? ? ? ? ? 102 SER A CB    1 
+ATOM   2227 O OG    . SER C 3 108 ? 42.322  49.432 107.699 1.00 67.32  ? ? ? ? ? ? 102 SER A OG    1 
+ATOM   2228 N N     . GLY C 3 109 ? 42.253  49.147 104.219 1.00 43.27  ? ? ? ? ? ? 103 GLY A N     1 
+ATOM   2229 C CA    . GLY C 3 109 ? 41.347  49.667 103.202 1.00 40.70  ? ? ? ? ? ? 103 GLY A CA    1 
+ATOM   2230 C C     . GLY C 3 109 ? 40.841  51.068 103.465 1.00 47.64  ? ? ? ? ? ? 103 GLY A C     1 
+ATOM   2231 O O     . GLY C 3 109 ? 40.094  51.630 102.656 1.00 47.35  ? ? ? ? ? ? 103 GLY A O     1 
+ATOM   2232 N N     . LEU C 3 110 ? 41.253  51.633 104.591 1.00 45.71  ? ? ? ? ? ? 104 LEU A N     1 
+ATOM   2233 C CA    . LEU C 3 110 ? 40.831  52.981 104.947 1.00 44.79  ? ? ? ? ? ? 104 LEU A CA    1 
+ATOM   2234 C C     . LEU C 3 110 ? 41.841  54.031 104.467 1.00 50.37  ? ? ? ? ? ? 104 LEU A C     1 
+ATOM   2235 O O     . LEU C 3 110 ? 42.985  53.701 104.149 1.00 49.77  ? ? ? ? ? ? 104 LEU A O     1 
+ATOM   2236 C CB    . LEU C 3 110 ? 40.549  53.059 106.456 1.00 43.77  ? ? ? ? ? ? 104 LEU A CB    1 
+ATOM   2237 C CG    . LEU C 3 110 ? 39.903  51.770 106.978 1.00 46.34  ? ? ? ? ? ? 104 LEU A CG    1 
+ATOM   2238 C CD1   . LEU C 3 110 ? 39.663  51.731 108.482 1.00 46.38  ? ? ? ? ? ? 104 LEU A CD1   1 
+ATOM   2239 C CD2   . LEU C 3 110 ? 38.615  51.526 106.229 1.00 51.07  ? ? ? ? ? ? 104 LEU A CD2   1 
+ATOM   2240 N N     . PRO C 3 111 ? 41.422  55.285 104.365 1.00 48.18  ? ? ? ? ? ? 105 PRO A N     1 
+ATOM   2241 C CA    . PRO C 3 111 ? 42.364  56.291 103.917 1.00 49.22  ? ? ? ? ? ? 105 PRO A CA    1 
+ATOM   2242 C C     . PRO C 3 111 ? 43.435  56.500 104.995 1.00 53.56  ? ? ? ? ? ? 105 PRO A C     1 
+ATOM   2243 O O     . PRO C 3 111 ? 43.136  56.455 106.194 1.00 51.62  ? ? ? ? ? ? 105 PRO A O     1 
+ATOM   2244 C CB    . PRO C 3 111 ? 41.496  57.546 103.769 1.00 50.17  ? ? ? ? ? ? 105 PRO A CB    1 
+ATOM   2245 C CG    . PRO C 3 111 ? 40.244  57.290 104.546 1.00 51.33  ? ? ? ? ? ? 105 PRO A CG    1 
+ATOM   2246 C CD    . PRO C 3 111 ? 40.295  55.895 105.093 1.00 47.05  ? ? ? ? ? ? 105 PRO A CD    1 
+ATOM   2247 N N     . ARG C 3 112 ? 44.676  56.701 104.563 1.00 49.62  ? ? ? ? ? ? 106 ARG A N     1 
+ATOM   2248 C CA    . ARG C 3 112 ? 45.775  56.936 105.490 1.00 48.50  ? ? ? ? ? ? 106 ARG A CA    1 
+ATOM   2249 C C     . ARG C 3 112 ? 45.651  58.344 106.036 1.00 53.42  ? ? ? ? ? ? 106 ARG A C     1 
+ATOM   2250 O O     . ARG C 3 112 ? 45.117  59.244 105.385 1.00 55.35  ? ? ? ? ? ? 106 ARG A O     1 
+ATOM   2251 C CB    . ARG C 3 112 ? 47.125  56.828 104.789 1.00 46.79  ? ? ? ? ? ? 106 ARG A CB    1 
+ATOM   2252 C CG    . ARG C 3 112 ? 47.359  55.529 104.075 1.00 59.85  ? ? ? ? ? ? 106 ARG A CG    1 
+ATOM   2253 C CD    . ARG C 3 112 ? 48.192  55.787 102.840 1.00 82.13  ? ? ? ? ? ? 106 ARG A CD    1 
+ATOM   2254 N NE    . ARG C 3 112 ? 49.615  55.902 103.141 1.00 84.66  ? ? ? ? ? ? 106 ARG A NE    1 
+ATOM   2255 C CZ    . ARG C 3 112 ? 50.284  57.051 103.194 1.00 100.00 ? ? ? ? ? ? 106 ARG A CZ    1 
+ATOM   2256 N NH1   . ARG C 3 112 ? 49.660  58.206 102.962 1.00 92.24  ? ? ? ? ? ? 106 ARG A NH1   1 
+ATOM   2257 N NH2   . ARG C 3 112 ? 51.580  57.048 103.453 1.00 90.83  ? ? ? ? ? ? 106 ARG A NH2   1 
+ATOM   2258 N N     . PRO C 3 113 ? 46.151  58.523 107.249 1.00 47.32  ? ? ? ? ? ? 107 PRO A N     1 
+ATOM   2259 C CA    . PRO C 3 113 ? 46.121  59.828 107.900 1.00 46.47  ? ? ? ? ? ? 107 PRO A CA    1 
+ATOM   2260 C C     . PRO C 3 113 ? 47.072  60.800 107.184 1.00 48.48  ? ? ? ? ? ? 107 PRO A C     1 
+ATOM   2261 O O     . PRO C 3 113 ? 46.805  61.996 107.083 1.00 45.13  ? ? ? ? ? ? 107 PRO A O     1 
+ATOM   2262 C CB    . PRO C 3 113 ? 46.605  59.512 109.321 1.00 48.37  ? ? ? ? ? ? 107 PRO A CB    1 
+ATOM   2263 C CG    . PRO C 3 113 ? 46.270  58.067 109.524 1.00 51.45  ? ? ? ? ? ? 107 PRO A CG    1 
+ATOM   2264 C CD    . PRO C 3 113 ? 46.449  57.423 108.184 1.00 46.44  ? ? ? ? ? ? 107 PRO A CD    1 
+ATOM   2265 N N     . SER C 3 114 ? 48.169  60.261 106.663 1.00 47.54  ? ? ? ? ? ? 108 SER A N     1 
+ATOM   2266 C CA    . SER C 3 114 ? 49.153  61.059 105.949 1.00 49.51  ? ? ? ? ? ? 108 SER A CA    1 
+ATOM   2267 C C     . SER C 3 114 ? 48.543  61.686 104.703 1.00 64.13  ? ? ? ? ? ? 108 SER A C     1 
+ATOM   2268 O O     . SER C 3 114 ? 49.096  62.615 104.110 1.00 67.57  ? ? ? ? ? ? 108 SER A O     1 
+ATOM   2269 C CB    . SER C 3 114 ? 50.341  60.179 105.598 1.00 51.42  ? ? ? ? ? ? 108 SER A CB    1 
+ATOM   2270 O OG    . SER C 3 114 ? 51.185  60.117 106.729 1.00 66.23  ? ? ? ? ? ? 108 SER A OG    1 
+ATOM   2271 N N     . ASP C 3 115 ? 47.372  61.191 104.330 1.00 61.63  ? ? ? ? ? ? 109 ASP A N     1 
+ATOM   2272 C CA    . ASP C 3 115 ? 46.703  61.708 103.153 1.00 61.77  ? ? ? ? ? ? 109 ASP A CA    1 
+ATOM   2273 C C     . ASP C 3 115 ? 45.829  62.911 103.461 1.00 64.51  ? ? ? ? ? ? 109 ASP A C     1 
+ATOM   2274 O O     . ASP C 3 115 ? 45.094  63.384 102.595 1.00 68.60  ? ? ? ? ? ? 109 ASP A O     1 
+ATOM   2275 C CB    . ASP C 3 115 ? 45.888  60.608 102.472 1.00 64.95  ? ? ? ? ? ? 109 ASP A CB    1 
+ATOM   2276 C CG    . ASP C 3 115 ? 46.762  59.501 101.904 1.00 78.27  ? ? ? ? ? ? 109 ASP A CG    1 
+ATOM   2277 O OD1   . ASP C 3 115 ? 47.996  59.691 101.817 1.00 73.64  ? ? ? ? ? ? 109 ASP A OD1   1 
+ATOM   2278 O OD2   . ASP C 3 115 ? 46.215  58.436 101.547 1.00 92.35  ? ? ? ? ? ? 109 ASP A OD2   1 
+ATOM   2279 N N     . SER C 3 116 ? 45.912  63.413 104.685 1.00 55.31  ? ? ? ? ? ? 110 SER A N     1 
+ATOM   2280 C CA    . SER C 3 116 ? 45.129  64.582 105.042 1.00 54.19  ? ? ? ? ? ? 110 SER A CA    1 
+ATOM   2281 C C     . SER C 3 116 ? 46.007  65.819 105.216 1.00 62.89  ? ? ? ? ? ? 110 SER A C     1 
+ATOM   2282 O O     . SER C 3 116 ? 47.027  65.784 105.904 1.00 63.09  ? ? ? ? ? ? 110 SER A O     1 
+ATOM   2283 C CB    . SER C 3 116 ? 44.347  64.319 106.320 1.00 53.18  ? ? ? ? ? ? 110 SER A CB    1 
+ATOM   2284 O OG    . SER C 3 116 ? 45.206  63.741 107.272 1.00 61.97  ? ? ? ? ? ? 110 SER A OG    1 
+ATOM   2285 N N     . ASN C 3 117 ? 45.592  66.909 104.576 1.00 61.52  ? ? ? ? ? ? 111 ASN A N     1 
+ATOM   2286 C CA    . ASN C 3 117 ? 46.286  68.191 104.660 1.00 59.69  ? ? ? ? ? ? 111 ASN A CA    1 
+ATOM   2287 C C     . ASN C 3 117 ? 46.770  68.447 106.097 1.00 56.67  ? ? ? ? ? ? 111 ASN A C     1 
+ATOM   2288 O O     . ASN C 3 117 ? 47.970  68.596 106.329 1.00 54.45  ? ? ? ? ? ? 111 ASN A O     1 
+ATOM   2289 C CB    . ASN C 3 117 ? 45.358  69.312 104.182 1.00 55.78  ? ? ? ? ? ? 111 ASN A CB    1 
+ATOM   2290 C CG    . ASN C 3 117 ? 46.093  70.590 103.869 1.00 57.24  ? ? ? ? ? ? 111 ASN A CG    1 
+ATOM   2291 O OD1   . ASN C 3 117 ? 47.082  70.597 103.131 1.00 65.99  ? ? ? ? ? ? 111 ASN A OD1   1 
+ATOM   2292 N ND2   . ASN C 3 117 ? 45.610  71.690 104.435 1.00 45.77  ? ? ? ? ? ? 111 ASN A ND2   1 
+ATOM   2293 N N     . ALA C 3 118 ? 45.850  68.469 107.056 1.00 52.27  ? ? ? ? ? ? 112 ALA A N     1 
+ATOM   2294 C CA    . ALA C 3 118 ? 46.221  68.710 108.448 1.00 52.84  ? ? ? ? ? ? 112 ALA A CA    1 
+ATOM   2295 C C     . ALA C 3 118 ? 47.322  67.806 108.999 1.00 54.01  ? ? ? ? ? ? 112 ALA A C     1 
+ATOM   2296 O O     . ALA C 3 118 ? 48.167  68.257 109.768 1.00 53.60  ? ? ? ? ? ? 112 ALA A O     1 
+ATOM   2297 C CB    . ALA C 3 118 ? 44.997  68.675 109.346 1.00 54.24  ? ? ? ? ? ? 112 ALA A CB    1 
+ATOM   2298 N N     . VAL C 3 119 ? 47.319  66.533 108.624 1.00 50.35  ? ? ? ? ? ? 113 VAL A N     1 
+ATOM   2299 C CA    . VAL C 3 119 ? 48.357  65.623 109.103 1.00 50.34  ? ? ? ? ? ? 113 VAL A CA    1 
+ATOM   2300 C C     . VAL C 3 119 ? 49.692  65.864 108.390 1.00 56.64  ? ? ? ? ? ? 113 VAL A C     1 
+ATOM   2301 O O     . VAL C 3 119 ? 50.754  65.779 109.004 1.00 56.49  ? ? ? ? ? ? 113 VAL A O     1 
+ATOM   2302 C CB    . VAL C 3 119 ? 47.953  64.144 108.964 1.00 51.11  ? ? ? ? ? ? 113 VAL A CB    1 
+ATOM   2303 C CG1   . VAL C 3 119 ? 49.188  63.271 108.918 1.00 49.81  ? ? ? ? ? ? 113 VAL A CG1   1 
+ATOM   2304 C CG2   . VAL C 3 119 ? 47.047  63.727 110.113 1.00 49.95  ? ? ? ? ? ? 113 VAL A CG2   1 
+ATOM   2305 N N     . SER C 3 120 ? 49.624  66.189 107.099 1.00 53.62  ? ? ? ? ? ? 114 SER A N     1 
+ATOM   2306 C CA    . SER C 3 120 ? 50.809  66.475 106.295 1.00 54.10  ? ? ? ? ? ? 114 SER A CA    1 
+ATOM   2307 C C     . SER C 3 120 ? 51.481  67.761 106.776 1.00 56.68  ? ? ? ? ? ? 114 SER A C     1 
+ATOM   2308 O O     . SER C 3 120 ? 52.698  67.820 106.958 1.00 55.50  ? ? ? ? ? ? 114 SER A O     1 
+ATOM   2309 C CB    . SER C 3 120 ? 50.424  66.625 104.820 1.00 59.42  ? ? ? ? ? ? 114 SER A CB    1 
+ATOM   2310 O OG    . SER C 3 120 ? 49.356  65.765 104.475 1.00 73.84  ? ? ? ? ? ? 114 SER A OG    1 
+ATOM   2311 N N     . LEU C 3 121 ? 50.671  68.796 106.977 1.00 52.47  ? ? ? ? ? ? 115 LEU A N     1 
+ATOM   2312 C CA    . LEU C 3 121 ? 51.153  70.088 107.445 1.00 52.08  ? ? ? ? ? ? 115 LEU A CA    1 
+ATOM   2313 C C     . LEU C 3 121 ? 51.808  70.018 108.824 1.00 51.89  ? ? ? ? ? ? 115 LEU A C     1 
+ATOM   2314 O O     . LEU C 3 121 ? 52.881  70.576 109.038 1.00 50.57  ? ? ? ? ? ? 115 LEU A O     1 
+ATOM   2315 C CB    . LEU C 3 121 ? 50.003  71.099 107.478 1.00 52.84  ? ? ? ? ? ? 115 LEU A CB    1 
+ATOM   2316 C CG    . LEU C 3 121 ? 49.529  71.638 106.129 1.00 58.65  ? ? ? ? ? ? 115 LEU A CG    1 
+ATOM   2317 C CD1   . LEU C 3 121 ? 48.389  72.620 106.342 1.00 58.07  ? ? ? ? ? ? 115 LEU A CD1   1 
+ATOM   2318 C CD2   . LEU C 3 121 ? 50.673  72.279 105.345 1.00 62.83  ? ? ? ? ? ? 115 LEU A CD2   1 
+ATOM   2319 N N     . VAL C 3 122 ? 51.146  69.360 109.770 1.00 48.07  ? ? ? ? ? ? 116 VAL A N     1 
+ATOM   2320 C CA    . VAL C 3 122 ? 51.685  69.261 111.121 1.00 48.94  ? ? ? ? ? ? 116 VAL A CA    1 
+ATOM   2321 C C     . VAL C 3 122 ? 53.018  68.515 111.244 1.00 52.27  ? ? ? ? ? ? 116 VAL A C     1 
+ATOM   2322 O O     . VAL C 3 122 ? 53.898  68.935 111.993 1.00 51.28  ? ? ? ? ? ? 116 VAL A O     1 
+ATOM   2323 C CB    . VAL C 3 122 ? 50.626  68.771 112.127 1.00 52.99  ? ? ? ? ? ? 116 VAL A CB    1 
+ATOM   2324 C CG1   . VAL C 3 122 ? 50.487  67.256 112.080 1.00 52.76  ? ? ? ? ? ? 116 VAL A CG1   1 
+ATOM   2325 C CG2   . VAL C 3 122 ? 50.929  69.282 113.532 1.00 51.80  ? ? ? ? ? ? 116 VAL A CG2   1 
+ATOM   2326 N N     . MET C 3 123 ? 53.174  67.440 110.474 1.00 49.04  ? ? ? ? ? ? 117 MET A N     1 
+ATOM   2327 C CA    . MET C 3 123 ? 54.402  66.637 110.428 1.00 48.06  ? ? ? ? ? ? 117 MET A CA    1 
+ATOM   2328 C C     . MET C 3 123 ? 55.549  67.542 109.942 1.00 52.12  ? ? ? ? ? ? 117 MET A C     1 
+ATOM   2329 O O     . MET C 3 123 ? 56.643  67.555 110.511 1.00 50.64  ? ? ? ? ? ? 117 MET A O     1 
+ATOM   2330 C CB    . MET C 3 123 ? 54.181  65.475 109.446 1.00 48.91  ? ? ? ? ? ? 117 MET A CB    1 
+ATOM   2331 C CG    . MET C 3 123 ? 54.711  64.118 109.856 1.00 50.70  ? ? ? ? ? ? 117 MET A CG    1 
+ATOM   2332 S SD    . MET C 3 123 ? 54.926  63.931 111.619 1.00 53.90  ? ? ? ? ? ? 117 MET A SD    1 
+ATOM   2333 C CE    . MET C 3 123 ? 56.447  62.976 111.664 1.00 51.19  ? ? ? ? ? ? 117 MET A CE    1 
+ATOM   2334 N N     . ARG C 3 124 ? 55.256  68.319 108.902 1.00 49.31  ? ? ? ? ? ? 118 ARG A N     1 
+ATOM   2335 C CA    . ARG C 3 124 ? 56.197  69.275 108.326 1.00 48.52  ? ? ? ? ? ? 118 ARG A CA    1 
+ATOM   2336 C C     . ARG C 3 124 ? 56.634  70.292 109.370 1.00 52.72  ? ? ? ? ? ? 118 ARG A C     1 
+ATOM   2337 O O     . ARG C 3 124 ? 57.822  70.501 109.591 1.00 54.84  ? ? ? ? ? ? 118 ARG A O     1 
+ATOM   2338 C CB    . ARG C 3 124 ? 55.510  70.029 107.185 1.00 48.15  ? ? ? ? ? ? 118 ARG A CB    1 
+ATOM   2339 C CG    . ARG C 3 124 ? 56.438  70.591 106.119 1.00 54.75  ? ? ? ? ? ? 118 ARG A CG    1 
+ATOM   2340 C CD    . ARG C 3 124 ? 55.641  70.948 104.873 1.00 56.79  ? ? ? ? ? ? 118 ARG A CD    1 
+ATOM   2341 N NE    . ARG C 3 124 ? 56.279  71.993 104.076 1.00 59.18  ? ? ? ? ? ? 118 ARG A NE    1 
+ATOM   2342 C CZ    . ARG C 3 124 ? 55.649  72.712 103.150 1.00 70.96  ? ? ? ? ? ? 118 ARG A CZ    1 
+ATOM   2343 N NH1   . ARG C 3 124 ? 54.367  72.500 102.900 1.00 62.60  ? ? ? ? ? ? 118 ARG A NH1   1 
+ATOM   2344 N NH2   . ARG C 3 124 ? 56.294  73.647 102.466 1.00 56.60  ? ? ? ? ? ? 118 ARG A NH2   1 
+ATOM   2345 N N     . ARG C 3 125 ? 55.667  70.962 109.981 1.00 49.85  ? ? ? ? ? ? 119 ARG A N     1 
+ATOM   2346 C CA    . ARG C 3 125 ? 55.974  71.968 110.983 1.00 51.24  ? ? ? ? ? ? 119 ARG A CA    1 
+ATOM   2347 C C     . ARG C 3 125 ? 56.809  71.371 112.100 1.00 54.09  ? ? ? ? ? ? 119 ARG A C     1 
+ATOM   2348 O O     . ARG C 3 125 ? 57.880  71.887 112.427 1.00 50.10  ? ? ? ? ? ? 119 ARG A O     1 
+ATOM   2349 C CB    . ARG C 3 125 ? 54.676  72.531 111.560 1.00 54.12  ? ? ? ? ? ? 119 ARG A CB    1 
+ATOM   2350 C CG    . ARG C 3 125 ? 54.682  72.662 113.069 1.00 59.75  ? ? ? ? ? ? 119 ARG A CG    1 
+ATOM   2351 C CD    . ARG C 3 125 ? 53.589  73.597 113.562 1.00 63.74  ? ? ? ? ? ? 119 ARG A CD    1 
+ATOM   2352 N NE    . ARG C 3 125 ? 53.321  73.362 114.977 1.00 77.12  ? ? ? ? ? ? 119 ARG A NE    1 
+ATOM   2353 C CZ    . ARG C 3 125 ? 52.187  73.670 115.598 1.00 94.76  ? ? ? ? ? ? 119 ARG A CZ    1 
+ATOM   2354 N NH1   . ARG C 3 125 ? 51.189  74.237 114.931 1.00 75.82  ? ? ? ? ? ? 119 ARG A NH1   1 
+ATOM   2355 N NH2   . ARG C 3 125 ? 52.049  73.409 116.890 1.00 85.02  ? ? ? ? ? ? 119 ARG A NH2   1 
+ATOM   2356 N N     . ILE C 3 126 ? 56.279  70.293 112.680 1.00 54.54  ? ? ? ? ? ? 120 ILE A N     1 
+ATOM   2357 C CA    . ILE C 3 126 ? 56.893  69.536 113.776 1.00 53.83  ? ? ? ? ? ? 120 ILE A CA    1 
+ATOM   2358 C C     . ILE C 3 126 ? 58.329  69.186 113.433 1.00 58.03  ? ? ? ? ? ? 120 ILE A C     1 
+ATOM   2359 O O     . ILE C 3 126 ? 59.244  69.363 114.237 1.00 57.96  ? ? ? ? ? ? 120 ILE A O     1 
+ATOM   2360 C CB    . ILE C 3 126 ? 56.125  68.226 114.058 1.00 54.65  ? ? ? ? ? ? 120 ILE A CB    1 
+ATOM   2361 C CG1   . ILE C 3 126 ? 55.064  68.451 115.138 1.00 53.21  ? ? ? ? ? ? 120 ILE A CG1   1 
+ATOM   2362 C CG2   . ILE C 3 126 ? 57.086  67.111 114.440 1.00 52.97  ? ? ? ? ? ? 120 ILE A CG2   1 
+ATOM   2363 C CD1   . ILE C 3 126 ? 54.292  67.207 115.507 1.00 52.44  ? ? ? ? ? ? 120 ILE A CD1   1 
+ATOM   2364 N N     . ARG C 3 127 ? 58.524  68.707 112.214 1.00 54.33  ? ? ? ? ? ? 121 ARG A N     1 
+ATOM   2365 C CA    . ARG C 3 127 ? 59.857  68.382 111.752 1.00 55.61  ? ? ? ? ? ? 121 ARG A CA    1 
+ATOM   2366 C C     . ARG C 3 127 ? 60.687  69.673 111.780 1.00 62.54  ? ? ? ? ? ? 121 ARG A C     1 
+ATOM   2367 O O     . ARG C 3 127 ? 61.780  69.698 112.348 1.00 61.24  ? ? ? ? ? ? 121 ARG A O     1 
+ATOM   2368 C CB    . ARG C 3 127 ? 59.753  67.820 110.335 1.00 57.87  ? ? ? ? ? ? 121 ARG A CB    1 
+ATOM   2369 C CG    . ARG C 3 127 ? 61.056  67.686 109.582 1.00 68.07  ? ? ? ? ? ? 121 ARG A CG    1 
+ATOM   2370 C CD    . ARG C 3 127 ? 60.839  66.883 108.309 1.00 70.94  ? ? ? ? ? ? 121 ARG A CD    1 
+ATOM   2371 N NE    . ARG C 3 127 ? 61.220  65.488 108.494 1.00 82.44  ? ? ? ? ? ? 121 ARG A NE    1 
+ATOM   2372 C CZ    . ARG C 3 127 ? 62.460  65.094 108.780 1.00 100.00 ? ? ? ? ? ? 121 ARG A CZ    1 
+ATOM   2373 N NH1   . ARG C 3 127 ? 63.427  65.994 108.894 1.00 96.48  ? ? ? ? ? ? 121 ARG A NH1   1 
+ATOM   2374 N NH2   . ARG C 3 127 ? 62.730  63.805 108.893 1.00 100.00 ? ? ? ? ? ? 121 ARG A NH2   1 
+ATOM   2375 N N     . LYS C 3 128 ? 60.146  70.749 111.202 1.00 61.39  ? ? ? ? ? ? 122 LYS A N     1 
+ATOM   2376 C CA    . LYS C 3 128 ? 60.808  72.052 111.148 1.00 60.11  ? ? ? ? ? ? 122 LYS A CA    1 
+ATOM   2377 C C     . LYS C 3 128 ? 61.140  72.569 112.542 1.00 60.81  ? ? ? ? ? ? 122 LYS A C     1 
+ATOM   2378 O O     . LYS C 3 128 ? 62.264  73.007 112.787 1.00 58.43  ? ? ? ? ? ? 122 LYS A O     1 
+ATOM   2379 C CB    . LYS C 3 128 ? 59.930  73.073 110.397 1.00 63.42  ? ? ? ? ? ? 122 LYS A CB    1 
+ATOM   2380 C CG    . LYS C 3 128 ? 60.341  74.550 110.547 1.00 80.18  ? ? ? ? ? ? 122 LYS A CG    1 
+ATOM   2381 C CD    . LYS C 3 128 ? 59.648  75.459 109.521 1.00 73.17  ? ? ? ? ? ? 122 LYS A CD    1 
+ATOM   2382 C CE    . LYS C 3 128 ? 59.502  76.915 109.984 1.00 65.19  ? ? ? ? ? ? 122 LYS A CE    1 
+ATOM   2383 N NZ    . LYS C 3 128 ? 58.552  77.117 111.134 1.00 74.07  ? ? ? ? ? ? 122 LYS A NZ    1 
+ATOM   2384 N N     . GLU C 3 129 ? 60.167  72.510 113.449 1.00 57.46  ? ? ? ? ? ? 123 GLU A N     1 
+ATOM   2385 C CA    . GLU C 3 129 ? 60.353  72.988 114.816 1.00 56.19  ? ? ? ? ? ? 123 GLU A CA    1 
+ATOM   2386 C C     . GLU C 3 129 ? 61.446  72.240 115.588 1.00 60.79  ? ? ? ? ? ? 123 GLU A C     1 
+ATOM   2387 O O     . GLU C 3 129 ? 62.150  72.843 116.396 1.00 62.87  ? ? ? ? ? ? 123 GLU A O     1 
+ATOM   2388 C CB    . GLU C 3 129 ? 59.033  72.935 115.601 1.00 56.95  ? ? ? ? ? ? 123 GLU A CB    1 
+ATOM   2389 C CG    . GLU C 3 129 ? 57.799  73.382 114.827 1.00 61.85  ? ? ? ? ? ? 123 GLU A CG    1 
+ATOM   2390 C CD    . GLU C 3 129 ? 56.695  73.891 115.739 1.00 69.06  ? ? ? ? ? ? 123 GLU A CD    1 
+ATOM   2391 O OE1   . GLU C 3 129 ? 56.337  73.184 116.704 1.00 67.10  ? ? ? ? ? ? 123 GLU A OE1   1 
+ATOM   2392 O OE2   . GLU C 3 129 ? 56.188  75.007 115.495 1.00 58.60  ? ? ? ? ? ? 123 GLU A OE2   1 
+ATOM   2393 N N     . ASN C 3 130 ? 61.548  70.937 115.367 1.00 55.24  ? ? ? ? ? ? 124 ASN A N     1 
+ATOM   2394 C CA    . ASN C 3 130 ? 62.501  70.073 116.068 1.00 54.88  ? ? ? ? ? ? 124 ASN A CA    1 
+ATOM   2395 C C     . ASN C 3 130 ? 63.968  70.226 115.667 1.00 59.79  ? ? ? ? ? ? 124 ASN A C     1 
+ATOM   2396 O O     . ASN C 3 130 ? 64.865  70.311 116.507 1.00 60.48  ? ? ? ? ? ? 124 ASN A O     1 
+ATOM   2397 C CB    . ASN C 3 130 ? 62.045  68.623 115.969 1.00 51.31  ? ? ? ? ? ? 124 ASN A CB    1 
+ATOM   2398 C CG    . ASN C 3 130 ? 61.069  68.245 117.050 1.00 62.50  ? ? ? ? ? ? 124 ASN A CG    1 
+ATOM   2399 O OD1   . ASN C 3 130 ? 60.223  69.050 117.435 1.00 55.06  ? ? ? ? ? ? 124 ASN A OD1   1 
+ATOM   2400 N ND2   . ASN C 3 130 ? 61.196  67.034 117.560 1.00 58.59  ? ? ? ? ? ? 124 ASN A ND2   1 
+ATOM   2401 N N     . VAL C 3 131 ? 64.182  70.233 114.362 1.00 56.75  ? ? ? ? ? ? 125 VAL A N     1 
+ATOM   2402 C CA    . VAL C 3 131 ? 65.504  70.415 113.756 1.00 56.52  ? ? ? ? ? ? 125 VAL A CA    1 
+ATOM   2403 C C     . VAL C 3 131 ? 66.130  71.716 114.347 1.00 66.07  ? ? ? ? ? ? 125 VAL A C     1 
+ATOM   2404 O O     . VAL C 3 131 ? 67.347  71.811 114.522 1.00 68.69  ? ? ? ? ? ? 125 VAL A O     1 
+ATOM   2405 C CB    . VAL C 3 131 ? 65.368  70.440 112.201 1.00 58.41  ? ? ? ? ? ? 125 VAL A CB    1 
+ATOM   2406 C CG1   . VAL C 3 131 ? 66.643  70.926 111.568 1.00 58.12  ? ? ? ? ? ? 125 VAL A CG1   1 
+ATOM   2407 C CG2   . VAL C 3 131 ? 64.980  69.052 111.655 1.00 57.38  ? ? ? ? ? ? 125 VAL A CG2   1 
+ATOM   2408 N N     . ASP C 3 132 ? 65.278  72.694 114.696 1.00 60.85  ? ? ? ? ? ? 126 ASP A N     1 
+ATOM   2409 C CA    . ASP C 3 132 ? 65.535  74.050 115.261 1.00 60.20  ? ? ? ? ? ? 126 ASP A CA    1 
+ATOM   2410 C C     . ASP C 3 132 ? 65.463  74.162 116.783 1.00 69.09  ? ? ? ? ? ? 126 ASP A C     1 
+ATOM   2411 O O     . ASP C 3 132 ? 65.095  75.217 117.323 1.00 71.29  ? ? ? ? ? ? 126 ASP A O     1 
+ATOM   2412 C CB    . ASP C 3 132 ? 64.443  75.031 114.812 1.00 62.16  ? ? ? ? ? ? 126 ASP A CB    1 
+ATOM   2413 C CG    . ASP C 3 132 ? 64.792  75.767 113.536 1.00 85.81  ? ? ? ? ? ? 126 ASP A CG    1 
+ATOM   2414 O OD1   . ASP C 3 132 ? 65.978  75.739 113.135 1.00 90.05  ? ? ? ? ? ? 126 ASP A OD1   1 
+ATOM   2415 O OD2   . ASP C 3 132 ? 63.865  76.362 112.934 1.00 88.44  ? ? ? ? ? ? 126 ASP A OD2   1 
+ATOM   2416 N N     . ALA C 3 133 ? 65.709  73.056 117.458 1.00 65.12  ? ? ? ? ? ? 127 ALA A N     1 
+ATOM   2417 C CA    . ALA C 3 133 ? 65.693  73.041 118.916 1.00 63.76  ? ? ? ? ? ? 127 ALA A CA    1 
+ATOM   2418 C C     . ALA C 3 133 ? 66.970  72.283 119.164 1.00 66.17  ? ? ? ? ? ? 127 ALA A C     1 
+ATOM   2419 O O     . ALA C 3 133 ? 67.368  72.071 120.298 1.00 65.24  ? ? ? ? ? ? 127 ALA A O     1 
+ATOM   2420 C CB    . ALA C 3 133 ? 64.494  72.260 119.407 1.00 64.94  ? ? ? ? ? ? 127 ALA A CB    1 
+ATOM   2421 N N     . GLY C 3 134 ? 67.588  71.900 118.049 1.00 66.14  ? ? ? ? ? ? 128 GLY A N     1 
+ATOM   2422 C CA    . GLY C 3 134 ? 68.851  71.192 118.041 1.00 68.85  ? ? ? ? ? ? 128 GLY A CA    1 
+ATOM   2423 C C     . GLY C 3 134 ? 68.736  69.687 117.859 1.00 77.18  ? ? ? ? ? ? 128 GLY A C     1 
+ATOM   2424 O O     . GLY C 3 134 ? 69.668  68.948 118.174 1.00 76.53  ? ? ? ? ? ? 128 GLY A O     1 
+ATOM   2425 N N     . GLU C 3 135 ? 67.616  69.223 117.319 1.00 76.39  ? ? ? ? ? ? 129 GLU A N     1 
+ATOM   2426 C CA    . GLU C 3 135 ? 67.460  67.787 117.127 1.00 76.08  ? ? ? ? ? ? 129 GLU A CA    1 
+ATOM   2427 C C     . GLU C 3 135 ? 68.674  67.066 116.545 1.00 78.87  ? ? ? ? ? ? 129 GLU A C     1 
+ATOM   2428 O O     . GLU C 3 135 ? 69.015  67.217 115.366 1.00 78.50  ? ? ? ? ? ? 129 GLU A O     1 
+ATOM   2429 C CB    . GLU C 3 135 ? 66.158  67.398 116.425 1.00 77.70  ? ? ? ? ? ? 129 GLU A CB    1 
+ATOM   2430 C CG    . GLU C 3 135 ? 65.937  65.891 116.461 1.00 84.59  ? ? ? ? ? ? 129 GLU A CG    1 
+ATOM   2431 C CD    . GLU C 3 135 ? 64.513  65.478 116.772 1.00 84.75  ? ? ? ? ? ? 129 GLU A CD    1 
+ATOM   2432 O OE1   . GLU C 3 135 ? 64.054  65.644 117.925 1.00 56.48  ? ? ? ? ? ? 129 GLU A OE1   1 
+ATOM   2433 O OE2   . GLU C 3 135 ? 63.861  64.963 115.843 1.00 70.06  ? ? ? ? ? ? 129 GLU A OE2   1 
+ATOM   2434 N N     . ARG C 3 136 ? 69.309  66.264 117.396 1.00 73.32  ? ? ? ? ? ? 130 ARG A N     1 
+ATOM   2435 C CA    . ARG C 3 136 ? 70.490  65.506 117.006 1.00 71.71  ? ? ? ? ? ? 130 ARG A CA    1 
+ATOM   2436 C C     . ARG C 3 136 ? 70.302  64.022 116.747 1.00 68.19  ? ? ? ? ? ? 130 ARG A C     1 
+ATOM   2437 O O     . ARG C 3 136 ? 70.006  63.253 117.654 1.00 68.17  ? ? ? ? ? ? 130 ARG A O     1 
+ATOM   2438 C CB    . ARG C 3 136 ? 71.596  65.685 118.038 1.00 74.75  ? ? ? ? ? ? 130 ARG A CB    1 
+ATOM   2439 C CG    . ARG C 3 136 ? 71.994  67.124 118.178 1.00 70.55  ? ? ? ? ? ? 130 ARG A CG    1 
+ATOM   2440 C CD    . ARG C 3 136 ? 72.382  67.650 116.819 1.00 53.81  ? ? ? ? ? ? 130 ARG A CD    1 
+ATOM   2441 N NE    . ARG C 3 136 ? 73.705  68.252 116.898 1.00 84.64  ? ? ? ? ? ? 130 ARG A NE    1 
+ATOM   2442 C CZ    . ARG C 3 136 ? 73.924  69.498 117.305 1.00 100.00 ? ? ? ? ? ? 130 ARG A CZ    1 
+ATOM   2443 N NH1   . ARG C 3 136 ? 72.901  70.276 117.640 1.00 83.55  ? ? ? ? ? ? 130 ARG A NH1   1 
+ATOM   2444 N NH2   . ARG C 3 136 ? 75.162  69.974 117.357 1.00 97.88  ? ? ? ? ? ? 130 ARG A NH2   1 
+ATOM   2445 N N     . ALA C 3 137 ? 70.551  63.609 115.511 1.00 60.26  ? ? ? ? ? ? 131 ALA A N     1 
+ATOM   2446 C CA    . ALA C 3 137 ? 70.470  62.186 115.208 1.00 59.35  ? ? ? ? ? ? 131 ALA A CA    1 
+ATOM   2447 C C     . ALA C 3 137 ? 71.749  61.569 115.781 1.00 65.69  ? ? ? ? ? ? 131 ALA A C     1 
+ATOM   2448 O O     . ALA C 3 137 ? 72.850  61.959 115.401 1.00 69.37  ? ? ? ? ? ? 131 ALA A O     1 
+ATOM   2449 C CB    . ALA C 3 137 ? 70.390  61.961 113.710 1.00 59.65  ? ? ? ? ? ? 131 ALA A CB    1 
+ATOM   2450 N N     . LYS C 3 138 ? 71.617  60.645 116.728 1.00 59.72  ? ? ? ? ? ? 132 LYS A N     1 
+ATOM   2451 C CA    . LYS C 3 138 ? 72.785  60.035 117.363 1.00 58.77  ? ? ? ? ? ? 132 LYS A CA    1 
+ATOM   2452 C C     . LYS C 3 138 ? 73.268  58.772 116.627 1.00 65.41  ? ? ? ? ? ? 132 LYS A C     1 
+ATOM   2453 O O     . LYS C 3 138 ? 72.524  58.210 115.826 1.00 65.41  ? ? ? ? ? ? 132 LYS A O     1 
+ATOM   2454 C CB    . LYS C 3 138 ? 72.468  59.734 118.836 1.00 60.38  ? ? ? ? ? ? 132 LYS A CB    1 
+ATOM   2455 C CG    . LYS C 3 138 ? 71.619  60.802 119.538 1.00 67.99  ? ? ? ? ? ? 132 LYS A CG    1 
+ATOM   2456 C CD    . LYS C 3 138 ? 72.450  61.648 120.504 1.00 78.35  ? ? ? ? ? ? 132 LYS A CD    1 
+ATOM   2457 C CE    . LYS C 3 138 ? 72.066  61.417 121.967 1.00 75.14  ? ? ? ? ? ? 132 LYS A CE    1 
+ATOM   2458 N NZ    . LYS C 3 138 ? 73.254  61.397 122.881 1.00 76.96  ? ? ? ? ? ? 132 LYS A NZ    1 
+ATOM   2459 N N     . GLN C 3 139 ? 74.515  58.354 116.872 1.00 63.63  ? ? ? ? ? ? 133 GLN A N     1 
+ATOM   2460 C CA    . GLN C 3 139 ? 75.119  57.134 116.311 1.00 62.99  ? ? ? ? ? ? 133 GLN A CA    1 
+ATOM   2461 C C     . GLN C 3 139 ? 75.965  56.543 117.438 1.00 68.07  ? ? ? ? ? ? 133 GLN A C     1 
+ATOM   2462 O O     . GLN C 3 139 ? 76.282  57.229 118.406 1.00 70.14  ? ? ? ? ? ? 133 GLN A O     1 
+ATOM   2463 C CB    . GLN C 3 139 ? 75.997  57.373 115.057 1.00 64.39  ? ? ? ? ? ? 133 GLN A CB    1 
+ATOM   2464 C CG    . GLN C 3 139 ? 76.707  58.736 114.886 1.00 70.73  ? ? ? ? ? ? 133 GLN A CG    1 
+ATOM   2465 C CD    . GLN C 3 139 ? 78.186  58.624 114.491 1.00 100.00 ? ? ? ? ? ? 133 GLN A CD    1 
+ATOM   2466 O OE1   . GLN C 3 139 ? 78.954  57.866 115.094 1.00 100.00 ? ? ? ? ? ? 133 GLN A OE1   1 
+ATOM   2467 N NE2   . GLN C 3 139 ? 78.610  59.377 113.481 1.00 100.00 ? ? ? ? ? ? 133 GLN A NE2   1 
+ATOM   2468 N N     . ALA C 3 140 ? 76.315  55.268 117.324 1.00 63.49  ? ? ? ? ? ? 134 ALA A N     1 
+ATOM   2469 C CA    . ALA C 3 140 ? 77.103  54.574 118.344 1.00 62.53  ? ? ? ? ? ? 134 ALA A CA    1 
+ATOM   2470 C C     . ALA C 3 140 ? 78.458  55.191 118.706 1.00 65.00  ? ? ? ? ? ? 134 ALA A C     1 
+ATOM   2471 O O     . ALA C 3 140 ? 79.174  55.707 117.839 1.00 64.33  ? ? ? ? ? ? 134 ALA A O     1 
+ATOM   2472 C CB    . ALA C 3 140 ? 77.281  53.099 117.966 1.00 62.52  ? ? ? ? ? ? 134 ALA A CB    1 
+ATOM   2473 N N     . LEU C 3 141 ? 78.815  55.102 119.988 1.00 58.87  ? ? ? ? ? ? 135 LEU A N     1 
+ATOM   2474 C CA    . LEU C 3 141 ? 80.095  55.601 120.483 1.00 57.27  ? ? ? ? ? ? 135 LEU A CA    1 
+ATOM   2475 C C     . LEU C 3 141 ? 81.168  54.698 119.884 1.00 54.34  ? ? ? ? ? ? 135 LEU A C     1 
+ATOM   2476 O O     . LEU C 3 141 ? 81.084  53.479 120.000 1.00 52.03  ? ? ? ? ? ? 135 LEU A O     1 
+ATOM   2477 C CB    . LEU C 3 141 ? 80.128  55.491 122.003 1.00 58.14  ? ? ? ? ? ? 135 LEU A CB    1 
+ATOM   2478 C CG    . LEU C 3 141 ? 80.883  56.554 122.801 1.00 64.20  ? ? ? ? ? ? 135 LEU A CG    1 
+ATOM   2479 C CD1   . LEU C 3 141 ? 81.079  56.031 124.210 1.00 65.52  ? ? ? ? ? ? 135 LEU A CD1   1 
+ATOM   2480 C CD2   . LEU C 3 141 ? 82.233  56.851 122.156 1.00 64.04  ? ? ? ? ? ? 135 LEU A CD2   1 
+ATOM   2481 N N     . ALA C 3 142 ? 82.156  55.270 119.205 1.00 46.97  ? ? ? ? ? ? 136 ALA A N     1 
+ATOM   2482 C CA    . ALA C 3 142 ? 83.133  54.404 118.566 1.00 45.72  ? ? ? ? ? ? 136 ALA A CA    1 
+ATOM   2483 C C     . ALA C 3 142 ? 83.851  53.480 119.519 1.00 51.20  ? ? ? ? ? ? 136 ALA A C     1 
+ATOM   2484 O O     . ALA C 3 142 ? 84.023  53.792 120.694 1.00 52.11  ? ? ? ? ? ? 136 ALA A O     1 
+ATOM   2485 C CB    . ALA C 3 142 ? 84.121  55.191 117.740 1.00 46.26  ? ? ? ? ? ? 136 ALA A CB    1 
+ATOM   2486 N N     . PHE C 3 143 ? 84.251  52.330 118.995 1.00 48.69  ? ? ? ? ? ? 137 PHE A N     1 
+ATOM   2487 C CA    . PHE C 3 143 ? 85.040  51.363 119.740 1.00 48.67  ? ? ? ? ? ? 137 PHE A CA    1 
+ATOM   2488 C C     . PHE C 3 143 ? 86.143  51.096 118.738 1.00 54.82  ? ? ? ? ? ? 137 PHE A C     1 
+ATOM   2489 O O     . PHE C 3 143 ? 86.031  50.224 117.877 1.00 53.82  ? ? ? ? ? ? 137 PHE A O     1 
+ATOM   2490 C CB    . PHE C 3 143 ? 84.270  50.087 120.050 1.00 50.15  ? ? ? ? ? ? 137 PHE A CB    1 
+ATOM   2491 C CG    . PHE C 3 143 ? 85.097  49.056 120.749 1.00 52.17  ? ? ? ? ? ? 137 PHE A CG    1 
+ATOM   2492 C CD1   . PHE C 3 143 ? 85.394  49.194 122.097 1.00 55.36  ? ? ? ? ? ? 137 PHE A CD1   1 
+ATOM   2493 C CD2   . PHE C 3 143 ? 85.600  47.967 120.056 1.00 54.38  ? ? ? ? ? ? 137 PHE A CD2   1 
+ATOM   2494 C CE1   . PHE C 3 143 ? 86.173  48.258 122.750 1.00 55.57  ? ? ? ? ? ? 137 PHE A CE1   1 
+ATOM   2495 C CE2   . PHE C 3 143 ? 86.382  47.030 120.698 1.00 57.29  ? ? ? ? ? ? 137 PHE A CE2   1 
+ATOM   2496 C CZ    . PHE C 3 143 ? 86.664  47.172 122.048 1.00 55.36  ? ? ? ? ? ? 137 PHE A CZ    1 
+ATOM   2497 N N     . GLU C 3 144 ? 87.165  51.940 118.807 1.00 55.13  ? ? ? ? ? ? 138 GLU A N     1 
+ATOM   2498 C CA    . GLU C 3 144 ? 88.281  51.892 117.883 1.00 55.86  ? ? ? ? ? ? 138 GLU A CA    1 
+ATOM   2499 C C     . GLU C 3 144 ? 89.449  51.077 118.442 1.00 68.79  ? ? ? ? ? ? 138 GLU A C     1 
+ATOM   2500 O O     . GLU C 3 144 ? 89.431  50.672 119.607 1.00 71.40  ? ? ? ? ? ? 138 GLU A O     1 
+ATOM   2501 C CB    . GLU C 3 144 ? 88.704  53.321 117.525 1.00 56.47  ? ? ? ? ? ? 138 GLU A CB    1 
+ATOM   2502 C CG    . GLU C 3 144 ? 87.614  54.378 117.703 1.00 58.89  ? ? ? ? ? ? 138 GLU A CG    1 
+ATOM   2503 C CD    . GLU C 3 144 ? 87.728  55.496 116.683 1.00 78.79  ? ? ? ? ? ? 138 GLU A CD    1 
+ATOM   2504 O OE1   . GLU C 3 144 ? 87.309  55.279 115.532 1.00 88.71  ? ? ? ? ? ? 138 GLU A OE1   1 
+ATOM   2505 O OE2   . GLU C 3 144 ? 88.247  56.585 117.019 1.00 76.12  ? ? ? ? ? ? 138 GLU A OE2   1 
+ATOM   2506 N N     . ARG C 3 145 ? 90.444  50.823 117.593 1.00 66.45  ? ? ? ? ? ? 139 ARG A N     1 
+ATOM   2507 C CA    . ARG C 3 145 ? 91.628  50.056 117.970 1.00 66.15  ? ? ? ? ? ? 139 ARG A CA    1 
+ATOM   2508 C C     . ARG C 3 145 ? 92.241  50.528 119.283 1.00 72.30  ? ? ? ? ? ? 139 ARG A C     1 
+ATOM   2509 O O     . ARG C 3 145 ? 92.669  49.716 120.106 1.00 73.25  ? ? ? ? ? ? 139 ARG A O     1 
+ATOM   2510 C CB    . ARG C 3 145 ? 92.694  50.123 116.883 1.00 61.45  ? ? ? ? ? ? 139 ARG A CB    1 
+ATOM   2511 C CG    . ARG C 3 145 ? 94.076  49.853 117.431 1.00 58.79  ? ? ? ? ? ? 139 ARG A CG    1 
+ATOM   2512 C CD    . ARG C 3 145 ? 94.736  48.715 116.696 1.00 69.77  ? ? ? ? ? ? 139 ARG A CD    1 
+ATOM   2513 N NE    . ARG C 3 145 ? 94.261  47.411 117.141 1.00 89.57  ? ? ? ? ? ? 139 ARG A NE    1 
+ATOM   2514 C CZ    . ARG C 3 145 ? 94.527  46.271 116.515 1.00 100.00 ? ? ? ? ? ? 139 ARG A CZ    1 
+ATOM   2515 N NH1   . ARG C 3 145 ? 95.277  46.278 115.417 1.00 93.14  ? ? ? ? ? ? 139 ARG A NH1   1 
+ATOM   2516 N NH2   . ARG C 3 145 ? 94.069  45.121 116.995 1.00 100.00 ? ? ? ? ? ? 139 ARG A NH2   1 
+ATOM   2517 N N     . THR C 3 146 ? 92.311  51.841 119.472 1.00 67.78  ? ? ? ? ? ? 140 THR A N     1 
+ATOM   2518 C CA    . THR C 3 146 ? 92.884  52.359 120.704 1.00 67.80  ? ? ? ? ? ? 140 THR A CA    1 
+ATOM   2519 C C     . THR C 3 146 ? 92.074  51.747 121.833 1.00 71.18  ? ? ? ? ? ? 140 THR A C     1 
+ATOM   2520 O O     . THR C 3 146 ? 92.587  51.478 122.917 1.00 71.46  ? ? ? ? ? ? 140 THR A O     1 
+ATOM   2521 C CB    . THR C 3 146 ? 92.754  53.884 120.793 1.00 81.42  ? ? ? ? ? ? 140 THR A CB    1 
+ATOM   2522 O OG1   . THR C 3 146 ? 91.450  54.216 121.286 1.00 79.19  ? ? ? ? ? ? 140 THR A OG1   1 
+ATOM   2523 C CG2   . THR C 3 146 ? 92.951  54.514 119.426 1.00 87.48  ? ? ? ? ? ? 140 THR A CG2   1 
+ATOM   2524 N N     . ASP C 3 147 ? 90.795  51.520 121.559 1.00 66.11  ? ? ? ? ? ? 141 ASP A N     1 
+ATOM   2525 C CA    . ASP C 3 147 ? 89.892  50.946 122.549 1.00 64.23  ? ? ? ? ? ? 141 ASP A CA    1 
+ATOM   2526 C C     . ASP C 3 147 ? 90.085  49.441 122.759 1.00 67.65  ? ? ? ? ? ? 141 ASP A C     1 
+ATOM   2527 O O     . ASP C 3 147 ? 90.100  48.949 123.887 1.00 66.12  ? ? ? ? ? ? 141 ASP A O     1 
+ATOM   2528 C CB    . ASP C 3 147 ? 88.443  51.311 122.216 1.00 65.27  ? ? ? ? ? ? 141 ASP A CB    1 
+ATOM   2529 C CG    . ASP C 3 147 ? 88.157  52.795 122.409 1.00 76.59  ? ? ? ? ? ? 141 ASP A CG    1 
+ATOM   2530 O OD1   . ASP C 3 147 ? 88.168  53.258 123.570 1.00 80.80  ? ? ? ? ? ? 141 ASP A OD1   1 
+ATOM   2531 O OD2   . ASP C 3 147 ? 87.909  53.499 121.406 1.00 73.65  ? ? ? ? ? ? 141 ASP A OD2   1 
+ATOM   2532 N N     . PHE C 3 148 ? 90.265  48.726 121.655 1.00 65.19  ? ? ? ? ? ? 142 PHE A N     1 
+ATOM   2533 C CA    . PHE C 3 148 ? 90.472  47.281 121.664 1.00 66.11  ? ? ? ? ? ? 142 PHE A CA    1 
+ATOM   2534 C C     . PHE C 3 148 ? 91.790  46.911 122.349 1.00 75.19  ? ? ? ? ? ? 142 PHE A C     1 
+ATOM   2535 O O     . PHE C 3 148 ? 91.828  46.009 123.187 1.00 76.09  ? ? ? ? ? ? 142 PHE A O     1 
+ATOM   2536 C CB    . PHE C 3 148 ? 90.438  46.771 120.221 1.00 67.46  ? ? ? ? ? ? 142 PHE A CB    1 
+ATOM   2537 C CG    . PHE C 3 148 ? 90.406  45.272 120.093 1.00 69.13  ? ? ? ? ? ? 142 PHE A CG    1 
+ATOM   2538 C CD1   . PHE C 3 148 ? 89.600  44.485 120.907 1.00 70.60  ? ? ? ? ? ? 142 PHE A CD1   1 
+ATOM   2539 C CD2   . PHE C 3 148 ? 91.185  44.644 119.131 1.00 71.74  ? ? ? ? ? ? 142 PHE A CD2   1 
+ATOM   2540 C CE1   . PHE C 3 148 ? 89.583  43.099 120.766 1.00 70.81  ? ? ? ? ? ? 142 PHE A CE1   1 
+ATOM   2541 C CE2   . PHE C 3 148 ? 91.169  43.266 118.980 1.00 72.95  ? ? ? ? ? ? 142 PHE A CE2   1 
+ATOM   2542 C CZ    . PHE C 3 148 ? 90.372  42.491 119.802 1.00 70.03  ? ? ? ? ? ? 142 PHE A CZ    1 
+ATOM   2543 N N     . ASP C 3 149 ? 92.860  47.627 122.013 1.00 72.86  ? ? ? ? ? ? 143 ASP A N     1 
+ATOM   2544 C CA    . ASP C 3 149 ? 94.175  47.388 122.603 1.00 71.94  ? ? ? ? ? ? 143 ASP A CA    1 
+ATOM   2545 C C     . ASP C 3 149 ? 94.137  47.565 124.108 1.00 71.15  ? ? ? ? ? ? 143 ASP A C     1 
+ATOM   2546 O O     . ASP C 3 149 ? 94.597  46.711 124.865 1.00 70.10  ? ? ? ? ? ? 143 ASP A O     1 
+ATOM   2547 C CB    . ASP C 3 149 ? 95.185  48.371 122.022 1.00 74.95  ? ? ? ? ? ? 143 ASP A CB    1 
+ATOM   2548 C CG    . ASP C 3 149 ? 95.737  47.909 120.696 1.00 91.23  ? ? ? ? ? ? 143 ASP A CG    1 
+ATOM   2549 O OD1   . ASP C 3 149 ? 95.521  46.734 120.329 1.00 90.82  ? ? ? ? ? ? 143 ASP A OD1   1 
+ATOM   2550 O OD2   . ASP C 3 149 ? 96.390  48.724 120.015 1.00 100.00 ? ? ? ? ? ? 143 ASP A OD2   1 
+ATOM   2551 N N     . GLN C 3 150 ? 93.594  48.705 124.520 1.00 66.07  ? ? ? ? ? ? 144 GLN A N     1 
+ATOM   2552 C CA    . GLN C 3 150 ? 93.479  49.042 125.929 1.00 64.61  ? ? ? ? ? ? 144 GLN A CA    1 
+ATOM   2553 C C     . GLN C 3 150 ? 92.645  48.018 126.679 1.00 70.50  ? ? ? ? ? ? 144 GLN A C     1 
+ATOM   2554 O O     . GLN C 3 150 ? 92.923  47.702 127.837 1.00 71.88  ? ? ? ? ? ? 144 GLN A O     1 
+ATOM   2555 C CB    . GLN C 3 150 ? 92.835  50.408 126.123 1.00 64.30  ? ? ? ? ? ? 144 GLN A CB    1 
+ATOM   2556 C CG    . GLN C 3 150 ? 92.393  50.601 127.563 1.00 63.41  ? ? ? ? ? ? 144 GLN A CG    1 
+ATOM   2557 C CD    . GLN C 3 150 ? 92.028  52.024 127.880 1.00 98.81  ? ? ? ? ? ? 144 GLN A CD    1 
+ATOM   2558 O OE1   . GLN C 3 150 ? 91.518  52.308 128.969 1.00 100.00 ? ? ? ? ? ? 144 GLN A OE1   1 
+ATOM   2559 N NE2   . GLN C 3 150 ? 92.241  52.932 126.940 1.00 98.25  ? ? ? ? ? ? 144 GLN A NE2   1 
+ATOM   2560 N N     . VAL C 3 151 ? 91.586  47.538 126.036 1.00 66.77  ? ? ? ? ? ? 145 VAL A N     1 
+ATOM   2561 C CA    . VAL C 3 151 ? 90.715  46.552 126.660 1.00 66.13  ? ? ? ? ? ? 145 VAL A CA    1 
+ATOM   2562 C C     . VAL C 3 151 ? 91.506  45.264 126.651 1.00 69.86  ? ? ? ? ? ? 145 VAL A C     1 
+ATOM   2563 O O     . VAL C 3 151 ? 91.619  44.580 127.669 1.00 67.95  ? ? ? ? ? ? 145 VAL A O     1 
+ATOM   2564 C CB    . VAL C 3 151 ? 89.400  46.371 125.875 1.00 69.21  ? ? ? ? ? ? 145 VAL A CB    1 
+ATOM   2565 C CG1   . VAL C 3 151 ? 88.551  45.267 126.486 1.00 68.39  ? ? ? ? ? ? 145 VAL A CG1   1 
+ATOM   2566 C CG2   . VAL C 3 151 ? 88.619  47.668 125.878 1.00 69.17  ? ? ? ? ? ? 145 VAL A CG2   1 
+ATOM   2567 N N     . ARG C 3 152 ? 92.082  44.974 125.492 1.00 69.63  ? ? ? ? ? ? 146 ARG A N     1 
+ATOM   2568 C CA    . ARG C 3 152 ? 92.921  43.800 125.313 1.00 71.09  ? ? ? ? ? ? 146 ARG A CA    1 
+ATOM   2569 C C     . ARG C 3 152 ? 93.999  43.823 126.399 1.00 78.99  ? ? ? ? ? ? 146 ARG A C     1 
+ATOM   2570 O O     . ARG C 3 152 ? 94.375  42.784 126.936 1.00 78.98  ? ? ? ? ? ? 146 ARG A O     1 
+ATOM   2571 C CB    . ARG C 3 152 ? 93.593  43.895 123.945 1.00 72.38  ? ? ? ? ? ? 146 ARG A CB    1 
+ATOM   2572 C CG    . ARG C 3 152 ? 93.514  42.645 123.101 1.00 82.04  ? ? ? ? ? ? 146 ARG A CG    1 
+ATOM   2573 C CD    . ARG C 3 152 ? 94.803  42.475 122.314 1.00 93.87  ? ? ? ? ? ? 146 ARG A CD    1 
+ATOM   2574 N NE    . ARG C 3 152 ? 94.729  43.113 121.005 1.00 95.46  ? ? ? ? ? ? 146 ARG A NE    1 
+ATOM   2575 C CZ    . ARG C 3 152 ? 94.277  42.502 119.917 1.00 100.00 ? ? ? ? ? ? 146 ARG A CZ    1 
+ATOM   2576 N NH1   . ARG C 3 152 ? 93.855  41.245 119.997 1.00 95.43  ? ? ? ? ? ? 146 ARG A NH1   1 
+ATOM   2577 N NH2   . ARG C 3 152 ? 94.226  43.144 118.757 1.00 92.74  ? ? ? ? ? ? 146 ARG A NH2   1 
+ATOM   2578 N N     . SER C 3 153 ? 94.502  45.014 126.715 1.00 77.08  ? ? ? ? ? ? 147 SER A N     1 
+ATOM   2579 C CA    . SER C 3 153 ? 95.536  45.155 127.731 1.00 78.29  ? ? ? ? ? ? 147 SER A CA    1 
+ATOM   2580 C C     . SER C 3 153 ? 95.053  44.755 129.127 1.00 87.03  ? ? ? ? ? ? 147 SER A C     1 
+ATOM   2581 O O     . SER C 3 153 ? 95.711  43.972 129.811 1.00 89.64  ? ? ? ? ? ? 147 SER A O     1 
+ATOM   2582 C CB    . SER C 3 153 ? 96.094  46.577 127.741 1.00 82.13  ? ? ? ? ? ? 147 SER A CB    1 
+ATOM   2583 O OG    . SER C 3 153 ? 96.084  47.109 129.055 1.00 93.44  ? ? ? ? ? ? 147 SER A OG    1 
+ATOM   2584 N N     . LEU C 3 154 ? 93.901  45.285 129.529 1.00 83.44  ? ? ? ? ? ? 148 LEU A N     1 
+ATOM   2585 C CA    . LEU C 3 154 ? 93.302  44.996 130.825 1.00 83.78  ? ? ? ? ? ? 148 LEU A CA    1 
+ATOM   2586 C C     . LEU C 3 154 ? 92.676  43.612 130.910 1.00 89.75  ? ? ? ? ? ? 148 LEU A C     1 
+ATOM   2587 O O     . LEU C 3 154 ? 92.116  43.265 131.947 1.00 92.06  ? ? ? ? ? ? 148 LEU A O     1 
+ATOM   2588 C CB    . LEU C 3 154 ? 92.194  46.004 131.113 1.00 84.14  ? ? ? ? ? ? 148 LEU A CB    1 
+ATOM   2589 C CG    . LEU C 3 154 ? 92.659  47.219 131.906 1.00 90.35  ? ? ? ? ? ? 148 LEU A CG    1 
+ATOM   2590 C CD1   . LEU C 3 154 ? 91.940  48.465 131.426 1.00 91.72  ? ? ? ? ? ? 148 LEU A CD1   1 
+ATOM   2591 C CD2   . LEU C 3 154 ? 92.409  46.991 133.387 1.00 94.83  ? ? ? ? ? ? 148 LEU A CD2   1 
+ATOM   2592 N N     . MET C 3 155 ? 92.731  42.821 129.842 1.00 85.71  ? ? ? ? ? ? 149 MET A N     1 
+ATOM   2593 C CA    . MET C 3 155 ? 92.097  41.505 129.910 1.00 86.03  ? ? ? ? ? ? 149 MET A CA    1 
+ATOM   2594 C C     . MET C 3 155 ? 92.792  40.223 129.429 1.00 90.40  ? ? ? ? ? ? 149 MET A C     1 
+ATOM   2595 O O     . MET C 3 155 ? 92.582  39.164 130.017 1.00 90.04  ? ? ? ? ? ? 149 MET A O     1 
+ATOM   2596 C CB    . MET C 3 155 ? 90.641  41.568 129.418 1.00 88.97  ? ? ? ? ? ? 149 MET A CB    1 
+ATOM   2597 C CG    . MET C 3 155 ? 89.830  42.764 129.943 1.00 93.89  ? ? ? ? ? ? 149 MET A CG    1 
+ATOM   2598 S SD    . MET C 3 155 ? 88.254  43.139 129.100 1.00 99.07  ? ? ? ? ? ? 149 MET A SD    1 
+ATOM   2599 C CE    . MET C 3 155 ? 87.727  41.523 128.589 1.00 95.71  ? ? ? ? ? ? 149 MET A CE    1 
+ATOM   2600 N N     . GLU C 3 156 ? 93.578  40.293 128.356 1.00 88.40  ? ? ? ? ? ? 150 GLU A N     1 
+ATOM   2601 C CA    . GLU C 3 156 ? 94.254  39.111 127.812 1.00 88.92  ? ? ? ? ? ? 150 GLU A CA    1 
+ATOM   2602 C C     . GLU C 3 156 ? 94.974  38.300 128.887 1.00 94.32  ? ? ? ? ? ? 150 GLU A C     1 
+ATOM   2603 O O     . GLU C 3 156 ? 95.332  37.140 128.678 1.00 94.70  ? ? ? ? ? ? 150 GLU A O     1 
+ATOM   2604 C CB    . GLU C 3 156 ? 95.208  39.506 126.692 1.00 89.75  ? ? ? ? ? ? 150 GLU A CB    1 
+ATOM   2605 C CG    . GLU C 3 156 ? 96.130  40.614 127.108 1.00 93.92  ? ? ? ? ? ? 150 GLU A CG    1 
+ATOM   2606 C CD    . GLU C 3 156 ? 96.887  41.166 125.939 1.00 100.00 ? ? ? ? ? ? 150 GLU A CD    1 
+ATOM   2607 O OE1   . GLU C 3 156 ? 96.618  40.720 124.807 1.00 91.46  ? ? ? ? ? ? 150 GLU A OE1   1 
+ATOM   2608 O OE2   . GLU C 3 156 ? 97.764  42.028 126.149 1.00 90.39  ? ? ? ? ? ? 150 GLU A OE2   1 
+ATOM   2609 N N     . ASN C 3 157 ? 95.169  38.905 130.048 1.00 89.43  ? ? ? ? ? ? 151 ASN A N     1 
+ATOM   2610 C CA    . ASN C 3 157 ? 95.803  38.191 131.130 1.00 88.69  ? ? ? ? ? ? 151 ASN A CA    1 
+ATOM   2611 C C     . ASN C 3 157 ? 94.779  37.741 132.149 1.00 94.28  ? ? ? ? ? ? 151 ASN A C     1 
+ATOM   2612 O O     . ASN C 3 157 ? 95.123  37.438 133.290 1.00 96.69  ? ? ? ? ? ? 151 ASN A O     1 
+ATOM   2613 C CB    . ASN C 3 157 ? 96.890  39.059 131.732 1.00 86.77  ? ? ? ? ? ? 151 ASN A CB    1 
+ATOM   2614 C CG    . ASN C 3 157 ? 97.739  39.675 130.658 1.00 100.00 ? ? ? ? ? ? 151 ASN A CG    1 
+ATOM   2615 O OD1   . ASN C 3 157 ? 97.417  40.739 130.131 1.00 100.00 ? ? ? ? ? ? 151 ASN A OD1   1 
+ATOM   2616 N ND2   . ASN C 3 157 ? 98.781  38.960 130.250 1.00 100.00 ? ? ? ? ? ? 151 ASN A ND2   1 
+ATOM   2617 N N     . SER C 3 158 ? 93.516  37.675 131.741 1.00 88.44  ? ? ? ? ? ? 152 SER A N     1 
+ATOM   2618 C CA    . SER C 3 158 ? 92.491  37.221 132.676 1.00 86.39  ? ? ? ? ? ? 152 SER A CA    1 
+ATOM   2619 C C     . SER C 3 158 ? 92.075  35.779 132.453 1.00 84.19  ? ? ? ? ? ? 152 SER A C     1 
+ATOM   2620 O O     . SER C 3 158 ? 91.649  35.397 131.366 1.00 82.12  ? ? ? ? ? ? 152 SER A O     1 
+ATOM   2621 C CB    . SER C 3 158 ? 91.257  38.114 132.721 1.00 90.36  ? ? ? ? ? ? 152 SER A CB    1 
+ATOM   2622 O OG    . SER C 3 158 ? 90.244  37.448 133.465 1.00 97.85  ? ? ? ? ? ? 152 SER A OG    1 
+ATOM   2623 N N     . ASP C 3 159 ? 92.206  34.994 133.515 1.00 77.82  ? ? ? ? ? ? 153 ASP A N     1 
+ATOM   2624 C CA    . ASP C 3 159 ? 91.886  33.571 133.534 1.00 76.24  ? ? ? ? ? ? 153 ASP A CA    1 
+ATOM   2625 C C     . ASP C 3 159 ? 90.380  33.353 133.456 1.00 75.63  ? ? ? ? ? ? 153 ASP A C     1 
+ATOM   2626 O O     . ASP C 3 159 ? 89.906  32.326 132.964 1.00 74.90  ? ? ? ? ? ? 153 ASP A O     1 
+ATOM   2627 C CB    . ASP C 3 159 ? 92.389  33.008 134.862 1.00 79.40  ? ? ? ? ? ? 153 ASP A CB    1 
+ATOM   2628 C CG    . ASP C 3 159 ? 91.848  33.786 136.055 1.00 99.70  ? ? ? ? ? ? 153 ASP A CG    1 
+ATOM   2629 O OD1   . ASP C 3 159 ? 92.234  34.963 136.236 1.00 100.00 ? ? ? ? ? ? 153 ASP A OD1   1 
+ATOM   2630 O OD2   . ASP C 3 159 ? 90.996  33.233 136.788 1.00 100.00 ? ? ? ? ? ? 153 ASP A OD2   1 
+ATOM   2631 N N     . ARG C 3 160 ? 89.648  34.347 133.956 1.00 69.13  ? ? ? ? ? ? 154 ARG A N     1 
+ATOM   2632 C CA    . ARG C 3 160 ? 88.188  34.347 133.983 1.00 67.14  ? ? ? ? ? ? 154 ARG A CA    1 
+ATOM   2633 C C     . ARG C 3 160 ? 87.535  33.916 132.678 1.00 68.79  ? ? ? ? ? ? 154 ARG A C     1 
+ATOM   2634 O O     . ARG C 3 160 ? 87.712  34.529 131.622 1.00 67.33  ? ? ? ? ? ? 154 ARG A O     1 
+ATOM   2635 C CB    . ARG C 3 160 ? 87.648  35.721 134.383 1.00 66.21  ? ? ? ? ? ? 154 ARG A CB    1 
+ATOM   2636 C CG    . ARG C 3 160 ? 88.093  36.201 135.749 1.00 71.53  ? ? ? ? ? ? 154 ARG A CG    1 
+ATOM   2637 C CD    . ARG C 3 160 ? 86.954  36.890 136.488 1.00 73.22  ? ? ? ? ? ? 154 ARG A CD    1 
+ATOM   2638 N NE    . ARG C 3 160 ? 86.338  37.932 135.678 1.00 70.82  ? ? ? ? ? ? 154 ARG A NE    1 
+ATOM   2639 C CZ    . ARG C 3 160 ? 85.605  38.930 136.163 1.00 94.90  ? ? ? ? ? ? 154 ARG A CZ    1 
+ATOM   2640 N NH1   . ARG C 3 160 ? 85.413  39.048 137.470 1.00 81.82  ? ? ? ? ? ? 154 ARG A NH1   1 
+ATOM   2641 N NH2   . ARG C 3 160 ? 85.095  39.829 135.333 1.00 88.25  ? ? ? ? ? ? 154 ARG A NH2   1 
+ATOM   2642 N N     . CYS C 3 161 ? 86.738  32.865 132.781 1.00 64.31  ? ? ? ? ? ? 155 CYS A N     1 
+ATOM   2643 C CA    . CYS C 3 161 ? 86.038  32.363 131.624 1.00 64.16  ? ? ? ? ? ? 155 CYS A CA    1 
+ATOM   2644 C C     . CYS C 3 161 ? 85.295  33.499 130.930 1.00 70.99  ? ? ? ? ? ? 155 CYS A C     1 
+ATOM   2645 O O     . CYS C 3 161 ? 85.393  33.630 129.711 1.00 71.70  ? ? ? ? ? ? 155 CYS A O     1 
+ATOM   2646 C CB    . CYS C 3 161 ? 85.081  31.250 132.038 1.00 65.21  ? ? ? ? ? ? 155 CYS A CB    1 
+ATOM   2647 S SG    . CYS C 3 161 ? 84.511  30.219 130.648 1.00 69.52  ? ? ? ? ? ? 155 CYS A SG    1 
+ATOM   2648 N N     . GLN C 3 162 ? 84.570  34.330 131.682 1.00 68.50  ? ? ? ? ? ? 156 GLN A N     1 
+ATOM   2649 C CA    . GLN C 3 162 ? 83.828  35.446 131.078 1.00 67.18  ? ? ? ? ? ? 156 GLN A CA    1 
+ATOM   2650 C C     . GLN C 3 162 ? 84.744  36.529 130.526 1.00 67.06  ? ? ? ? ? ? 156 GLN A C     1 
+ATOM   2651 O O     . GLN C 3 162 ? 84.378  37.247 129.597 1.00 66.51  ? ? ? ? ? ? 156 GLN A O     1 
+ATOM   2652 C CB    . GLN C 3 162 ? 82.769  36.039 132.018 1.00 68.39  ? ? ? ? ? ? 156 GLN A CB    1 
+ATOM   2653 C CG    . GLN C 3 162 ? 81.672  36.853 131.307 1.00 86.37  ? ? ? ? ? ? 156 GLN A CG    1 
+ATOM   2654 C CD    . GLN C 3 162 ? 80.250  36.506 131.747 1.00 100.00 ? ? ? ? ? ? 156 GLN A CD    1 
+ATOM   2655 O OE1   . GLN C 3 162 ? 79.516  35.816 131.039 1.00 92.48  ? ? ? ? ? ? 156 GLN A OE1   1 
+ATOM   2656 N NE2   . GLN C 3 162 ? 79.852  37.007 132.908 1.00 99.92  ? ? ? ? ? ? 156 GLN A NE2   1 
+ATOM   2657 N N     . ASP C 3 163 ? 85.933  36.654 131.102 1.00 61.76  ? ? ? ? ? ? 157 ASP A N     1 
+ATOM   2658 C CA    . ASP C 3 163 ? 86.865  37.632 130.586 1.00 62.06  ? ? ? ? ? ? 157 ASP A CA    1 
+ATOM   2659 C C     . ASP C 3 163 ? 87.376  37.079 129.253 1.00 66.69  ? ? ? ? ? ? 157 ASP A C     1 
+ATOM   2660 O O     . ASP C 3 163 ? 87.414  37.795 128.248 1.00 66.64  ? ? ? ? ? ? 157 ASP A O     1 
+ATOM   2661 C CB    . ASP C 3 163 ? 87.963  37.964 131.596 1.00 64.92  ? ? ? ? ? ? 157 ASP A CB    1 
+ATOM   2662 C CG    . ASP C 3 163 ? 87.566  39.116 132.494 1.00 81.28  ? ? ? ? ? ? 157 ASP A CG    1 
+ATOM   2663 O OD1   . ASP C 3 163 ? 86.349  39.228 132.764 1.00 84.02  ? ? ? ? ? ? 157 ASP A OD1   1 
+ATOM   2664 O OD2   . ASP C 3 163 ? 88.442  39.904 132.911 1.00 89.33  ? ? ? ? ? ? 157 ASP A OD2   1 
+ATOM   2665 N N     . ILE C 3 164 ? 87.694  35.792 129.196 1.00 61.03  ? ? ? ? ? ? 158 ILE A N     1 
+ATOM   2666 C CA    . ILE C 3 164 ? 88.151  35.261 127.921 1.00 59.51  ? ? ? ? ? ? 158 ILE A CA    1 
+ATOM   2667 C C     . ILE C 3 164 ? 87.106  35.385 126.812 1.00 61.91  ? ? ? ? ? ? 158 ILE A C     1 
+ATOM   2668 O O     . ILE C 3 164 ? 87.436  35.831 125.716 1.00 60.85  ? ? ? ? ? ? 158 ILE A O     1 
+ATOM   2669 C CB    . ILE C 3 164 ? 88.821  33.873 128.013 1.00 62.11  ? ? ? ? ? ? 158 ILE A CB    1 
+ATOM   2670 C CG1   . ILE C 3 164 ? 87.831  32.753 127.840 1.00 61.58  ? ? ? ? ? ? 158 ILE A CG1   1 
+ATOM   2671 C CG2   . ILE C 3 164 ? 89.671  33.710 129.249 1.00 63.55  ? ? ? ? ? ? 158 ILE A CG2   1 
+ATOM   2672 C CD1   . ILE C 3 164 ? 88.291  31.958 126.705 1.00 56.70  ? ? ? ? ? ? 158 ILE A CD1   1 
+ATOM   2673 N N     . ARG C 3 165 ? 85.854  35.028 127.101 1.00 59.28  ? ? ? ? ? ? 159 ARG A N     1 
+ATOM   2674 C CA    . ARG C 3 165 ? 84.756  35.105 126.126 1.00 57.81  ? ? ? ? ? ? 159 ARG A CA    1 
+ATOM   2675 C C     . ARG C 3 165 ? 84.489  36.518 125.606 1.00 63.50  ? ? ? ? ? ? 159 ARG A C     1 
+ATOM   2676 O O     . ARG C 3 165 ? 84.284  36.731 124.408 1.00 63.73  ? ? ? ? ? ? 159 ARG A O     1 
+ATOM   2677 C CB    . ARG C 3 165 ? 83.457  34.545 126.710 1.00 50.96  ? ? ? ? ? ? 159 ARG A CB    1 
+ATOM   2678 C CG    . ARG C 3 165 ? 82.362  34.436 125.657 1.00 52.52  ? ? ? ? ? ? 159 ARG A CG    1 
+ATOM   2679 C CD    . ARG C 3 165 ? 80.950  34.540 126.219 1.00 63.65  ? ? ? ? ? ? 159 ARG A CD    1 
+ATOM   2680 N NE    . ARG C 3 165 ? 80.731  35.761 126.989 1.00 61.43  ? ? ? ? ? ? 159 ARG A NE    1 
+ATOM   2681 C CZ    . ARG C 3 165 ? 79.700  35.954 127.806 1.00 61.10  ? ? ? ? ? ? 159 ARG A CZ    1 
+ATOM   2682 N NH1   . ARG C 3 165 ? 78.766  35.019 127.934 1.00 37.12  ? ? ? ? ? ? 159 ARG A NH1   1 
+ATOM   2683 N NH2   . ARG C 3 165 ? 79.582  37.099 128.466 1.00 43.78  ? ? ? ? ? ? 159 ARG A NH2   1 
+ATOM   2684 N N     . ASN C 3 166 ? 84.473  37.482 126.519 1.00 59.03  ? ? ? ? ? ? 160 ASN A N     1 
+ATOM   2685 C CA    . ASN C 3 166 ? 84.226  38.858 126.138 1.00 57.97  ? ? ? ? ? ? 160 ASN A CA    1 
+ATOM   2686 C C     . ASN C 3 166 ? 85.363  39.432 125.300 1.00 63.60  ? ? ? ? ? ? 160 ASN A C     1 
+ATOM   2687 O O     . ASN C 3 166 ? 85.214  40.496 124.704 1.00 64.13  ? ? ? ? ? ? 160 ASN A O     1 
+ATOM   2688 C CB    . ASN C 3 166 ? 83.959  39.737 127.361 1.00 52.75  ? ? ? ? ? ? 160 ASN A CB    1 
+ATOM   2689 C CG    . ASN C 3 166 ? 82.714  39.324 128.133 1.00 48.27  ? ? ? ? ? ? 160 ASN A CG    1 
+ATOM   2690 O OD1   . ASN C 3 166 ? 82.079  38.310 127.841 1.00 45.30  ? ? ? ? ? ? 160 ASN A OD1   1 
+ATOM   2691 N ND2   . ASN C 3 166 ? 82.369  40.111 129.142 1.00 43.25  ? ? ? ? ? ? 160 ASN A ND2   1 
+ATOM   2692 N N     . LEU C 3 167 ? 86.497  38.746 125.233 1.00 62.22  ? ? ? ? ? ? 161 LEU A N     1 
+ATOM   2693 C CA    . LEU C 3 167 ? 87.581  39.277 124.407 1.00 63.74  ? ? ? ? ? ? 161 LEU A CA    1 
+ATOM   2694 C C     . LEU C 3 167 ? 87.378  38.834 122.966 1.00 65.13  ? ? ? ? ? ? 161 LEU A C     1 
+ATOM   2695 O O     . LEU C 3 167 ? 87.392  39.642 122.036 1.00 64.70  ? ? ? ? ? ? 161 LEU A O     1 
+ATOM   2696 C CB    . LEU C 3 167 ? 88.971  38.907 124.933 1.00 64.30  ? ? ? ? ? ? 161 LEU A CB    1 
+ATOM   2697 C CG    . LEU C 3 167 ? 89.693  40.095 125.578 1.00 68.61  ? ? ? ? ? ? 161 LEU A CG    1 
+ATOM   2698 C CD1   . LEU C 3 167 ? 91.183  39.852 125.729 1.00 68.74  ? ? ? ? ? ? 161 LEU A CD1   1 
+ATOM   2699 C CD2   . LEU C 3 167 ? 89.446  41.361 124.776 1.00 69.95  ? ? ? ? ? ? 161 LEU A CD2   1 
+ATOM   2700 N N     . ALA C 3 168 ? 87.115  37.541 122.798 1.00 59.79  ? ? ? ? ? ? 162 ALA A N     1 
+ATOM   2701 C CA    . ALA C 3 168 ? 86.845  36.987 121.487 1.00 60.27  ? ? ? ? ? ? 162 ALA A CA    1 
+ATOM   2702 C C     . ALA C 3 168 ? 85.768  37.842 120.822 1.00 64.33  ? ? ? ? ? ? 162 ALA A C     1 
+ATOM   2703 O O     . ALA C 3 168 ? 85.834  38.134 119.629 1.00 64.74  ? ? ? ? ? ? 162 ALA A O     1 
+ATOM   2704 C CB    . ALA C 3 168 ? 86.342  35.560 121.643 1.00 61.14  ? ? ? ? ? ? 162 ALA A CB    1 
+ATOM   2705 N N     . PHE C 3 169 ? 84.760  38.215 121.605 1.00 57.47  ? ? ? ? ? ? 163 PHE A N     1 
+ATOM   2706 C CA    . PHE C 3 169 ? 83.635  38.977 121.087 1.00 52.41  ? ? ? ? ? ? 163 PHE A CA    1 
+ATOM   2707 C C     . PHE C 3 169 ? 83.958  40.326 120.519 1.00 54.75  ? ? ? ? ? ? 163 PHE A C     1 
+ATOM   2708 O O     . PHE C 3 169 ? 83.513  40.655 119.425 1.00 52.87  ? ? ? ? ? ? 163 PHE A O     1 
+ATOM   2709 C CB    . PHE C 3 169 ? 82.538  39.167 122.120 1.00 51.66  ? ? ? ? ? ? 163 PHE A CB    1 
+ATOM   2710 C CG    . PHE C 3 169 ? 81.357  39.941 121.600 1.00 50.18  ? ? ? ? ? ? 163 PHE A CG    1 
+ATOM   2711 C CD1   . PHE C 3 169 ? 80.444  39.338 120.748 1.00 47.61  ? ? ? ? ? ? 163 PHE A CD1   1 
+ATOM   2712 C CD2   . PHE C 3 169 ? 81.166  41.267 121.954 1.00 49.68  ? ? ? ? ? ? 163 PHE A CD2   1 
+ATOM   2713 C CE1   . PHE C 3 169 ? 79.356  40.031 120.278 1.00 46.00  ? ? ? ? ? ? 163 PHE A CE1   1 
+ATOM   2714 C CE2   . PHE C 3 169 ? 80.076  41.964 121.489 1.00 50.83  ? ? ? ? ? ? 163 PHE A CE2   1 
+ATOM   2715 C CZ    . PHE C 3 169 ? 79.170  41.343 120.646 1.00 48.13  ? ? ? ? ? ? 163 PHE A CZ    1 
+ATOM   2716 N N     . LEU C 3 170 ? 84.671  41.128 121.299 1.00 55.52  ? ? ? ? ? ? 164 LEU A N     1 
+ATOM   2717 C CA    . LEU C 3 170 ? 85.033  42.464 120.863 1.00 57.00  ? ? ? ? ? ? 164 LEU A CA    1 
+ATOM   2718 C C     . LEU C 3 170 ? 85.996  42.287 119.697 1.00 64.66  ? ? ? ? ? ? 164 LEU A C     1 
+ATOM   2719 O O     . LEU C 3 170 ? 86.117  43.160 118.837 1.00 65.84  ? ? ? ? ? ? 164 LEU A O     1 
+ATOM   2720 C CB    . LEU C 3 170 ? 85.623  43.275 122.022 1.00 56.47  ? ? ? ? ? ? 164 LEU A CB    1 
+ATOM   2721 C CG    . LEU C 3 170 ? 84.644  43.490 123.185 1.00 58.95  ? ? ? ? ? ? 164 LEU A CG    1 
+ATOM   2722 C CD1   . LEU C 3 170 ? 85.343  43.967 124.448 1.00 57.99  ? ? ? ? ? ? 164 LEU A CD1   1 
+ATOM   2723 C CD2   . LEU C 3 170 ? 83.494  44.415 122.806 1.00 55.21  ? ? ? ? ? ? 164 LEU A CD2   1 
+ATOM   2724 N N     . GLY C 3 171 ? 86.607  41.106 119.631 1.00 61.94  ? ? ? ? ? ? 165 GLY A N     1 
+ATOM   2725 C CA    . GLY C 3 171 ? 87.538  40.771 118.557 1.00 60.20  ? ? ? ? ? ? 165 GLY A CA    1 
+ATOM   2726 C C     . GLY C 3 171 ? 86.763  40.582 117.262 1.00 61.21  ? ? ? ? ? ? 165 GLY A C     1 
+ATOM   2727 O O     . GLY C 3 171 ? 87.009  41.266 116.274 1.00 59.17  ? ? ? ? ? ? 165 GLY A O     1 
+ATOM   2728 N N     . ILE C 3 172 ? 85.792  39.673 117.303 1.00 61.40  ? ? ? ? ? ? 166 ILE A N     1 
+ATOM   2729 C CA    . ILE C 3 172 ? 84.920  39.358 116.170 1.00 62.54  ? ? ? ? ? ? 166 ILE A CA    1 
+ATOM   2730 C C     . ILE C 3 172 ? 83.956  40.499 115.827 1.00 71.03  ? ? ? ? ? ? 166 ILE A C     1 
+ATOM   2731 O O     . ILE C 3 172 ? 83.330  40.492 114.769 1.00 72.05  ? ? ? ? ? ? 166 ILE A O     1 
+ATOM   2732 C CB    . ILE C 3 172 ? 84.130  38.023 116.402 1.00 64.64  ? ? ? ? ? ? 166 ILE A CB    1 
+ATOM   2733 C CG1   . ILE C 3 172 ? 85.088  36.829 116.505 1.00 66.27  ? ? ? ? ? ? 166 ILE A CG1   1 
+ATOM   2734 C CG2   . ILE C 3 172 ? 83.102  37.762 115.301 1.00 61.07  ? ? ? ? ? ? 166 ILE A CG2   1 
+ATOM   2735 C CD1   . ILE C 3 172 ? 84.396  35.482 116.658 1.00 71.73  ? ? ? ? ? ? 166 ILE A CD1   1 
+ATOM   2736 N N     . ALA C 3 173 ? 83.865  41.507 116.684 1.00 68.01  ? ? ? ? ? ? 167 ALA A N     1 
+ATOM   2737 C CA    . ALA C 3 173 ? 82.960  42.615 116.416 1.00 66.63  ? ? ? ? ? ? 167 ALA A CA    1 
+ATOM   2738 C C     . ALA C 3 173 ? 83.716  43.717 115.690 1.00 68.64  ? ? ? ? ? ? 167 ALA A C     1 
+ATOM   2739 O O     . ALA C 3 173 ? 83.210  44.306 114.729 1.00 64.06  ? ? ? ? ? ? 167 ALA A O     1 
+ATOM   2740 C CB    . ALA C 3 173 ? 82.358  43.134 117.715 1.00 67.25  ? ? ? ? ? ? 167 ALA A CB    1 
+ATOM   2741 N N     . TYR C 3 174 ? 84.938  43.967 116.160 1.00 67.98  ? ? ? ? ? ? 168 TYR A N     1 
+ATOM   2742 C CA    . TYR C 3 174 ? 85.816  44.987 115.591 1.00 68.97  ? ? ? ? ? ? 168 TYR A CA    1 
+ATOM   2743 C C     . TYR C 3 174 ? 86.537  44.495 114.335 1.00 72.12  ? ? ? ? ? ? 168 TYR A C     1 
+ATOM   2744 O O     . TYR C 3 174 ? 86.421  45.090 113.261 1.00 68.98  ? ? ? ? ? ? 168 TYR A O     1 
+ATOM   2745 C CB    . TYR C 3 174 ? 86.823  45.492 116.621 1.00 70.31  ? ? ? ? ? ? 168 TYR A CB    1 
+ATOM   2746 C CG    . TYR C 3 174 ? 87.788  46.509 116.054 1.00 74.00  ? ? ? ? ? ? 168 TYR A CG    1 
+ATOM   2747 C CD1   . TYR C 3 174 ? 87.512  47.871 116.121 1.00 76.00  ? ? ? ? ? ? 168 TYR A CD1   1 
+ATOM   2748 C CD2   . TYR C 3 174 ? 88.963  46.107 115.433 1.00 75.69  ? ? ? ? ? ? 168 TYR A CD2   1 
+ATOM   2749 C CE1   . TYR C 3 174 ? 88.394  48.809 115.609 1.00 76.42  ? ? ? ? ? ? 168 TYR A CE1   1 
+ATOM   2750 C CE2   . TYR C 3 174 ? 89.856  47.041 114.915 1.00 76.66  ? ? ? ? ? ? 168 TYR A CE2   1 
+ATOM   2751 C CZ    . TYR C 3 174 ? 89.562  48.392 115.009 1.00 83.78  ? ? ? ? ? ? 168 TYR A CZ    1 
+ATOM   2752 O OH    . TYR C 3 174 ? 90.428  49.341 114.506 1.00 85.65  ? ? ? ? ? ? 168 TYR A OH    1 
+ATOM   2753 N N     . ASN C 3 175 ? 87.267  43.394 114.471 1.00 70.48  ? ? ? ? ? ? 169 ASN A N     1 
+ATOM   2754 C CA    . ASN C 3 175 ? 87.969  42.787 113.349 1.00 69.94  ? ? ? ? ? ? 169 ASN A CA    1 
+ATOM   2755 C C     . ASN C 3 175 ? 86.979  42.585 112.177 1.00 72.23  ? ? ? ? ? ? 169 ASN A C     1 
+ATOM   2756 O O     . ASN C 3 175 ? 87.361  42.713 111.012 1.00 72.53  ? ? ? ? ? ? 169 ASN A O     1 
+ATOM   2757 C CB    . ASN C 3 175 ? 88.582  41.454 113.834 1.00 69.66  ? ? ? ? ? ? 169 ASN A CB    1 
+ATOM   2758 C CG    . ASN C 3 175 ? 89.325  40.691 112.746 1.00 88.50  ? ? ? ? ? ? 169 ASN A CG    1 
+ATOM   2759 O OD1   . ASN C 3 175 ? 90.553  40.590 112.760 1.00 75.51  ? ? ? ? ? ? 169 ASN A OD1   1 
+ATOM   2760 N ND2   . ASN C 3 175 ? 88.570  40.129 111.808 1.00 83.69  ? ? ? ? ? ? 169 ASN A ND2   1 
+ATOM   2761 N N     . THR C 3 176 ? 85.699  42.378 112.478 1.00 67.86  ? ? ? ? ? ? 170 THR A N     1 
+ATOM   2762 C CA    . THR C 3 176 ? 84.680  42.098 111.449 1.00 66.73  ? ? ? ? ? ? 170 THR A CA    1 
+ATOM   2763 C C     . THR C 3 176 ? 83.520  43.048 111.075 1.00 67.98  ? ? ? ? ? ? 170 THR A C     1 
+ATOM   2764 O O     . THR C 3 176 ? 82.974  42.974 109.972 1.00 66.02  ? ? ? ? ? ? 170 THR A O     1 
+ATOM   2765 C CB    . THR C 3 176 ? 84.245  40.597 111.473 1.00 75.44  ? ? ? ? ? ? 170 THR A CB    1 
+ATOM   2766 O OG1   . THR C 3 176 ? 83.049  40.432 112.253 1.00 68.19  ? ? ? ? ? ? 170 THR A OG1   1 
+ATOM   2767 C CG2   . THR C 3 176 ? 85.366  39.705 112.026 1.00 71.69  ? ? ? ? ? ? 170 THR A CG2   1 
+ATOM   2768 N N     . LEU C 3 177 ? 83.148  43.941 111.983 1.00 62.68  ? ? ? ? ? ? 171 LEU A N     1 
+ATOM   2769 C CA    . LEU C 3 177 ? 82.086  44.886 111.678 1.00 60.34  ? ? ? ? ? ? 171 LEU A CA    1 
+ATOM   2770 C C     . LEU C 3 177 ? 80.765  44.159 111.503 1.00 60.77  ? ? ? ? ? ? 171 LEU A C     1 
+ATOM   2771 O O     . LEU C 3 177 ? 79.829  44.720 110.936 1.00 59.90  ? ? ? ? ? ? 171 LEU A O     1 
+ATOM   2772 C CB    . LEU C 3 177 ? 82.411  45.688 110.406 1.00 59.94  ? ? ? ? ? ? 171 LEU A CB    1 
+ATOM   2773 C CG    . LEU C 3 177 ? 83.433  46.833 110.440 1.00 63.96  ? ? ? ? ? ? 171 LEU A CG    1 
+ATOM   2774 C CD1   . LEU C 3 177 ? 84.846  46.381 110.090 1.00 62.47  ? ? ? ? ? ? 171 LEU A CD1   1 
+ATOM   2775 C CD2   . LEU C 3 177 ? 82.987  47.978 109.540 1.00 65.44  ? ? ? ? ? ? 171 LEU A CD2   1 
+ATOM   2776 N N     . LEU C 3 178 ? 80.685  42.926 111.993 1.00 55.68  ? ? ? ? ? ? 172 LEU A N     1 
+ATOM   2777 C CA    . LEU C 3 178 ? 79.453  42.147 111.908 1.00 54.90  ? ? ? ? ? ? 172 LEU A CA    1 
+ATOM   2778 C C     . LEU C 3 178 ? 78.394  42.692 112.869 1.00 58.06  ? ? ? ? ? ? 172 LEU A C     1 
+ATOM   2779 O O     . LEU C 3 178 ? 78.715  43.161 113.959 1.00 58.10  ? ? ? ? ? ? 172 LEU A O     1 
+ATOM   2780 C CB    . LEU C 3 178 ? 79.750  40.695 112.261 1.00 55.46  ? ? ? ? ? ? 172 LEU A CB    1 
+ATOM   2781 C CG    . LEU C 3 178 ? 79.988  39.731 111.101 1.00 60.79  ? ? ? ? ? ? 172 LEU A CG    1 
+ATOM   2782 C CD1   . LEU C 3 178 ? 80.572  38.448 111.663 1.00 61.31  ? ? ? ? ? ? 172 LEU A CD1   1 
+ATOM   2783 C CD2   . LEU C 3 178 ? 78.695  39.464 110.321 1.00 62.67  ? ? ? ? ? ? 172 LEU A CD2   1 
+ATOM   2784 N N     . ARG C 3 179 ? 77.126  42.629 112.484 1.00 56.18  ? ? ? ? ? ? 173 ARG A N     1 
+ATOM   2785 C CA    . ARG C 3 179 ? 76.073  43.135 113.363 1.00 59.18  ? ? ? ? ? ? 173 ARG A CA    1 
+ATOM   2786 C C     . ARG C 3 179 ? 75.733  42.206 114.543 1.00 62.01  ? ? ? ? ? ? 173 ARG A C     1 
+ATOM   2787 O O     . ARG C 3 179 ? 75.962  40.992 114.481 1.00 61.62  ? ? ? ? ? ? 173 ARG A O     1 
+ATOM   2788 C CB    . ARG C 3 179 ? 74.841  43.565 112.560 1.00 68.30  ? ? ? ? ? ? 173 ARG A CB    1 
+ATOM   2789 C CG    . ARG C 3 179 ? 75.161  44.551 111.427 1.00 89.72  ? ? ? ? ? ? 173 ARG A CG    1 
+ATOM   2790 C CD    . ARG C 3 179 ? 74.100  44.526 110.330 1.00 96.38  ? ? ? ? ? ? 173 ARG A CD    1 
+ATOM   2791 N NE    . ARG C 3 179 ? 74.345  45.499 109.264 1.00 100.00 ? ? ? ? ? ? 173 ARG A NE    1 
+ATOM   2792 C CZ    . ARG C 3 179 ? 74.607  45.184 107.998 1.00 100.00 ? ? ? ? ? ? 173 ARG A CZ    1 
+ATOM   2793 N NH1   . ARG C 3 179 ? 74.686  43.910 107.628 1.00 100.00 ? ? ? ? ? ? 173 ARG A NH1   1 
+ATOM   2794 N NH2   . ARG C 3 179 ? 74.810  46.146 107.104 1.00 97.56  ? ? ? ? ? ? 173 ARG A NH2   1 
+ATOM   2795 N N     . ILE C 3 180 ? 75.229  42.780 115.636 1.00 53.87  ? ? ? ? ? ? 174 ILE A N     1 
+ATOM   2796 C CA    . ILE C 3 180 ? 74.921  41.966 116.811 1.00 49.77  ? ? ? ? ? ? 174 ILE A CA    1 
+ATOM   2797 C C     . ILE C 3 180 ? 74.005  40.794 116.564 1.00 52.37  ? ? ? ? ? ? 174 ILE A C     1 
+ATOM   2798 O O     . ILE C 3 180 ? 74.295  39.690 117.007 1.00 53.56  ? ? ? ? ? ? 174 ILE A O     1 
+ATOM   2799 C CB    . ILE C 3 180 ? 74.548  42.723 118.102 1.00 50.26  ? ? ? ? ? ? 174 ILE A CB    1 
+ATOM   2800 C CG1   . ILE C 3 180 ? 73.400  43.712 117.888 1.00 50.24  ? ? ? ? ? ? 174 ILE A CG1   1 
+ATOM   2801 C CG2   . ILE C 3 180 ? 75.784  43.363 118.712 1.00 48.79  ? ? ? ? ? ? 174 ILE A CG2   1 
+ATOM   2802 C CD1   . ILE C 3 180 ? 72.783  44.259 119.185 1.00 35.78  ? ? ? ? ? ? 174 ILE A CD1   1 
+ATOM   2803 N N     . ALA C 3 181 ? 72.913  41.034 115.851 1.00 47.15  ? ? ? ? ? ? 175 ALA A N     1 
+ATOM   2804 C CA    . ALA C 3 181 ? 71.972  39.969 115.516 1.00 48.18  ? ? ? ? ? ? 175 ALA A CA    1 
+ATOM   2805 C C     . ALA C 3 181 ? 72.706  38.958 114.634 1.00 56.00  ? ? ? ? ? ? 175 ALA A C     1 
+ATOM   2806 O O     . ALA C 3 181 ? 72.297  37.799 114.490 1.00 54.39  ? ? ? ? ? ? 175 ALA A O     1 
+ATOM   2807 C CB    . ALA C 3 181 ? 70.762  40.531 114.789 1.00 49.14  ? ? ? ? ? ? 175 ALA A CB    1 
+ATOM   2808 N N     . GLU C 3 182 ? 73.833  39.396 114.087 1.00 54.30  ? ? ? ? ? ? 176 GLU A N     1 
+ATOM   2809 C CA    . GLU C 3 182 ? 74.631  38.519 113.253 1.00 55.12  ? ? ? ? ? ? 176 GLU A CA    1 
+ATOM   2810 C C     . GLU C 3 182 ? 75.642  37.642 113.996 1.00 61.21  ? ? ? ? ? ? 176 GLU A C     1 
+ATOM   2811 O O     . GLU C 3 182 ? 75.818  36.481 113.631 1.00 57.61  ? ? ? ? ? ? 176 GLU A O     1 
+ATOM   2812 C CB    . GLU C 3 182 ? 75.281  39.299 112.110 1.00 57.78  ? ? ? ? ? ? 176 GLU A CB    1 
+ATOM   2813 C CG    . GLU C 3 182 ? 74.326  39.622 110.957 1.00 76.05  ? ? ? ? ? ? 176 GLU A CG    1 
+ATOM   2814 C CD    . GLU C 3 182 ? 74.936  40.552 109.921 1.00 100.00 ? ? ? ? ? ? 176 GLU A CD    1 
+ATOM   2815 O OE1   . GLU C 3 182 ? 76.168  40.737 109.945 1.00 100.00 ? ? ? ? ? ? 176 GLU A OE1   1 
+ATOM   2816 O OE2   . GLU C 3 182 ? 74.185  41.107 109.090 1.00 91.24  ? ? ? ? ? ? 176 GLU A OE2   1 
+ATOM   2817 N N     . ILE C 3 183 ? 76.327  38.157 115.018 1.00 64.06  ? ? ? ? ? ? 177 ILE A N     1 
+ATOM   2818 C CA    . ILE C 3 183 ? 77.296  37.301 115.718 1.00 65.11  ? ? ? ? ? ? 177 ILE A CA    1 
+ATOM   2819 C C     . ILE C 3 183 ? 76.613  36.242 116.555 1.00 66.34  ? ? ? ? ? ? 177 ILE A C     1 
+ATOM   2820 O O     . ILE C 3 183 ? 77.124  35.139 116.739 1.00 65.80  ? ? ? ? ? ? 177 ILE A O     1 
+ATOM   2821 C CB    . ILE C 3 183 ? 78.263  38.051 116.633 1.00 68.80  ? ? ? ? ? ? 177 ILE A CB    1 
+ATOM   2822 C CG1   . ILE C 3 183 ? 79.257  38.845 115.787 1.00 71.22  ? ? ? ? ? ? 177 ILE A CG1   1 
+ATOM   2823 C CG2   . ILE C 3 183 ? 79.016  37.056 117.515 1.00 66.68  ? ? ? ? ? ? 177 ILE A CG2   1 
+ATOM   2824 C CD1   . ILE C 3 183 ? 79.013  40.339 115.815 1.00 87.44  ? ? ? ? ? ? 177 ILE A CD1   1 
+ATOM   2825 N N     . ALA C 3 184 ? 75.435  36.593 117.049 1.00 62.06  ? ? ? ? ? ? 178 ALA A N     1 
+ATOM   2826 C CA    . ALA C 3 184 ? 74.646  35.664 117.836 1.00 61.99  ? ? ? ? ? ? 178 ALA A CA    1 
+ATOM   2827 C C     . ALA C 3 184 ? 74.323  34.431 116.985 1.00 64.60  ? ? ? ? ? ? 178 ALA A C     1 
+ATOM   2828 O O     . ALA C 3 184 ? 74.427  33.308 117.470 1.00 63.93  ? ? ? ? ? ? 178 ALA A O     1 
+ATOM   2829 C CB    . ALA C 3 184 ? 73.364  36.331 118.327 1.00 62.34  ? ? ? ? ? ? 178 ALA A CB    1 
+ATOM   2830 N N     . ARG C 3 185 ? 73.948  34.646 115.725 1.00 59.32  ? ? ? ? ? ? 179 ARG A N     1 
+ATOM   2831 C CA    . ARG C 3 185 ? 73.592  33.573 114.794 1.00 57.64  ? ? ? ? ? ? 179 ARG A CA    1 
+ATOM   2832 C C     . ARG C 3 185 ? 74.730  32.592 114.511 1.00 62.26  ? ? ? ? ? ? 179 ARG A C     1 
+ATOM   2833 O O     . ARG C 3 185 ? 74.486  31.418 114.243 1.00 62.22  ? ? ? ? ? ? 179 ARG A O     1 
+ATOM   2834 C CB    . ARG C 3 185 ? 73.133  34.181 113.458 1.00 56.98  ? ? ? ? ? ? 179 ARG A CB    1 
+ATOM   2835 C CG    . ARG C 3 185 ? 71.659  34.014 113.100 1.00 74.96  ? ? ? ? ? ? 179 ARG A CG    1 
+ATOM   2836 C CD    . ARG C 3 185 ? 71.381  34.395 111.640 1.00 97.39  ? ? ? ? ? ? 179 ARG A CD    1 
+ATOM   2837 N NE    . ARG C 3 185 ? 71.457  35.835 111.408 1.00 100.00 ? ? ? ? ? ? 179 ARG A NE    1 
+ATOM   2838 C CZ    . ARG C 3 185 ? 70.537  36.709 111.804 1.00 100.00 ? ? ? ? ? ? 179 ARG A CZ    1 
+ATOM   2839 N NH1   . ARG C 3 185 ? 69.465  36.297 112.465 1.00 85.17  ? ? ? ? ? ? 179 ARG A NH1   1 
+ATOM   2840 N NH2   . ARG C 3 185 ? 70.701  38.000 111.552 1.00 84.00  ? ? ? ? ? ? 179 ARG A NH2   1 
+ATOM   2841 N N     . ILE C 3 186 ? 75.966  33.081 114.535 1.00 59.09  ? ? ? ? ? ? 180 ILE A N     1 
+ATOM   2842 C CA    . ILE C 3 186 ? 77.142  32.264 114.232 1.00 59.54  ? ? ? ? ? ? 180 ILE A CA    1 
+ATOM   2843 C C     . ILE C 3 186 ? 77.308  30.899 114.925 1.00 71.28  ? ? ? ? ? ? 180 ILE A C     1 
+ATOM   2844 O O     . ILE C 3 186 ? 77.267  30.794 116.157 1.00 73.68  ? ? ? ? ? ? 180 ILE A O     1 
+ATOM   2845 C CB    . ILE C 3 186 ? 78.426  33.096 114.377 1.00 61.06  ? ? ? ? ? ? 180 ILE A CB    1 
+ATOM   2846 C CG1   . ILE C 3 186 ? 78.260  34.442 113.661 1.00 58.94  ? ? ? ? ? ? 180 ILE A CG1   1 
+ATOM   2847 C CG2   . ILE C 3 186 ? 79.659  32.287 113.951 1.00 63.32  ? ? ? ? ? ? 180 ILE A CG2   1 
+ATOM   2848 C CD1   . ILE C 3 186 ? 79.175  35.528 114.158 1.00 60.19  ? ? ? ? ? ? 180 ILE A CD1   1 
+ATOM   2849 N N     . ARG C 3 187 ? 77.558  29.856 114.132 1.00 69.60  ? ? ? ? ? ? 181 ARG A N     1 
+ATOM   2850 C CA    . ARG C 3 187 ? 77.773  28.521 114.701 1.00 71.00  ? ? ? ? ? ? 181 ARG A CA    1 
+ATOM   2851 C C     . ARG C 3 187 ? 79.261  28.165 114.646 1.00 78.19  ? ? ? ? ? ? 181 ARG A C     1 
+ATOM   2852 O O     . ARG C 3 187 ? 80.045  28.878 114.020 1.00 79.40  ? ? ? ? ? ? 181 ARG A O     1 
+ATOM   2853 C CB    . ARG C 3 187 ? 76.945  27.450 113.963 1.00 71.81  ? ? ? ? ? ? 181 ARG A CB    1 
+ATOM   2854 C CG    . ARG C 3 187 ? 75.547  27.286 114.554 1.00 80.29  ? ? ? ? ? ? 181 ARG A CG    1 
+ATOM   2855 C CD    . ARG C 3 187 ? 74.463  26.857 113.599 1.00 82.20  ? ? ? ? ? ? 181 ARG A CD    1 
+ATOM   2856 N NE    . ARG C 3 187 ? 73.116  27.165 114.119 1.00 85.18  ? ? ? ? ? ? 181 ARG A NE    1 
+ATOM   2857 C CZ    . ARG C 3 187 ? 72.391  26.347 114.878 1.00 98.73  ? ? ? ? ? ? 181 ARG A CZ    1 
+ATOM   2858 N NH1   . ARG C 3 187 ? 72.887  25.173 115.248 1.00 80.15  ? ? ? ? ? ? 181 ARG A NH1   1 
+ATOM   2859 N NH2   . ARG C 3 187 ? 71.165  26.704 115.246 1.00 92.81  ? ? ? ? ? ? 181 ARG A NH2   1 
+ATOM   2860 N N     . VAL C 3 188 ? 79.658  27.078 115.304 1.00 75.04  ? ? ? ? ? ? 182 VAL A N     1 
+ATOM   2861 C CA    . VAL C 3 188 ? 81.063  26.682 115.299 1.00 74.52  ? ? ? ? ? ? 182 VAL A CA    1 
+ATOM   2862 C C     . VAL C 3 188 ? 81.328  25.968 113.979 1.00 84.02  ? ? ? ? ? ? 182 VAL A C     1 
+ATOM   2863 O O     . VAL C 3 188 ? 82.461  25.911 113.495 1.00 84.06  ? ? ? ? ? ? 182 VAL A O     1 
+ATOM   2864 C CB    . VAL C 3 188 ? 81.421  25.790 116.498 0.00 77.41  ? ? ? ? ? ? 182 VAL A CB    1 
+ATOM   2865 C CG1   . VAL C 3 188 ? 82.687  24.997 116.211 0.00 77.09  ? ? ? ? ? ? 182 VAL A CG1   1 
+ATOM   2866 C CG2   . VAL C 3 188 ? 81.598  26.642 117.746 0.00 77.10  ? ? ? ? ? ? 182 VAL A CG2   1 
+ATOM   2867 N N     . LYS C 3 189 ? 80.236  25.460 113.403 1.00 83.98  ? ? ? ? ? ? 183 LYS A N     1 
+ATOM   2868 C CA    . LYS C 3 189 ? 80.210  24.766 112.112 1.00 84.12  ? ? ? ? ? ? 183 LYS A CA    1 
+ATOM   2869 C C     . LYS C 3 189 ? 80.163  25.809 110.993 1.00 87.40  ? ? ? ? ? ? 183 LYS A C     1 
+ATOM   2870 O O     . LYS C 3 189 ? 79.696  25.554 109.875 1.00 87.14  ? ? ? ? ? ? 183 LYS A O     1 
+ATOM   2871 C CB    . LYS C 3 189 ? 79.055  23.746 112.018 1.00 85.85  ? ? ? ? ? ? 183 LYS A CB    1 
+ATOM   2872 C CG    . LYS C 3 189 ? 77.657  24.317 111.834 1.00 80.92  ? ? ? ? ? ? 183 LYS A CG    1 
+ATOM   2873 C CD    . LYS C 3 189 ? 77.171  24.092 110.405 1.00 91.81  ? ? ? ? ? ? 183 LYS A CD    1 
+ATOM   2874 C CE    . LYS C 3 189 ? 75.798  24.704 110.235 1.00 99.93  ? ? ? ? ? ? 183 LYS A CE    1 
+ATOM   2875 N NZ    . LYS C 3 189 ? 75.150  24.431 108.927 1.00 97.40  ? ? ? ? ? ? 183 LYS A NZ    1 
+ATOM   2876 N N     . ASP C 3 190 ? 80.687  26.983 111.334 1.00 83.56  ? ? ? ? ? ? 184 ASP A N     1 
+ATOM   2877 C CA    . ASP C 3 190 ? 80.746  28.094 110.402 1.00 83.14  ? ? ? ? ? ? 184 ASP A CA    1 
+ATOM   2878 C C     . ASP C 3 190 ? 82.162  28.655 110.316 1.00 87.29  ? ? ? ? ? ? 184 ASP A C     1 
+ATOM   2879 O O     . ASP C 3 190 ? 82.382  29.698 109.708 1.00 87.62  ? ? ? ? ? ? 184 ASP A O     1 
+ATOM   2880 C CB    . ASP C 3 190 ? 79.786  29.194 110.852 1.00 85.55  ? ? ? ? ? ? 184 ASP A CB    1 
+ATOM   2881 C CG    . ASP C 3 190 ? 78.335  28.806 110.670 1.00 98.47  ? ? ? ? ? ? 184 ASP A CG    1 
+ATOM   2882 O OD1   . ASP C 3 190 ? 78.093  27.638 110.302 1.00 97.57  ? ? ? ? ? ? 184 ASP A OD1   1 
+ATOM   2883 O OD2   . ASP C 3 190 ? 77.450  29.655 110.953 1.00 100.00 ? ? ? ? ? ? 184 ASP A OD2   1 
+ATOM   2884 N N     . ILE C 3 191 ? 83.126  27.963 110.915 1.00 86.64  ? ? ? ? ? ? 185 ILE A N     1 
+ATOM   2885 C CA    . ILE C 3 191 ? 84.513  28.423 110.928 1.00 89.17  ? ? ? ? ? ? 185 ILE A CA    1 
+ATOM   2886 C C     . ILE C 3 191 ? 85.487  27.505 110.184 1.00 99.43  ? ? ? ? ? ? 185 ILE A C     1 
+ATOM   2887 O O     . ILE C 3 191 ? 85.341  26.282 110.193 1.00 100.00 ? ? ? ? ? ? 185 ILE A O     1 
+ATOM   2888 C CB    . ILE C 3 191 ? 85.013  28.590 112.382 1.00 92.35  ? ? ? ? ? ? 185 ILE A CB    1 
+ATOM   2889 C CG1   . ILE C 3 191 ? 84.173  29.623 113.144 1.00 91.87  ? ? ? ? ? ? 185 ILE A CG1   1 
+ATOM   2890 C CG2   . ILE C 3 191 ? 86.485  28.919 112.404 1.00 92.61  ? ? ? ? ? ? 185 ILE A CG2   1 
+ATOM   2891 C CD1   . ILE C 3 191 ? 84.434  29.645 114.640 1.00 79.07  ? ? ? ? ? ? 185 ILE A CD1   1 
+ATOM   2892 N N     . SER C 3 192 ? 86.494  28.111 109.562 1.00 97.84  ? ? ? ? ? ? 186 SER A N     1 
+ATOM   2893 C CA    . SER C 3 192 ? 87.517  27.396 108.803 1.00 96.75  ? ? ? ? ? ? 186 SER A CA    1 
+ATOM   2894 C C     . SER C 3 192 ? 88.890  27.714 109.403 1.00 99.98  ? ? ? ? ? ? 186 SER A C     1 
+ATOM   2895 O O     . SER C 3 192 ? 88.967  28.200 110.529 1.00 99.68  ? ? ? ? ? ? 186 SER A O     1 
+ATOM   2896 C CB    . SER C 3 192 ? 87.450  27.829 107.339 1.00 98.45  ? ? ? ? ? ? 186 SER A CB    1 
+ATOM   2897 O OG    . SER C 3 192 ? 86.628  28.979 107.200 1.00 100.00 ? ? ? ? ? ? 186 SER A OG    1 
+ATOM   2898 N N     . ARG C 3 193 ? 89.977  27.440 108.689 1.00 96.13  ? ? ? ? ? ? 187 ARG A N     1 
+ATOM   2899 C CA    . ARG C 3 193 ? 91.298  27.721 109.258 1.00 95.87  ? ? ? ? ? ? 187 ARG A CA    1 
+ATOM   2900 C C     . ARG C 3 193 ? 92.200  28.531 108.337 1.00 100.00 ? ? ? ? ? ? 187 ARG A C     1 
+ATOM   2901 O O     . ARG C 3 193 ? 93.306  28.942 108.698 1.00 99.99  ? ? ? ? ? ? 187 ARG A O     1 
+ATOM   2902 C CB    . ARG C 3 193 ? 91.988  26.437 109.703 1.00 94.30  ? ? ? ? ? ? 187 ARG A CB    1 
+ATOM   2903 C CG    . ARG C 3 193 ? 91.946  26.230 111.201 1.00 94.49  ? ? ? ? ? ? 187 ARG A CG    1 
+ATOM   2904 C CD    . ARG C 3 193 ? 91.429  27.462 111.930 1.00 79.59  ? ? ? ? ? ? 187 ARG A CD    1 
+ATOM   2905 N NE    . ARG C 3 193 ? 91.732  27.357 113.352 1.00 85.06  ? ? ? ? ? ? 187 ARG A NE    1 
+ATOM   2906 C CZ    . ARG C 3 193 ? 92.754  27.965 113.941 1.00 100.00 ? ? ? ? ? ? 187 ARG A CZ    1 
+ATOM   2907 N NH1   . ARG C 3 193 ? 93.560  28.751 113.237 1.00 100.00 ? ? ? ? ? ? 187 ARG A NH1   1 
+ATOM   2908 N NH2   . ARG C 3 193 ? 92.964  27.810 115.240 1.00 100.00 ? ? ? ? ? ? 187 ARG A NH2   1 
+ATOM   2909 N N     . THR C 3 194 ? 91.686  28.735 107.133 1.00 97.44  ? ? ? ? ? ? 188 THR A N     1 
+ATOM   2910 C CA    . THR C 3 194 ? 92.296  29.521 106.069 1.00 97.06  ? ? ? ? ? ? 188 THR A CA    1 
+ATOM   2911 C C     . THR C 3 194 ? 93.630  30.263 106.268 1.00 100.00 ? ? ? ? ? ? 188 THR A C     1 
+ATOM   2912 O O     . THR C 3 194 ? 93.911  30.819 107.326 1.00 99.37  ? ? ? ? ? ? 188 THR A O     1 
+ATOM   2913 C CB    . THR C 3 194 ? 91.261  30.564 105.623 1.00 99.96  ? ? ? ? ? ? 188 THR A CB    1 
+ATOM   2914 O OG1   . THR C 3 194 ? 91.850  31.466 104.676 1.00 100.00 ? ? ? ? ? ? 188 THR A OG1   1 
+ATOM   2915 C CG2   . THR C 3 194 ? 90.751  31.341 106.830 1.00 93.50  ? ? ? ? ? ? 188 THR A CG2   1 
+ATOM   2916 N N     . ASP C 3 195 ? 94.415  30.317 105.198 1.00 96.87  ? ? ? ? ? ? 189 ASP A N     1 
+ATOM   2917 C CA    . ASP C 3 195 ? 95.670  31.051 105.154 1.00 96.65  ? ? ? ? ? ? 189 ASP A CA    1 
+ATOM   2918 C C     . ASP C 3 195 ? 96.627  31.192 106.328 1.00 100.00 ? ? ? ? ? ? 189 ASP A C     1 
+ATOM   2919 O O     . ASP C 3 195 ? 97.536  32.020 106.268 1.00 100.00 ? ? ? ? ? ? 189 ASP A O     1 
+ATOM   2920 C CB    . ASP C 3 195 ? 95.517  32.354 104.373 1.00 98.12  ? ? ? ? ? ? 189 ASP A CB    1 
+ATOM   2921 C CG    . ASP C 3 195 ? 95.316  32.113 102.890 1.00 100.00 ? ? ? ? ? ? 189 ASP A CG    1 
+ATOM   2922 O OD1   . ASP C 3 195 ? 94.646  31.118 102.523 1.00 100.00 ? ? ? ? ? ? 189 ASP A OD1   1 
+ATOM   2923 O OD2   . ASP C 3 195 ? 95.834  32.915 102.088 1.00 100.00 ? ? ? ? ? ? 189 ASP A OD2   1 
+ATOM   2924 N N     . GLY C 3 196 ? 96.491  30.375 107.367 1.00 96.07  ? ? ? ? ? ? 190 GLY A N     1 
+ATOM   2925 C CA    . GLY C 3 196 ? 97.504  30.463 108.409 1.00 95.82  ? ? ? ? ? ? 190 GLY A CA    1 
+ATOM   2926 C C     . GLY C 3 196 ? 97.200  30.404 109.894 1.00 100.00 ? ? ? ? ? ? 190 GLY A C     1 
+ATOM   2927 O O     . GLY C 3 196 ? 97.877  31.064 110.682 1.00 100.00 ? ? ? ? ? ? 190 GLY A O     1 
+ATOM   2928 N N     . GLY C 3 197 ? 96.227  29.601 110.301 0.00 96.38  ? ? ? ? ? ? 191 GLY A N     1 
+ATOM   2929 C CA    . GLY C 3 197 ? 95.909  29.527 111.719 0.00 96.14  ? ? ? ? ? ? 191 GLY A CA    1 
+ATOM   2930 C C     . GLY C 3 197 ? 95.063  30.764 111.933 0.00 100.00 ? ? ? ? ? ? 191 GLY A C     1 
+ATOM   2931 O O     . GLY C 3 197 ? 94.711  31.124 113.056 0.00 99.53  ? ? ? ? ? ? 191 GLY A O     1 
+ATOM   2932 N N     . ARG C 3 198 ? 94.774  31.422 110.816 1.00 96.78  ? ? ? ? ? ? 192 ARG A N     1 
+ATOM   2933 C CA    . ARG C 3 198 ? 93.938  32.598 110.838 1.00 96.67  ? ? ? ? ? ? 192 ARG A CA    1 
+ATOM   2934 C C     . ARG C 3 198 ? 92.645  31.918 111.209 1.00 99.26  ? ? ? ? ? ? 192 ARG A C     1 
+ATOM   2935 O O     . ARG C 3 198 ? 92.598  31.143 112.165 1.00 99.38  ? ? ? ? ? ? 192 ARG A O     1 
+ATOM   2936 C CB    . ARG C 3 198 ? 93.821  33.201 109.435 1.00 97.67  ? ? ? ? ? ? 192 ARG A CB    1 
+ATOM   2937 C CG    . ARG C 3 198 ? 94.407  34.599 109.311 1.00 100.00 ? ? ? ? ? ? 192 ARG A CG    1 
+ATOM   2938 C CD    . ARG C 3 198 ? 95.260  34.935 110.528 1.00 99.81  ? ? ? ? ? ? 192 ARG A CD    1 
+ATOM   2939 N NE    . ARG C 3 198 ? 96.397  35.780 110.193 1.00 100.00 ? ? ? ? ? ? 192 ARG A NE    1 
+ATOM   2940 C CZ    . ARG C 3 198 ? 97.612  35.572 110.690 1.00 100.00 ? ? ? ? ? ? 192 ARG A CZ    1 
+ATOM   2941 N NH1   . ARG C 3 198 ? 97.808  34.603 111.570 1.00 81.11  ? ? ? ? ? ? 192 ARG A NH1   1 
+ATOM   2942 N NH2   . ARG C 3 198 ? 98.636  36.339 110.330 1.00 100.00 ? ? ? ? ? ? 192 ARG A NH2   1 
+ATOM   2943 N N     . MET C 3 199 ? 91.653  32.110 110.352 1.00 94.09  ? ? ? ? ? ? 193 MET A N     1 
+ATOM   2944 C CA    . MET C 3 199 ? 90.328  31.532 110.533 1.00 92.37  ? ? ? ? ? ? 193 MET A CA    1 
+ATOM   2945 C C     . MET C 3 199 ? 89.372  32.359 109.695 1.00 91.09  ? ? ? ? ? ? 193 MET A C     1 
+ATOM   2946 O O     . MET C 3 199 ? 89.478  33.583 109.652 1.00 88.09  ? ? ? ? ? ? 193 MET A O     1 
+ATOM   2947 C CB    . MET C 3 199 ? 89.873  31.630 112.004 1.00 94.51  ? ? ? ? ? ? 193 MET A CB    1 
+ATOM   2948 C CG    . MET C 3 199 ? 89.056  30.434 112.494 1.00 97.15  ? ? ? ? ? ? 193 MET A CG    1 
+ATOM   2949 S SD    . MET C 3 199 ? 88.822  30.111 114.264 1.00 100.00 ? ? ? ? ? ? 193 MET A SD    1 
+ATOM   2950 C CE    . MET C 3 199 ? 89.944  31.204 115.073 1.00 96.82  ? ? ? ? ? ? 193 MET A CE    1 
+ATOM   2951 N N     . LEU C 3 200 ? 88.423  31.694 109.048 1.00 88.84  ? ? ? ? ? ? 194 LEU A N     1 
+ATOM   2952 C CA    . LEU C 3 200 ? 87.429  32.408 108.266 1.00 90.36  ? ? ? ? ? ? 194 LEU A CA    1 
+ATOM   2953 C C     . LEU C 3 200 ? 86.065  32.101 108.880 1.00 93.67  ? ? ? ? ? ? 194 LEU A C     1 
+ATOM   2954 O O     . LEU C 3 200 ? 85.854  31.026 109.446 1.00 92.14  ? ? ? ? ? ? 194 LEU A O     1 
+ATOM   2955 C CB    . LEU C 3 200 ? 87.486  32.043 106.775 1.00 90.93  ? ? ? ? ? ? 194 LEU A CB    1 
+ATOM   2956 C CG    . LEU C 3 200 ? 88.389  32.960 105.942 1.00 96.26  ? ? ? ? ? ? 194 LEU A CG    1 
+ATOM   2957 C CD1   . LEU C 3 200 ? 88.519  32.513 104.491 1.00 97.39  ? ? ? ? ? ? 194 LEU A CD1   1 
+ATOM   2958 C CD2   . LEU C 3 200 ? 88.035  34.448 106.085 1.00 96.61  ? ? ? ? ? ? 194 LEU A CD2   1 
+ATOM   2959 N N     . ILE C 3 201 ? 85.153  33.064 108.784 1.00 88.41  ? ? ? ? ? ? 195 ILE A N     1 
+ATOM   2960 C CA    . ILE C 3 201 ? 83.798  32.929 109.313 1.00 85.94  ? ? ? ? ? ? 195 ILE A CA    1 
+ATOM   2961 C C     . ILE C 3 201 ? 82.775  33.106 108.194 1.00 88.51  ? ? ? ? ? ? 195 ILE A C     1 
+ATOM   2962 O O     . ILE C 3 201 ? 82.360  34.228 107.904 1.00 85.54  ? ? ? ? ? ? 195 ILE A O     1 
+ATOM   2963 C CB    . ILE C 3 201 ? 83.481  33.980 110.417 1.00 88.01  ? ? ? ? ? ? 195 ILE A CB    1 
+ATOM   2964 C CG1   . ILE C 3 201 ? 84.326  33.733 111.671 1.00 87.95  ? ? ? ? ? ? 195 ILE A CG1   1 
+ATOM   2965 C CG2   . ILE C 3 201 ? 81.997  33.960 110.769 1.00 86.34  ? ? ? ? ? ? 195 ILE A CG2   1 
+ATOM   2966 C CD1   . ILE C 3 201 ? 84.000  34.656 112.824 1.00 94.89  ? ? ? ? ? ? 195 ILE A CD1   1 
+ATOM   2967 N N     . HIS C 3 202 ? 82.351  32.004 107.575 1.00 89.19  ? ? ? ? ? ? 196 HIS A N     1 
+ATOM   2968 C CA    . HIS C 3 202 ? 81.349  32.131 106.518 1.00 90.93  ? ? ? ? ? ? 196 HIS A CA    1 
+ATOM   2969 C C     . HIS C 3 202 ? 80.146  32.705 107.209 1.00 90.92  ? ? ? ? ? ? 196 HIS A C     1 
+ATOM   2970 O O     . HIS C 3 202 ? 79.575  32.104 108.119 1.00 89.53  ? ? ? ? ? ? 196 HIS A O     1 
+ATOM   2971 C CB    . HIS C 3 202 ? 80.990  30.795 105.795 1.00 93.04  ? ? ? ? ? ? 196 HIS A CB    1 
+ATOM   2972 C CG    . HIS C 3 202 ? 79.622  30.757 105.151 1.00 97.55  ? ? ? ? ? ? 196 HIS A CG    1 
+ATOM   2973 N ND1   . HIS C 3 202 ? 79.050  29.567 104.754 1.00 100.00 ? ? ? ? ? ? 196 HIS A ND1   1 
+ATOM   2974 C CD2   . HIS C 3 202 ? 78.731  31.724 104.804 1.00 100.00 ? ? ? ? ? ? 196 HIS A CD2   1 
+ATOM   2975 C CE1   . HIS C 3 202 ? 77.867  29.800 104.216 1.00 99.83  ? ? ? ? ? ? 196 HIS A CE1   1 
+ATOM   2976 N NE2   . HIS C 3 202 ? 77.647  31.102 104.234 1.00 100.00 ? ? ? ? ? ? 196 HIS A NE2   1 
+ATOM   2977 N N     . ILE C 3 203 ? 79.742  33.874 106.735 1.00 87.44  ? ? ? ? ? ? 197 ILE A N     1 
+ATOM   2978 C CA    . ILE C 3 203 ? 78.572  34.503 107.306 1.00 88.19  ? ? ? ? ? ? 197 ILE A CA    1 
+ATOM   2979 C C     . ILE C 3 203 ? 77.256  34.443 106.548 1.00 88.50  ? ? ? ? ? ? 197 ILE A C     1 
+ATOM   2980 O O     . ILE C 3 203 ? 76.810  33.381 106.124 1.00 86.05  ? ? ? ? ? ? 197 ILE A O     1 
+ATOM   2981 C CB    . ILE C 3 203 ? 78.823  35.748 108.214 1.00 92.90  ? ? ? ? ? ? 197 ILE A CB    1 
+ATOM   2982 C CG1   . ILE C 3 203 ? 78.696  37.094 107.487 1.00 94.27  ? ? ? ? ? ? 197 ILE A CG1   1 
+ATOM   2983 C CG2   . ILE C 3 203 ? 80.154  35.636 108.935 1.00 94.29  ? ? ? ? ? ? 197 ILE A CG2   1 
+ATOM   2984 C CD1   . ILE C 3 203 ? 77.504  37.909 107.959 1.00 100.00 ? ? ? ? ? ? 197 ILE A CD1   1 
+ATOM   2985 N N     . GLY C 3 204 ? 76.631  35.597 106.414 1.00 87.80  ? ? ? ? ? ? 198 GLY A N     1 
+ATOM   2986 C CA    . GLY C 3 204 ? 75.352  35.765 105.763 1.00 90.41  ? ? ? ? ? ? 198 GLY A CA    1 
+ATOM   2987 C C     . GLY C 3 204 ? 74.901  37.075 106.388 1.00 99.06  ? ? ? ? ? ? 198 GLY A C     1 
+ATOM   2988 O O     . GLY C 3 204 ? 74.146  37.086 107.362 1.00 100.00 ? ? ? ? ? ? 198 GLY A O     1 
+ATOM   2989 N N     . ARG C 3 205 ? 75.441  38.181 105.891 1.00 96.06  ? ? ? ? ? ? 199 ARG A N     1 
+ATOM   2990 C CA    . ARG C 3 205 ? 75.037  39.460 106.449 1.00 95.54  ? ? ? ? ? ? 199 ARG A CA    1 
+ATOM   2991 C C     . ARG C 3 205 ? 74.080  40.106 105.489 1.00 98.39  ? ? ? ? ? ? 199 ARG A C     1 
+ATOM   2992 O O     . ARG C 3 205 ? 73.853  41.312 105.537 1.00 99.46  ? ? ? ? ? ? 199 ARG A O     1 
+ATOM   2993 C CB    . ARG C 3 205 ? 76.184  40.407 106.785 1.00 96.52  ? ? ? ? ? ? 199 ARG A CB    1 
+ATOM   2994 C CG    . ARG C 3 205 ? 77.407  40.388 105.901 1.00 100.00 ? ? ? ? ? ? 199 ARG A CG    1 
+ATOM   2995 C CD    . ARG C 3 205 ? 78.622  40.647 106.784 1.00 97.81  ? ? ? ? ? ? 199 ARG A CD    1 
+ATOM   2996 N NE    . ARG C 3 205 ? 78.914  42.063 107.029 1.00 99.46  ? ? ? ? ? ? 199 ARG A NE    1 
+ATOM   2997 C CZ    . ARG C 3 205 ? 78.186  42.909 107.760 1.00 100.00 ? ? ? ? ? ? 199 ARG A CZ    1 
+ATOM   2998 N NH1   . ARG C 3 205 ? 77.062  42.540 108.356 1.00 81.48  ? ? ? ? ? ? 199 ARG A NH1   1 
+ATOM   2999 N NH2   . ARG C 3 205 ? 78.600  44.155 107.916 1.00 84.70  ? ? ? ? ? ? 199 ARG A NH2   1 
+ATOM   3000 N N     . THR C 3 206 ? 73.527  39.284 104.609 1.00 93.97  ? ? ? ? ? ? 200 THR A N     1 
+ATOM   3001 C CA    . THR C 3 206 ? 72.534  39.746 103.658 1.00 94.56  ? ? ? ? ? ? 200 THR A CA    1 
+ATOM   3002 C C     . THR C 3 206 ? 71.276  38.941 103.877 1.00 98.93  ? ? ? ? ? ? 200 THR A C     1 
+ATOM   3003 O O     . THR C 3 206 ? 71.323  37.835 104.418 1.00 99.57  ? ? ? ? ? ? 200 THR A O     1 
+ATOM   3004 C CB    . THR C 3 206 ? 72.992  39.625 102.201 1.00 100.00 ? ? ? ? ? ? 200 THR A CB    1 
+ATOM   3005 O OG1   . THR C 3 206 ? 73.332  38.262 101.884 1.00 100.00 ? ? ? ? ? ? 200 THR A OG1   1 
+ATOM   3006 C CG2   . THR C 3 206 ? 74.140  40.596 102.061 1.00 100.00 ? ? ? ? ? ? 200 THR A CG2   1 
+ATOM   3007 N N     . LYS C 3 207 ? 70.148  39.508 103.470 1.00 92.35  ? ? ? ? ? ? 201 LYS A N     1 
+ATOM   3008 C CA    . LYS C 3 207 ? 68.850  38.853 103.546 1.00 90.81  ? ? ? ? ? ? 201 LYS A CA    1 
+ATOM   3009 C C     . LYS C 3 207 ? 68.167  39.451 102.351 1.00 93.62  ? ? ? ? ? ? 201 LYS A C     1 
+ATOM   3010 O O     . LYS C 3 207 ? 66.992  39.805 102.394 1.00 92.61  ? ? ? ? ? ? 201 LYS A O     1 
+ATOM   3011 C CB    . LYS C 3 207 ? 68.092  39.221 104.822 1.00 92.77  ? ? ? ? ? ? 201 LYS A CB    1 
+ATOM   3012 C CG    . LYS C 3 207 ? 67.305  38.068 105.435 1.00 94.66  ? ? ? ? ? ? 201 LYS A CG    1 
+ATOM   3013 C CD    . LYS C 3 207 ? 68.231  36.986 105.968 1.00 100.00 ? ? ? ? ? ? 201 LYS A CD    1 
+ATOM   3014 C CE    . LYS C 3 207 ? 68.480  35.919 104.916 1.00 100.00 ? ? ? ? ? ? 201 LYS A CE    1 
+ATOM   3015 N NZ    . LYS C 3 207 ? 69.931  35.707 104.649 1.00 100.00 ? ? ? ? ? ? 201 LYS A NZ    1 
+ATOM   3016 N N     . THR C 3 208 ? 68.939  39.644 101.300 1.00 90.30  ? ? ? ? ? ? 202 THR A N     1 
+ATOM   3017 C CA    . THR C 3 208 ? 68.302  40.219 100.157 1.00 90.58  ? ? ? ? ? ? 202 THR A CA    1 
+ATOM   3018 C C     . THR C 3 208 ? 68.381  39.105 99.152  1.00 93.24  ? ? ? ? ? ? 202 THR A C     1 
+ATOM   3019 O O     . THR C 3 208 ? 69.429  38.511 99.015  1.00 94.74  ? ? ? ? ? ? 202 THR A O     1 
+ATOM   3020 C CB    . THR C 3 208 ? 68.895  41.598 99.816  1.00 100.00 ? ? ? ? ? ? 202 THR A CB    1 
+ATOM   3021 O OG1   . THR C 3 208 ? 69.748  41.557 98.668  1.00 100.00 ? ? ? ? ? ? 202 THR A OG1   1 
+ATOM   3022 C CG2   . THR C 3 208 ? 69.651  42.180 100.994 1.00 100.00 ? ? ? ? ? ? 202 THR A CG2   1 
+ATOM   3023 N N     . LEU C 3 209 ? 67.317  38.783 98.440  1.00 85.88  ? ? ? ? ? ? 203 LEU A N     1 
+ATOM   3024 C CA    . LEU C 3 209 ? 67.445  37.699 97.471  1.00 83.74  ? ? ? ? ? ? 203 LEU A CA    1 
+ATOM   3025 C C     . LEU C 3 209 ? 68.525  38.040 96.417  1.00 87.91  ? ? ? ? ? ? 203 LEU A C     1 
+ATOM   3026 O O     . LEU C 3 209 ? 69.373  37.225 96.069  1.00 86.29  ? ? ? ? ? ? 203 LEU A O     1 
+ATOM   3027 C CB    . LEU C 3 209 ? 66.096  37.479 96.791  1.00 82.18  ? ? ? ? ? ? 203 LEU A CB    1 
+ATOM   3028 C CG    . LEU C 3 209 ? 66.015  36.416 95.696  1.00 81.88  ? ? ? ? ? ? 203 LEU A CG    1 
+ATOM   3029 C CD1   . LEU C 3 209 ? 65.511  35.106 96.271  1.00 80.67  ? ? ? ? ? ? 203 LEU A CD1   1 
+ATOM   3030 C CD2   . LEU C 3 209 ? 65.130  36.884 94.552  1.00 78.58  ? ? ? ? ? ? 203 LEU A CD2   1 
+ATOM   3031 N N     . VAL C 3 210 ? 68.490  39.234 95.841  1.00 84.74  ? ? ? ? ? ? 204 VAL A N     1 
+ATOM   3032 C CA    . VAL C 3 210 ? 69.520  39.542 94.847  1.00 85.08  ? ? ? ? ? ? 204 VAL A CA    1 
+ATOM   3033 C C     . VAL C 3 210 ? 70.678  40.312 95.441  1.00 91.29  ? ? ? ? ? ? 204 VAL A C     1 
+ATOM   3034 O O     . VAL C 3 210 ? 71.030  41.414 95.017  1.00 91.37  ? ? ? ? ? ? 204 VAL A O     1 
+ATOM   3035 C CB    . VAL C 3 210 ? 69.017  40.191 93.543  1.00 88.49  ? ? ? ? ? ? 204 VAL A CB    1 
+ATOM   3036 C CG1   . VAL C 3 210 ? 69.299  39.289 92.343  1.00 88.55  ? ? ? ? ? ? 204 VAL A CG1   1 
+ATOM   3037 C CG2   . VAL C 3 210 ? 67.546  40.538 93.634  1.00 87.90  ? ? ? ? ? ? 204 VAL A CG2   1 
+ATOM   3038 N N     . SER C 3 211 ? 71.246  39.671 96.454  1.00 89.63  ? ? ? ? ? ? 205 SER A N     1 
+ATOM   3039 C CA    . SER C 3 211 ? 72.438  40.140 97.134  1.00 91.06  ? ? ? ? ? ? 205 SER A CA    1 
+ATOM   3040 C C     . SER C 3 211 ? 73.434  39.013 97.118  1.00 99.28  ? ? ? ? ? ? 205 SER A C     1 
+ATOM   3041 O O     . SER C 3 211 ? 74.042  38.693 96.093  1.00 100.00 ? ? ? ? ? ? 205 SER A O     1 
+ATOM   3042 C CB    . SER C 3 211 ? 72.275  40.450 98.618  1.00 93.52  ? ? ? ? ? ? 205 SER A CB    1 
+ATOM   3043 O OG    . SER C 3 211 ? 72.787  41.739 98.926  1.00 100.00 ? ? ? ? ? ? 205 SER A OG    1 
+ATOM   3044 N N     . THR C 3 212 ? 73.585  38.424 98.297  1.00 96.57  ? ? ? ? ? ? 206 THR A N     1 
+ATOM   3045 C CA    . THR C 3 212 ? 74.569  37.391 98.557  1.00 96.45  ? ? ? ? ? ? 206 THR A CA    1 
+ATOM   3046 C C     . THR C 3 212 ? 73.986  36.164 99.234  1.00 100.00 ? ? ? ? ? ? 206 THR A C     1 
+ATOM   3047 O O     . THR C 3 212 ? 72.859  36.180 99.728  1.00 100.00 ? ? ? ? ? ? 206 THR A O     1 
+ATOM   3048 C CB    . THR C 3 212 ? 75.597  37.956 99.551  1.00 100.00 ? ? ? ? ? ? 206 THR A CB    1 
+ATOM   3049 O OG1   . THR C 3 212 ? 75.448  37.320 100.833 1.00 100.00 ? ? ? ? ? ? 206 THR A OG1   1 
+ATOM   3050 C CG2   . THR C 3 212 ? 75.386  39.437 99.657  1.00 98.56  ? ? ? ? ? ? 206 THR A CG2   1 
+ATOM   3051 N N     . ALA C 3 213 ? 74.790  35.108 99.283  1.00 96.87  ? ? ? ? ? ? 207 ALA A N     1 
+ATOM   3052 C CA    . ALA C 3 213 ? 74.424  33.875 99.966  1.00 96.71  ? ? ? ? ? ? 207 ALA A CA    1 
+ATOM   3053 C C     . ALA C 3 213 ? 75.080  33.898 101.352 1.00 100.00 ? ? ? ? ? ? 207 ALA A C     1 
+ATOM   3054 O O     . ALA C 3 213 ? 74.491  33.455 102.340 1.00 100.00 ? ? ? ? ? ? 207 ALA A O     1 
+ATOM   3055 C CB    . ALA C 3 213 ? 74.903  32.671 99.178  1.00 97.75  ? ? ? ? ? ? 207 ALA A CB    1 
+ATOM   3056 N N     . GLY C 3 214 ? 76.310  34.408 101.395 1.00 95.78  ? ? ? ? ? ? 208 GLY A N     1 
+ATOM   3057 C CA    . GLY C 3 214 ? 77.106  34.529 102.614 1.00 94.53  ? ? ? ? ? ? 208 GLY A CA    1 
+ATOM   3058 C C     . GLY C 3 214 ? 78.452  35.138 102.249 1.00 95.67  ? ? ? ? ? ? 208 GLY A C     1 
+ATOM   3059 O O     . GLY C 3 214 ? 78.693  35.468 101.087 1.00 94.63  ? ? ? ? ? ? 208 GLY A O     1 
+ATOM   3060 N N     . VAL C 3 215 ? 79.330  35.312 103.227 1.00 90.30  ? ? ? ? ? ? 209 VAL A N     1 
+ATOM   3061 C CA    . VAL C 3 215 ? 80.634  35.865 102.913 1.00 89.05  ? ? ? ? ? ? 209 VAL A CA    1 
+ATOM   3062 C C     . VAL C 3 215 ? 81.637  35.216 103.824 1.00 90.85  ? ? ? ? ? ? 209 VAL A C     1 
+ATOM   3063 O O     . VAL C 3 215 ? 81.308  34.291 104.564 1.00 89.34  ? ? ? ? ? ? 209 VAL A O     1 
+ATOM   3064 C CB    . VAL C 3 215 ? 80.706  37.370 103.159 1.00 92.07  ? ? ? ? ? ? 209 VAL A CB    1 
+ATOM   3065 C CG1   . VAL C 3 215 ? 80.962  37.645 104.631 1.00 92.14  ? ? ? ? ? ? 209 VAL A CG1   1 
+ATOM   3066 C CG2   . VAL C 3 215 ? 81.808  37.980 102.303 1.00 91.31  ? ? ? ? ? ? 209 VAL A CG2   1 
+ATOM   3067 N N     . GLU C 3 216 ? 82.868  35.697 103.769 1.00 86.82  ? ? ? ? ? ? 210 GLU A N     1 
+ATOM   3068 C CA    . GLU C 3 216 ? 83.891  35.149 104.631 1.00 86.32  ? ? ? ? ? ? 210 GLU A CA    1 
+ATOM   3069 C C     . GLU C 3 216 ? 84.584  36.314 105.324 1.00 95.32  ? ? ? ? ? ? 210 GLU A C     1 
+ATOM   3070 O O     . GLU C 3 216 ? 84.987  37.282 104.675 1.00 96.92  ? ? ? ? ? ? 210 GLU A O     1 
+ATOM   3071 C CB    . GLU C 3 216 ? 84.869  34.312 103.815 1.00 86.30  ? ? ? ? ? ? 210 GLU A CB    1 
+ATOM   3072 C CG    . GLU C 3 216 ? 85.656  33.357 104.664 1.00 81.24  ? ? ? ? ? ? 210 GLU A CG    1 
+ATOM   3073 C CD    . GLU C 3 216 ? 85.426  31.902 104.325 1.00 100.00 ? ? ? ? ? ? 210 GLU A CD    1 
+ATOM   3074 O OE1   . GLU C 3 216 ? 85.736  31.475 103.190 1.00 100.00 ? ? ? ? ? ? 210 GLU A OE1   1 
+ATOM   3075 O OE2   . GLU C 3 216 ? 84.966  31.177 105.228 1.00 100.00 ? ? ? ? ? ? 210 GLU A OE2   1 
+ATOM   3076 N N     . LYS C 3 217 ? 84.657  36.261 106.647 1.00 92.38  ? ? ? ? ? ? 211 LYS A N     1 
+ATOM   3077 C CA    . LYS C 3 217 ? 85.302  37.330 107.393 1.00 91.60  ? ? ? ? ? ? 211 LYS A CA    1 
+ATOM   3078 C C     . LYS C 3 217 ? 86.517  36.655 108.002 1.00 97.20  ? ? ? ? ? ? 211 LYS A C     1 
+ATOM   3079 O O     . LYS C 3 217 ? 86.419  35.541 108.515 1.00 96.93  ? ? ? ? ? ? 211 LYS A O     1 
+ATOM   3080 C CB    . LYS C 3 217 ? 84.365  37.877 108.475 1.00 91.99  ? ? ? ? ? ? 211 LYS A CB    1 
+ATOM   3081 C CG    . LYS C 3 217 ? 83.436  39.001 107.986 1.00 87.57  ? ? ? ? ? ? 211 LYS A CG    1 
+ATOM   3082 C CD    . LYS C 3 217 ? 84.232  40.257 107.635 1.00 90.67  ? ? ? ? ? ? 211 LYS A CD    1 
+ATOM   3083 C CE    . LYS C 3 217 ? 83.352  41.443 107.290 1.00 93.96  ? ? ? ? ? ? 211 LYS A CE    1 
+ATOM   3084 N NZ    . LYS C 3 217 ? 84.116  42.705 107.094 1.00 78.29  ? ? ? ? ? ? 211 LYS A NZ    1 
+ATOM   3085 N N     . ALA C 3 218 ? 87.677  37.292 107.884 1.00 95.02  ? ? ? ? ? ? 212 ALA A N     1 
+ATOM   3086 C CA    . ALA C 3 218 ? 88.923  36.721 108.400 1.00 95.20  ? ? ? ? ? ? 212 ALA A CA    1 
+ATOM   3087 C C     . ALA C 3 218 ? 89.429  37.404 109.674 1.00 97.71  ? ? ? ? ? ? 212 ALA A C     1 
+ATOM   3088 O O     . ALA C 3 218 ? 88.950  38.478 110.038 1.00 97.85  ? ? ? ? ? ? 212 ALA A O     1 
+ATOM   3089 C CB    . ALA C 3 218 ? 89.998  36.735 107.321 1.00 96.22  ? ? ? ? ? ? 212 ALA A CB    1 
+ATOM   3090 N N     . LEU C 3 219 ? 90.395  36.783 110.350 1.00 93.39  ? ? ? ? ? ? 213 LEU A N     1 
+ATOM   3091 C CA    . LEU C 3 219 ? 90.933  37.335 111.598 1.00 93.53  ? ? ? ? ? ? 213 LEU A CA    1 
+ATOM   3092 C C     . LEU C 3 219 ? 92.471  37.393 111.759 1.00 97.02  ? ? ? ? ? ? 213 LEU A C     1 
+ATOM   3093 O O     . LEU C 3 219 ? 93.201  36.734 111.033 1.00 98.58  ? ? ? ? ? ? 213 LEU A O     1 
+ATOM   3094 C CB    . LEU C 3 219 ? 90.244  36.675 112.797 1.00 93.51  ? ? ? ? ? ? 213 LEU A CB    1 
+ATOM   3095 C CG    . LEU C 3 219 ? 88.873  36.024 112.548 1.00 97.67  ? ? ? ? ? ? 213 LEU A CG    1 
+ATOM   3096 C CD1   . LEU C 3 219 ? 88.451  35.158 113.731 1.00 97.93  ? ? ? ? ? ? 213 LEU A CD1   1 
+ATOM   3097 C CD2   . LEU C 3 219 ? 87.781  37.028 112.179 1.00 97.89  ? ? ? ? ? ? 213 LEU A CD2   1 
+ATOM   3098 N N     . SER C 3 220 ? 92.953  38.203 112.696 1.00 91.40  ? ? ? ? ? ? 214 SER A N     1 
+ATOM   3099 C CA    . SER C 3 220 ? 94.383  38.408 112.936 1.00 90.56  ? ? ? ? ? ? 214 SER A CA    1 
+ATOM   3100 C C     . SER C 3 220 ? 95.008  37.488 113.986 1.00 93.60  ? ? ? ? ? ? 214 SER A C     1 
+ATOM   3101 O O     . SER C 3 220 ? 94.462  36.428 114.286 1.00 94.34  ? ? ? ? ? ? 214 SER A O     1 
+ATOM   3102 C CB    . SER C 3 220 ? 94.542  39.846 113.425 1.00 94.71  ? ? ? ? ? ? 214 SER A CB    1 
+ATOM   3103 O OG    . SER C 3 220 ? 93.349  40.581 113.183 1.00 100.00 ? ? ? ? ? ? 214 SER A OG    1 
+ATOM   3104 N N     . LEU C 3 221 ? 96.148  37.897 114.546 0.00 87.17  ? ? ? ? ? ? 215 LEU A N     1 
+ATOM   3105 C CA    . LEU C 3 221 ? 96.777  37.148 115.634 0.00 85.84  ? ? ? ? ? ? 215 LEU A CA    1 
+ATOM   3106 C C     . LEU C 3 221 ? 96.034  37.765 116.799 0.00 90.45  ? ? ? ? ? ? 215 LEU A C     1 
+ATOM   3107 O O     . LEU C 3 221 ? 96.032  37.256 117.921 0.00 89.74  ? ? ? ? ? ? 215 LEU A O     1 
+ATOM   3108 C CB    . LEU C 3 221 ? 98.270  37.449 115.793 0.00 85.37  ? ? ? ? ? ? 215 LEU A CB    1 
+ATOM   3109 C CG    . LEU C 3 221 ? 98.868  36.924 117.106 0.00 89.39  ? ? ? ? ? ? 215 LEU A CG    1 
+ATOM   3110 C CD1   . LEU C 3 221 ? 98.263  35.575 117.474 0.00 89.35  ? ? ? ? ? ? 215 LEU A CD1   1 
+ATOM   3111 C CD2   . LEU C 3 221 ? 100.383 36.827 117.012 0.00 91.66  ? ? ? ? ? ? 215 LEU A CD2   1 
+ATOM   3112 N N     . GLY C 3 222 ? 95.395  38.889 116.498 1.00 88.47  ? ? ? ? ? ? 216 GLY A N     1 
+ATOM   3113 C CA    . GLY C 3 222 ? 94.581  39.560 117.485 1.00 87.50  ? ? ? ? ? ? 216 GLY A CA    1 
+ATOM   3114 C C     . GLY C 3 222 ? 93.470  38.526 117.603 1.00 86.15  ? ? ? ? ? ? 216 GLY A C     1 
+ATOM   3115 O O     . GLY C 3 222 ? 93.633  37.492 118.254 1.00 82.33  ? ? ? ? ? ? 216 GLY A O     1 
+ATOM   3116 N N     . VAL C 3 223 ? 92.383  38.763 116.877 1.00 82.30  ? ? ? ? ? ? 217 VAL A N     1 
+ATOM   3117 C CA    . VAL C 3 223 ? 91.229  37.872 116.879 1.00 82.07  ? ? ? ? ? ? 217 VAL A CA    1 
+ATOM   3118 C C     . VAL C 3 223 ? 91.206  36.340 116.882 1.00 90.79  ? ? ? ? ? ? 217 VAL A C     1 
+ATOM   3119 O O     . VAL C 3 223 ? 90.758  35.737 117.855 1.00 93.88  ? ? ? ? ? ? 217 VAL A O     1 
+ATOM   3120 C CB    . VAL C 3 223 ? 89.887  38.553 116.611 1.00 84.71  ? ? ? ? ? ? 217 VAL A CB    1 
+ATOM   3121 C CG1   . VAL C 3 223 ? 90.006  40.053 116.794 1.00 84.34  ? ? ? ? ? ? 217 VAL A CG1   1 
+ATOM   3122 C CG2   . VAL C 3 223 ? 89.397  38.217 115.225 1.00 84.55  ? ? ? ? ? ? 217 VAL A CG2   1 
+ATOM   3123 N N     . THR C 3 224 ? 91.621  35.707 115.790 1.00 85.90  ? ? ? ? ? ? 218 THR A N     1 
+ATOM   3124 C CA    . THR C 3 224 ? 91.633  34.243 115.682 1.00 84.20  ? ? ? ? ? ? 218 THR A CA    1 
+ATOM   3125 C C     . THR C 3 224 ? 92.115  33.600 117.003 1.00 87.15  ? ? ? ? ? ? 218 THR A C     1 
+ATOM   3126 O O     . THR C 3 224 ? 91.483  32.682 117.527 1.00 87.56  ? ? ? ? ? ? 218 THR A O     1 
+ATOM   3127 C CB    . THR C 3 224 ? 92.512  33.814 114.473 1.00 85.91  ? ? ? ? ? ? 218 THR A CB    1 
+ATOM   3128 O OG1   . THR C 3 224 ? 92.077  32.553 113.940 1.00 76.89  ? ? ? ? ? ? 218 THR A OG1   1 
+ATOM   3129 C CG2   . THR C 3 224 ? 93.973  33.735 114.884 1.00 87.54  ? ? ? ? ? ? 218 THR A CG2   1 
+ATOM   3130 N N     . LYS C 3 225 ? 93.213  34.111 117.558 1.00 81.81  ? ? ? ? ? ? 219 LYS A N     1 
+ATOM   3131 C CA    . LYS C 3 225 ? 93.767  33.586 118.811 1.00 80.91  ? ? ? ? ? ? 219 LYS A CA    1 
+ATOM   3132 C C     . LYS C 3 225 ? 92.793  33.673 119.979 1.00 81.17  ? ? ? ? ? ? 219 LYS A C     1 
+ATOM   3133 O O     . LYS C 3 225 ? 92.401  32.655 120.546 1.00 82.44  ? ? ? ? ? ? 219 LYS A O     1 
+ATOM   3134 C CB    . LYS C 3 225 ? 95.088  34.272 119.170 1.00 83.39  ? ? ? ? ? ? 219 LYS A CB    1 
+ATOM   3135 C CG    . LYS C 3 225 ? 96.236  33.302 119.429 1.00 91.85  ? ? ? ? ? ? 219 LYS A CG    1 
+ATOM   3136 C CD    . LYS C 3 225 ? 96.418  32.346 118.257 1.00 96.67  ? ? ? ? ? ? 219 LYS A CD    1 
+ATOM   3137 C CE    . LYS C 3 225 ? 97.768  32.538 117.582 1.00 100.00 ? ? ? ? ? ? 219 LYS A CE    1 
+ATOM   3138 N NZ    . LYS C 3 225 ? 97.846  31.822 116.275 1.00 100.00 ? ? ? ? ? ? 219 LYS A NZ    1 
+ATOM   3139 N N     . LEU C 3 226 ? 92.412  34.893 120.348 1.00 71.00  ? ? ? ? ? ? 220 LEU A N     1 
+ATOM   3140 C CA    . LEU C 3 226 ? 91.466  35.052 121.440 1.00 67.26  ? ? ? ? ? ? 220 LEU A CA    1 
+ATOM   3141 C C     . LEU C 3 226 ? 90.383  34.021 121.161 1.00 68.20  ? ? ? ? ? ? 220 LEU A C     1 
+ATOM   3142 O O     . LEU C 3 226 ? 89.969  33.284 122.056 1.00 67.69  ? ? ? ? ? ? 220 LEU A O     1 
+ATOM   3143 C CB    . LEU C 3 226 ? 90.865  36.462 121.466 1.00 66.07  ? ? ? ? ? ? 220 LEU A CB    1 
+ATOM   3144 C CG    . LEU C 3 226 ? 91.768  37.657 121.140 1.00 68.72  ? ? ? ? ? ? 220 LEU A CG    1 
+ATOM   3145 C CD1   . LEU C 3 226 ? 91.084  38.610 120.174 1.00 67.49  ? ? ? ? ? ? 220 LEU A CD1   1 
+ATOM   3146 C CD2   . LEU C 3 226 ? 92.194  38.404 122.394 1.00 72.22  ? ? ? ? ? ? 220 LEU A CD2   1 
+ATOM   3147 N N     . VAL C 3 227 ? 89.961  33.947 119.904 1.00 62.29  ? ? ? ? ? ? 221 VAL A N     1 
+ATOM   3148 C CA    . VAL C 3 227 ? 88.927  33.006 119.520 1.00 63.09  ? ? ? ? ? ? 221 VAL A CA    1 
+ATOM   3149 C C     . VAL C 3 227 ? 89.368  31.556 119.659 1.00 73.91  ? ? ? ? ? ? 221 VAL A C     1 
+ATOM   3150 O O     . VAL C 3 227 ? 88.634  30.640 119.297 1.00 78.15  ? ? ? ? ? ? 221 VAL A O     1 
+ATOM   3151 C CB    . VAL C 3 227 ? 88.343  33.328 118.134 0.00 67.03  ? ? ? ? ? ? 221 VAL A CB    1 
+ATOM   3152 C CG1   . VAL C 3 227 ? 87.105  32.492 117.864 0.00 66.81  ? ? ? ? ? ? 221 VAL A CG1   1 
+ATOM   3153 C CG2   . VAL C 3 227 ? 87.997  34.806 118.053 0.00 66.82  ? ? ? ? ? ? 221 VAL A CG2   1 
+ATOM   3154 N N     . GLU C 3 228 ? 90.554  31.341 120.220 1.00 69.36  ? ? ? ? ? ? 222 GLU A N     1 
+ATOM   3155 C CA    . GLU C 3 228 ? 91.051  29.988 120.447 1.00 68.33  ? ? ? ? ? ? 222 GLU A CA    1 
+ATOM   3156 C C     . GLU C 3 228 ? 90.839  29.702 121.928 1.00 70.95  ? ? ? ? ? ? 222 GLU A C     1 
+ATOM   3157 O O     . GLU C 3 228 ? 90.229  28.704 122.312 1.00 69.20  ? ? ? ? ? ? 222 GLU A O     1 
+ATOM   3158 C CB    . GLU C 3 228 ? 92.536  29.882 120.087 0.00 69.76  ? ? ? ? ? ? 222 GLU A CB    1 
+ATOM   3159 C CG    . GLU C 3 228 ? 92.825  29.979 118.594 0.00 80.23  ? ? ? ? ? ? 222 GLU A CG    1 
+ATOM   3160 C CD    . GLU C 3 228 ? 93.675  28.828 118.085 0.00 100.00 ? ? ? ? ? ? 222 GLU A CD    1 
+ATOM   3161 O OE1   . GLU C 3 228 ? 93.542  27.709 118.622 0.00 93.94  ? ? ? ? ? ? 222 GLU A OE1   1 
+ATOM   3162 O OE2   . GLU C 3 228 ? 94.469  29.041 117.145 0.00 94.21  ? ? ? ? ? ? 222 GLU A OE2   1 
+ATOM   3163 N N     . ARG C 3 229 ? 91.330  30.624 122.748 1.00 68.33  ? ? ? ? ? ? 223 ARG A N     1 
+ATOM   3164 C CA    . ARG C 3 229 ? 91.185  30.509 124.188 1.00 67.34  ? ? ? ? ? ? 223 ARG A CA    1 
+ATOM   3165 C C     . ARG C 3 229 ? 89.704  30.385 124.529 1.00 75.64  ? ? ? ? ? ? 223 ARG A C     1 
+ATOM   3166 O O     . ARG C 3 229 ? 89.378  29.644 125.454 1.00 78.29  ? ? ? ? ? ? 223 ARG A O     1 
+ATOM   3167 C CB    . ARG C 3 229 ? 91.824  31.692 124.926 1.00 60.19  ? ? ? ? ? ? 223 ARG A CB    1 
+ATOM   3168 C CG    . ARG C 3 229 ? 92.537  31.393 126.255 1.00 54.51  ? ? ? ? ? ? 223 ARG A CG    1 
+ATOM   3169 C CD    . ARG C 3 229 ? 93.501  32.552 126.585 1.00 65.78  ? ? ? ? ? ? 223 ARG A CD    1 
+ATOM   3170 N NE    . ARG C 3 229 ? 93.758  32.770 128.011 1.00 83.31  ? ? ? ? ? ? 223 ARG A NE    1 
+ATOM   3171 C CZ    . ARG C 3 229 ? 94.085  33.948 128.559 1.00 100.00 ? ? ? ? ? ? 223 ARG A CZ    1 
+ATOM   3172 N NH1   . ARG C 3 229 ? 94.208  35.043 127.815 1.00 90.52  ? ? ? ? ? ? 223 ARG A NH1   1 
+ATOM   3173 N NH2   . ARG C 3 229 ? 94.300  34.032 129.865 1.00 96.00  ? ? ? ? ? ? 223 ARG A NH2   1 
+ATOM   3174 N N     . TRP C 3 230 ? 88.803  31.072 123.810 1.00 71.39  ? ? ? ? ? ? 224 TRP A N     1 
+ATOM   3175 C CA    . TRP C 3 230 ? 87.369  30.941 124.101 1.00 70.93  ? ? ? ? ? ? 224 TRP A CA    1 
+ATOM   3176 C C     . TRP C 3 230 ? 86.880  29.537 123.835 1.00 83.42  ? ? ? ? ? ? 224 TRP A C     1 
+ATOM   3177 O O     . TRP C 3 230 ? 86.035  29.049 124.556 1.00 83.91  ? ? ? ? ? ? 224 TRP A O     1 
+ATOM   3178 C CB    . TRP C 3 230 ? 86.438  32.028 123.530 1.00 67.62  ? ? ? ? ? ? 224 TRP A CB    1 
+ATOM   3179 C CG    . TRP C 3 230 ? 84.956  31.703 123.770 1.00 66.99  ? ? ? ? ? ? 224 TRP A CG    1 
+ATOM   3180 C CD1   . TRP C 3 230 ? 84.020  31.401 122.816 1.00 69.56  ? ? ? ? ? ? 224 TRP A CD1   1 
+ATOM   3181 C CD2   . TRP C 3 230 ? 84.278  31.596 125.041 1.00 66.22  ? ? ? ? ? ? 224 TRP A CD2   1 
+ATOM   3182 N NE1   . TRP C 3 230 ? 82.804  31.112 123.410 1.00 69.28  ? ? ? ? ? ? 224 TRP A NE1   1 
+ATOM   3183 C CE2   . TRP C 3 230 ? 82.937  31.239 124.771 1.00 70.48  ? ? ? ? ? ? 224 TRP A CE2   1 
+ATOM   3184 C CE3   . TRP C 3 230 ? 84.670  31.771 126.372 1.00 66.29  ? ? ? ? ? ? 224 TRP A CE3   1 
+ATOM   3185 C CZ2   . TRP C 3 230 ? 81.994  31.046 125.783 1.00 68.63  ? ? ? ? ? ? 224 TRP A CZ2   1 
+ATOM   3186 C CZ3   . TRP C 3 230 ? 83.735  31.590 127.367 1.00 67.14  ? ? ? ? ? ? 224 TRP A CZ3   1 
+ATOM   3187 C CH2   . TRP C 3 230 ? 82.418  31.241 127.071 1.00 67.72  ? ? ? ? ? ? 224 TRP A CH2   1 
+ATOM   3188 N N     . ILE C 3 231 ? 87.488  28.842 122.885 1.00 84.30  ? ? ? ? ? ? 225 ILE A N     1 
+ATOM   3189 C CA    . ILE C 3 231 ? 87.076  27.467 122.657 1.00 84.94  ? ? ? ? ? ? 225 ILE A CA    1 
+ATOM   3190 C C     . ILE C 3 231 ? 87.649  26.401 123.597 1.00 86.56  ? ? ? ? ? ? 225 ILE A C     1 
+ATOM   3191 O O     . ILE C 3 231 ? 86.963  25.427 123.909 1.00 83.80  ? ? ? ? ? ? 225 ILE A O     1 
+ATOM   3192 C CB    . ILE C 3 231 ? 86.954  27.087 121.179 1.00 88.81  ? ? ? ? ? ? 225 ILE A CB    1 
+ATOM   3193 C CG1   . ILE C 3 231 ? 85.799  27.876 120.555 1.00 88.91  ? ? ? ? ? ? 225 ILE A CG1   1 
+ATOM   3194 C CG2   . ILE C 3 231 ? 86.715  25.594 121.036 1.00 90.97  ? ? ? ? ? ? 225 ILE A CG2   1 
+ATOM   3195 C CD1   . ILE C 3 231 ? 86.004  28.211 119.092 1.00 92.28  ? ? ? ? ? ? 225 ILE A CD1   1 
+ATOM   3196 N N     . SER C 3 232 ? 88.862  26.616 124.101 1.00 84.02  ? ? ? ? ? ? 226 SER A N     1 
+ATOM   3197 C CA    . SER C 3 232 ? 89.434  25.691 125.073 1.00 84.64  ? ? ? ? ? ? 226 SER A CA    1 
+ATOM   3198 C C     . SER C 3 232 ? 88.595  25.752 126.365 1.00 89.49  ? ? ? ? ? ? 226 SER A C     1 
+ATOM   3199 O O     . SER C 3 232 ? 88.245  24.721 126.951 1.00 90.12  ? ? ? ? ? ? 226 SER A O     1 
+ATOM   3200 C CB    . SER C 3 232 ? 90.902  26.048 125.364 1.00 86.23  ? ? ? ? ? ? 226 SER A CB    1 
+ATOM   3201 O OG    . SER C 3 232 ? 91.003  27.242 126.117 1.00 90.23  ? ? ? ? ? ? 226 SER A OG    1 
+ATOM   3202 N N     . VAL C 3 233 ? 88.275  26.971 126.796 1.00 83.51  ? ? ? ? ? ? 227 VAL A N     1 
+ATOM   3203 C CA    . VAL C 3 233 ? 87.511  27.219 128.014 1.00 82.36  ? ? ? ? ? ? 227 VAL A CA    1 
+ATOM   3204 C C     . VAL C 3 233 ? 86.007  27.071 127.831 1.00 87.34  ? ? ? ? ? ? 227 VAL A C     1 
+ATOM   3205 O O     . VAL C 3 233 ? 85.333  26.597 128.744 1.00 90.15  ? ? ? ? ? ? 227 VAL A O     1 
+ATOM   3206 C CB    . VAL C 3 233 ? 87.818  28.594 128.607 1.00 86.03  ? ? ? ? ? ? 227 VAL A CB    1 
+ATOM   3207 C CG1   . VAL C 3 233 ? 89.311  28.924 128.419 1.00 85.88  ? ? ? ? ? ? 227 VAL A CG1   1 
+ATOM   3208 C CG2   . VAL C 3 233 ? 86.903  29.626 127.936 1.00 85.77  ? ? ? ? ? ? 227 VAL A CG2   1 
+ATOM   3209 N N     . SER C 3 234 ? 85.463  27.474 126.686 1.00 82.05  ? ? ? ? ? ? 228 SER A N     1 
+ATOM   3210 C CA    . SER C 3 234 ? 84.020  27.329 126.471 1.00 81.94  ? ? ? ? ? ? 228 SER A CA    1 
+ATOM   3211 C C     . SER C 3 234 ? 83.653  25.880 126.180 1.00 84.03  ? ? ? ? ? ? 228 SER A C     1 
+ATOM   3212 O O     . SER C 3 234 ? 82.496  25.483 126.344 1.00 81.68  ? ? ? ? ? ? 228 SER A O     1 
+ATOM   3213 C CB    . SER C 3 234 ? 83.517  28.155 125.291 1.00 87.79  ? ? ? ? ? ? 228 SER A CB    1 
+ATOM   3214 O OG    . SER C 3 234 ? 84.097  27.679 124.086 1.00 100.00 ? ? ? ? ? ? 228 SER A OG    1 
+ATOM   3215 N N     . GLY C 3 235 ? 84.618  25.108 125.690 1.00 81.78  ? ? ? ? ? ? 229 GLY A N     1 
+ATOM   3216 C CA    . GLY C 3 235 ? 84.372  23.710 125.324 1.00 82.52  ? ? ? ? ? ? 229 GLY A CA    1 
+ATOM   3217 C C     . GLY C 3 235 ? 83.163  23.738 124.400 1.00 87.38  ? ? ? ? ? ? 229 GLY A C     1 
+ATOM   3218 O O     . GLY C 3 235 ? 82.335  22.825 124.372 1.00 86.73  ? ? ? ? ? ? 229 GLY A O     1 
+ATOM   3219 N N     . VAL C 3 236 ? 83.079  24.839 123.662 1.00 84.09  ? ? ? ? ? ? 230 VAL A N     1 
+ATOM   3220 C CA    . VAL C 3 236 ? 81.972  25.129 122.767 1.00 83.68  ? ? ? ? ? ? 230 VAL A CA    1 
+ATOM   3221 C C     . VAL C 3 236 ? 81.898  24.260 121.517 1.00 88.89  ? ? ? ? ? ? 230 VAL A C     1 
+ATOM   3222 O O     . VAL C 3 236 ? 80.821  24.053 120.947 1.00 87.70  ? ? ? ? ? ? 230 VAL A O     1 
+ATOM   3223 C CB    . VAL C 3 236 ? 81.937  26.639 122.405 1.00 86.97  ? ? ? ? ? ? 230 VAL A CB    1 
+ATOM   3224 C CG1   . VAL C 3 236 ? 82.458  26.883 120.995 1.00 86.13  ? ? ? ? ? ? 230 VAL A CG1   1 
+ATOM   3225 C CG2   . VAL C 3 236 ? 80.534  27.197 122.579 1.00 86.83  ? ? ? ? ? ? 230 VAL A CG2   1 
+ATOM   3226 N N     . ALA C 3 237 ? 83.053  23.731 121.118 1.00 86.33  ? ? ? ? ? ? 231 ALA A N     1 
+ATOM   3227 C CA    . ALA C 3 237 ? 83.164  22.909 119.922 1.00 85.95  ? ? ? ? ? ? 231 ALA A CA    1 
+ATOM   3228 C C     . ALA C 3 237 ? 82.867  21.416 120.074 1.00 90.07  ? ? ? ? ? ? 231 ALA A C     1 
+ATOM   3229 O O     . ALA C 3 237 ? 82.841  20.696 119.076 1.00 91.40  ? ? ? ? ? ? 231 ALA A O     1 
+ATOM   3230 C CB    . ALA C 3 237 ? 84.509  23.133 119.240 1.00 86.46  ? ? ? ? ? ? 231 ALA A CB    1 
+ATOM   3231 N N     . ASP C 3 238 ? 82.621  20.947 121.295 1.00 83.63  ? ? ? ? ? ? 232 ASP A N     1 
+ATOM   3232 C CA    . ASP C 3 238 ? 82.333  19.533 121.498 1.00 81.77  ? ? ? ? ? ? 232 ASP A CA    1 
+ATOM   3233 C C     . ASP C 3 238 ? 81.306  18.943 120.523 1.00 84.29  ? ? ? ? ? ? 232 ASP A C     1 
+ATOM   3234 O O     . ASP C 3 238 ? 81.440  17.792 120.110 1.00 87.58  ? ? ? ? ? ? 232 ASP A O     1 
+ATOM   3235 C CB    . ASP C 3 238 ? 82.033  19.230 122.968 1.00 83.92  ? ? ? ? ? ? 232 ASP A CB    1 
+ATOM   3236 C CG    . ASP C 3 238 ? 83.271  19.354 123.852 1.00 99.81  ? ? ? ? ? ? 232 ASP A CG    1 
+ATOM   3237 O OD1   . ASP C 3 238 ? 84.324  18.795 123.474 1.00 100.00 ? ? ? ? ? ? 232 ASP A OD1   1 
+ATOM   3238 O OD2   . ASP C 3 238 ? 83.190  19.997 124.920 1.00 100.00 ? ? ? ? ? ? 232 ASP A OD2   1 
+ATOM   3239 N N     . ASP C 3 239 ? 80.303  19.726 120.137 1.00 76.77  ? ? ? ? ? ? 233 ASP A N     1 
+ATOM   3240 C CA    . ASP C 3 239 ? 79.299  19.302 119.161 1.00 75.87  ? ? ? ? ? ? 233 ASP A CA    1 
+ATOM   3241 C C     . ASP C 3 239 ? 79.262  20.479 118.206 1.00 79.93  ? ? ? ? ? ? 233 ASP A C     1 
+ATOM   3242 O O     . ASP C 3 239 ? 79.251  21.627 118.642 1.00 78.97  ? ? ? ? ? ? 233 ASP A O     1 
+ATOM   3243 C CB    . ASP C 3 239 ? 77.930  19.084 119.822 1.00 77.56  ? ? ? ? ? ? 233 ASP A CB    1 
+ATOM   3244 C CG    . ASP C 3 239 ? 76.754  19.491 118.930 1.00 87.55  ? ? ? ? ? ? 233 ASP A CG    1 
+ATOM   3245 O OD1   . ASP C 3 239 ? 76.792  19.278 117.697 1.00 84.25  ? ? ? ? ? ? 233 ASP A OD1   1 
+ATOM   3246 O OD2   . ASP C 3 239 ? 75.753  20.007 119.479 1.00 100.00 ? ? ? ? ? ? 233 ASP A OD2   1 
+ATOM   3247 N N     . PRO C 3 240 ? 79.184  20.202 116.907 1.00 78.04  ? ? ? ? ? ? 234 PRO A N     1 
+ATOM   3248 C CA    . PRO C 3 240 ? 79.171  21.256 115.896 1.00 78.47  ? ? ? ? ? ? 234 PRO A CA    1 
+ATOM   3249 C C     . PRO C 3 240 ? 77.831  21.883 115.579 1.00 89.29  ? ? ? ? ? ? 234 PRO A C     1 
+ATOM   3250 O O     . PRO C 3 240 ? 77.805  22.921 114.989 1.00 91.76  ? ? ? ? ? ? 234 PRO A O     1 
+ATOM   3251 C CB    . PRO C 3 240 ? 79.642  20.543 114.627 0.00 79.72  ? ? ? ? ? ? 234 PRO A CB    1 
+ATOM   3252 C CG    . PRO C 3 240 ? 80.300  19.297 115.058 0.00 83.60  ? ? ? ? ? ? 234 PRO A CG    1 
+ATOM   3253 C CD    . PRO C 3 240 ? 80.127  19.129 116.543 0.00 78.65  ? ? ? ? ? ? 234 PRO A CD    1 
+ATOM   3254 N N     . ASN C 3 241 ? 76.675  21.321 115.898 1.00 86.50  ? ? ? ? ? ? 235 ASN A N     1 
+ATOM   3255 C CA    . ASN C 3 241 ? 75.526  22.102 115.567 1.00 84.55  ? ? ? ? ? ? 235 ASN A CA    1 
+ATOM   3256 C C     . ASN C 3 241 ? 75.497  23.488 116.344 1.00 82.31  ? ? ? ? ? ? 235 ASN A C     1 
+ATOM   3257 O O     . ASN C 3 241 ? 75.117  24.565 115.822 1.00 80.67  ? ? ? ? ? ? 235 ASN A O     1 
+ATOM   3258 C CB    . ASN C 3 241 ? 74.271  21.253 115.693 1.00 84.56  ? ? ? ? ? ? 235 ASN A CB    1 
+ATOM   3259 C CG    . ASN C 3 241 ? 74.327  20.028 114.754 1.00 100.00 ? ? ? ? ? ? 235 ASN A CG    1 
+ATOM   3260 O OD1   . ASN C 3 241 ? 73.457  19.851 113.901 1.00 100.00 ? ? ? ? ? ? 235 ASN A OD1   1 
+ATOM   3261 N ND2   . ASN C 3 241 ? 75.366  19.202 114.898 1.00 100.00 ? ? ? ? ? ? 235 ASN A ND2   1 
+ATOM   3262 N N     . ASN C 3 242 ? 75.976  23.418 117.583 1.00 75.84  ? ? ? ? ? ? 236 ASN A N     1 
+ATOM   3263 C CA    . ASN C 3 242 ? 76.126  24.571 118.470 1.00 75.05  ? ? ? ? ? ? 236 ASN A CA    1 
+ATOM   3264 C C     . ASN C 3 242 ? 76.438  25.931 117.853 1.00 78.98  ? ? ? ? ? ? 236 ASN A C     1 
+ATOM   3265 O O     . ASN C 3 242 ? 76.895  25.970 116.727 1.00 80.14  ? ? ? ? ? ? 236 ASN A O     1 
+ATOM   3266 C CB    . ASN C 3 242 ? 77.224  24.281 119.486 1.00 74.84  ? ? ? ? ? ? 236 ASN A CB    1 
+ATOM   3267 C CG    . ASN C 3 242 ? 76.711  23.469 120.635 1.00 95.72  ? ? ? ? ? ? 236 ASN A CG    1 
+ATOM   3268 O OD1   . ASN C 3 242 ? 75.541  23.090 120.657 1.00 90.02  ? ? ? ? ? ? 236 ASN A OD1   1 
+ATOM   3269 N ND2   . ASN C 3 242 ? 77.571  23.208 121.605 1.00 86.25  ? ? ? ? ? ? 236 ASN A ND2   1 
+ATOM   3270 N N     . TYR C 3 243 ? 76.400  26.978 118.679 1.00 72.12  ? ? ? ? ? ? 237 TYR A N     1 
+ATOM   3271 C CA    . TYR C 3 243 ? 76.699  28.361 118.256 1.00 69.29  ? ? ? ? ? ? 237 TYR A CA    1 
+ATOM   3272 C C     . TYR C 3 243 ? 77.989  28.813 118.928 1.00 70.44  ? ? ? ? ? ? 237 TYR A C     1 
+ATOM   3273 O O     . TYR C 3 243 ? 78.189  28.513 120.106 1.00 72.29  ? ? ? ? ? ? 237 TYR A O     1 
+ATOM   3274 C CB    . TYR C 3 243 ? 75.645  29.309 118.816 1.00 70.11  ? ? ? ? ? ? 237 TYR A CB    1 
+ATOM   3275 C CG    . TYR C 3 243 ? 74.290  29.275 118.175 1.00 71.78  ? ? ? ? ? ? 237 TYR A CG    1 
+ATOM   3276 C CD1   . TYR C 3 243 ? 73.249  28.576 118.771 1.00 73.67  ? ? ? ? ? ? 237 TYR A CD1   1 
+ATOM   3277 C CD2   . TYR C 3 243 ? 74.010  30.051 117.056 1.00 71.50  ? ? ? ? ? ? 237 TYR A CD2   1 
+ATOM   3278 C CE1   . TYR C 3 243 ? 71.989  28.577 118.222 1.00 74.00  ? ? ? ? ? ? 237 TYR A CE1   1 
+ATOM   3279 C CE2   . TYR C 3 243 ? 72.747  30.071 116.506 1.00 71.30  ? ? ? ? ? ? 237 TYR A CE2   1 
+ATOM   3280 C CZ    . TYR C 3 243 ? 71.742  29.334 117.095 1.00 79.84  ? ? ? ? ? ? 237 TYR A CZ    1 
+ATOM   3281 O OH    . TYR C 3 243 ? 70.479  29.328 116.550 1.00 80.97  ? ? ? ? ? ? 237 TYR A OH    1 
+ATOM   3282 N N     . LEU C 3 244 ? 78.844  29.572 118.246 1.00 62.10  ? ? ? ? ? ? 238 LEU A N     1 
+ATOM   3283 C CA    . LEU C 3 244 ? 80.098  29.966 118.899 1.00 59.01  ? ? ? ? ? ? 238 LEU A CA    1 
+ATOM   3284 C C     . LEU C 3 244 ? 80.024  30.629 120.282 1.00 67.45  ? ? ? ? ? ? 238 LEU A C     1 
+ATOM   3285 O O     . LEU C 3 244 ? 80.726  30.222 121.209 1.00 69.82  ? ? ? ? ? ? 238 LEU A O     1 
+ATOM   3286 C CB    . LEU C 3 244 ? 81.057  30.713 117.967 1.00 56.59  ? ? ? ? ? ? 238 LEU A CB    1 
+ATOM   3287 C CG    . LEU C 3 244 ? 82.351  31.136 118.671 1.00 58.91  ? ? ? ? ? ? 238 LEU A CG    1 
+ATOM   3288 C CD1   . LEU C 3 244 ? 83.279  29.947 118.893 1.00 58.41  ? ? ? ? ? ? 238 LEU A CD1   1 
+ATOM   3289 C CD2   . LEU C 3 244 ? 83.054  32.318 117.996 1.00 57.32  ? ? ? ? ? ? 238 LEU A CD2   1 
+ATOM   3290 N N     . PHE C 3 245 ? 79.184  31.652 120.410 1.00 61.11  ? ? ? ? ? ? 239 PHE A N     1 
+ATOM   3291 C CA    . PHE C 3 245 ? 79.018  32.390 121.656 1.00 58.22  ? ? ? ? ? ? 239 PHE A CA    1 
+ATOM   3292 C C     . PHE C 3 245 ? 77.876  31.924 122.545 1.00 64.13  ? ? ? ? ? ? 239 PHE A C     1 
+ATOM   3293 O O     . PHE C 3 245 ? 76.718  31.821 122.132 1.00 63.49  ? ? ? ? ? ? 239 PHE A O     1 
+ATOM   3294 C CB    . PHE C 3 245 ? 78.937  33.882 121.375 1.00 59.09  ? ? ? ? ? ? 239 PHE A CB    1 
+ATOM   3295 C CG    . PHE C 3 245 ? 80.249  34.466 120.953 1.00 61.28  ? ? ? ? ? ? 239 PHE A CG    1 
+ATOM   3296 C CD1   . PHE C 3 245 ? 80.415  34.995 119.685 1.00 64.46  ? ? ? ? ? ? 239 PHE A CD1   1 
+ATOM   3297 C CD2   . PHE C 3 245 ? 81.337  34.433 121.813 1.00 64.41  ? ? ? ? ? ? 239 PHE A CD2   1 
+ATOM   3298 C CE1   . PHE C 3 245 ? 81.638  35.513 119.292 1.00 67.26  ? ? ? ? ? ? 239 PHE A CE1   1 
+ATOM   3299 C CE2   . PHE C 3 245 ? 82.560  34.948 121.429 1.00 65.88  ? ? ? ? ? ? 239 PHE A CE2   1 
+ATOM   3300 C CZ    . PHE C 3 245 ? 82.712  35.485 120.165 1.00 65.67  ? ? ? ? ? ? 239 PHE A CZ    1 
+ATOM   3301 N N     . CYS C 3 246 ? 78.228  31.638 123.790 1.00 62.81  ? ? ? ? ? ? 240 CYS A N     1 
+ATOM   3302 C CA    . CYS C 3 246 ? 77.252  31.169 124.754 1.00 62.76  ? ? ? ? ? ? 240 CYS A CA    1 
+ATOM   3303 C C     . CYS C 3 246 ? 77.342  31.938 126.064 1.00 61.57  ? ? ? ? ? ? 240 CYS A C     1 
+ATOM   3304 O O     . CYS C 3 246 ? 78.278  32.705 126.301 1.00 57.50  ? ? ? ? ? ? 240 CYS A O     1 
+ATOM   3305 C CB    . CYS C 3 246 ? 77.460  29.680 125.027 1.00 64.56  ? ? ? ? ? ? 240 CYS A CB    1 
+ATOM   3306 S SG    . CYS C 3 246 ? 79.105  29.311 125.726 1.00 69.10  ? ? ? ? ? ? 240 CYS A SG    1 
+ATOM   3307 N N     . ARG C 3 247 ? 76.349  31.700 126.914 1.00 58.87  ? ? ? ? ? ? 241 ARG A N     1 
+ATOM   3308 C CA    . ARG C 3 247 ? 76.277  32.323 128.227 1.00 57.40  ? ? ? ? ? ? 241 ARG A CA    1 
+ATOM   3309 C C     . ARG C 3 247 ? 77.228  31.599 129.192 1.00 57.52  ? ? ? ? ? ? 241 ARG A C     1 
+ATOM   3310 O O     . ARG C 3 247 ? 77.467  30.394 129.065 1.00 55.76  ? ? ? ? ? ? 241 ARG A O     1 
+ATOM   3311 C CB    . ARG C 3 247 ? 74.823  32.373 128.734 1.00 54.96  ? ? ? ? ? ? 241 ARG A CB    1 
+ATOM   3312 C CG    . ARG C 3 247 ? 74.166  31.009 128.944 1.00 60.83  ? ? ? ? ? ? 241 ARG A CG    1 
+ATOM   3313 C CD    . ARG C 3 247 ? 72.663  31.110 129.199 1.00 54.64  ? ? ? ? ? ? 241 ARG A CD    1 
+ATOM   3314 N NE    . ARG C 3 247 ? 72.346  31.624 130.528 1.00 61.26  ? ? ? ? ? ? 241 ARG A NE    1 
+ATOM   3315 C CZ    . ARG C 3 247 ? 71.112  31.830 130.983 1.00 81.08  ? ? ? ? ? ? 241 ARG A CZ    1 
+ATOM   3316 N NH1   . ARG C 3 247 ? 70.056  31.549 130.222 1.00 69.73  ? ? ? ? ? ? 241 ARG A NH1   1 
+ATOM   3317 N NH2   . ARG C 3 247 ? 70.934  32.309 132.204 1.00 74.25  ? ? ? ? ? ? 241 ARG A NH2   1 
+ATOM   3318 N N     . VAL C 3 248 ? 77.804  32.375 130.111 1.00 52.03  ? ? ? ? ? ? 242 VAL A N     1 
+ATOM   3319 C CA    . VAL C 3 248 ? 78.728  31.897 131.140 1.00 50.86  ? ? ? ? ? ? 242 VAL A CA    1 
+ATOM   3320 C C     . VAL C 3 248 ? 78.137  32.322 132.484 1.00 50.65  ? ? ? ? ? ? 242 VAL A C     1 
+ATOM   3321 O O     . VAL C 3 248 ? 77.977  33.511 132.765 1.00 46.77  ? ? ? ? ? ? 242 VAL A O     1 
+ATOM   3322 C CB    . VAL C 3 248 ? 80.147  32.508 130.968 1.00 55.06  ? ? ? ? ? ? 242 VAL A CB    1 
+ATOM   3323 C CG1   . VAL C 3 248 ? 81.051  32.131 132.133 1.00 54.34  ? ? ? ? ? ? 242 VAL A CG1   1 
+ATOM   3324 C CG2   . VAL C 3 248 ? 80.773  32.058 129.660 1.00 55.08  ? ? ? ? ? ? 242 VAL A CG2   1 
+ATOM   3325 N N     . ARG C 3 249 ? 77.787  31.336 133.297 1.00 47.09  ? ? ? ? ? ? 243 ARG A N     1 
+ATOM   3326 C CA    . ARG C 3 249 ? 77.171  31.585 134.587 1.00 46.67  ? ? ? ? ? ? 243 ARG A CA    1 
+ATOM   3327 C C     . ARG C 3 249 ? 78.091  32.209 135.617 1.00 52.79  ? ? ? ? ? ? 243 ARG A C     1 
+ATOM   3328 O O     . ARG C 3 249 ? 79.263  32.439 135.345 1.00 55.00  ? ? ? ? ? ? 243 ARG A O     1 
+ATOM   3329 C CB    . ARG C 3 249 ? 76.566  30.299 135.122 1.00 45.41  ? ? ? ? ? ? 243 ARG A CB    1 
+ATOM   3330 C CG    . ARG C 3 249 ? 75.132  30.150 134.686 1.00 55.86  ? ? ? ? ? ? 243 ARG A CG    1 
+ATOM   3331 C CD    . ARG C 3 249 ? 74.873  28.846 133.966 1.00 66.06  ? ? ? ? ? ? 243 ARG A CD    1 
+ATOM   3332 N NE    . ARG C 3 249 ? 73.481  28.810 133.545 1.00 61.80  ? ? ? ? ? ? 243 ARG A NE    1 
+ATOM   3333 C CZ    . ARG C 3 249 ? 73.044  28.285 132.408 1.00 77.93  ? ? ? ? ? ? 243 ARG A CZ    1 
+ATOM   3334 N NH1   . ARG C 3 249 ? 73.876  27.721 131.542 1.00 77.83  ? ? ? ? ? ? 243 ARG A NH1   1 
+ATOM   3335 N NH2   . ARG C 3 249 ? 71.747  28.318 132.150 1.00 68.67  ? ? ? ? ? ? 243 ARG A NH2   1 
+ATOM   3336 N N     . LYS C 3 250 ? 77.542  32.504 136.789 1.00 49.29  ? ? ? ? ? ? 244 LYS A N     1 
+ATOM   3337 C CA    . LYS C 3 250 ? 78.291  33.136 137.876 1.00 49.17  ? ? ? ? ? ? 244 LYS A CA    1 
+ATOM   3338 C C     . LYS C 3 250 ? 79.509  32.346 138.360 1.00 48.50  ? ? ? ? ? ? 244 LYS A C     1 
+ATOM   3339 O O     . LYS C 3 250 ? 80.457  32.925 138.880 1.00 43.75  ? ? ? ? ? ? 244 LYS A O     1 
+ATOM   3340 C CB    . LYS C 3 250 ? 77.362  33.464 139.056 1.00 53.22  ? ? ? ? ? ? 244 LYS A CB    1 
+ATOM   3341 C CG    . LYS C 3 250 ? 76.532  32.273 139.548 1.00 70.45  ? ? ? ? ? ? 244 LYS A CG    1 
+ATOM   3342 C CD    . LYS C 3 250 ? 75.399  32.667 140.491 1.00 61.18  ? ? ? ? ? ? 244 LYS A CD    1 
+ATOM   3343 C CE    . LYS C 3 250 ? 75.884  33.653 141.530 1.00 47.16  ? ? ? ? ? ? 244 LYS A CE    1 
+ATOM   3344 N NZ    . LYS C 3 250 ? 74.786  34.110 142.413 1.00 48.03  ? ? ? ? ? ? 244 LYS A NZ    1 
+ATOM   3345 N N     . ASN C 3 251 ? 79.479  31.027 138.196 1.00 46.88  ? ? ? ? ? ? 245 ASN A N     1 
+ATOM   3346 C CA    . ASN C 3 251 ? 80.588  30.180 138.623 1.00 47.83  ? ? ? ? ? ? 245 ASN A CA    1 
+ATOM   3347 C C     . ASN C 3 251 ? 81.674  30.207 137.566 1.00 60.35  ? ? ? ? ? ? 245 ASN A C     1 
+ATOM   3348 O O     . ASN C 3 251 ? 82.706  29.561 137.713 1.00 65.59  ? ? ? ? ? ? 245 ASN A O     1 
+ATOM   3349 C CB    . ASN C 3 251 ? 80.121  28.746 138.801 1.00 43.64  ? ? ? ? ? ? 245 ASN A CB    1 
+ATOM   3350 C CG    . ASN C 3 251 ? 79.492  28.192 137.551 1.00 72.47  ? ? ? ? ? ? 245 ASN A CG    1 
+ATOM   3351 O OD1   . ASN C 3 251 ? 79.099  27.034 137.521 1.00 68.54  ? ? ? ? ? ? 245 ASN A OD1   1 
+ATOM   3352 N ND2   . ASN C 3 251 ? 79.389  29.015 136.514 1.00 62.32  ? ? ? ? ? ? 245 ASN A ND2   1 
+ATOM   3353 N N     . GLY C 3 252 ? 81.411  30.899 136.467 1.00 57.08  ? ? ? ? ? ? 246 GLY A N     1 
+ATOM   3354 C CA    . GLY C 3 252 ? 82.408  30.987 135.417 1.00 55.75  ? ? ? ? ? ? 246 GLY A CA    1 
+ATOM   3355 C C     . GLY C 3 252 ? 82.398  29.733 134.569 1.00 59.48  ? ? ? ? ? ? 246 GLY A C     1 
+ATOM   3356 O O     . GLY C 3 252 ? 83.364  29.445 133.869 1.00 61.11  ? ? ? ? ? ? 246 GLY A O     1 
+ATOM   3357 N N     . VAL C 3 253 ? 81.301  28.989 134.628 1.00 57.07  ? ? ? ? ? ? 247 VAL A N     1 
+ATOM   3358 C CA    . VAL C 3 253 ? 81.184  27.791 133.813 1.00 58.97  ? ? ? ? ? ? 247 VAL A CA    1 
+ATOM   3359 C C     . VAL C 3 253 ? 80.363  28.064 132.550 1.00 70.42  ? ? ? ? ? ? 247 VAL A C     1 
+ATOM   3360 O O     . VAL C 3 253 ? 79.340  28.749 132.590 1.00 69.75  ? ? ? ? ? ? 247 VAL A O     1 
+ATOM   3361 C CB    . VAL C 3 253 ? 80.574  26.615 134.588 1.00 61.78  ? ? ? ? ? ? 247 VAL A CB    1 
+ATOM   3362 C CG1   . VAL C 3 253 ? 80.151  25.512 133.623 1.00 61.08  ? ? ? ? ? ? 247 VAL A CG1   1 
+ATOM   3363 C CG2   . VAL C 3 253 ? 81.569  26.085 135.609 1.00 61.44  ? ? ? ? ? ? 247 VAL A CG2   1 
+ATOM   3364 N N     . ALA C 3 254 ? 80.819  27.512 131.431 1.00 72.00  ? ? ? ? ? ? 248 ALA A N     1 
+ATOM   3365 C CA    . ALA C 3 254 ? 80.159  27.695 130.142 1.00 73.53  ? ? ? ? ? ? 248 ALA A CA    1 
+ATOM   3366 C C     . ALA C 3 254 ? 79.025  26.709 129.865 1.00 80.65  ? ? ? ? ? ? 248 ALA A C     1 
+ATOM   3367 O O     . ALA C 3 254 ? 78.934  25.654 130.496 1.00 83.95  ? ? ? ? ? ? 248 ALA A O     1 
+ATOM   3368 C CB    . ALA C 3 254 ? 81.181  27.666 129.018 1.00 74.63  ? ? ? ? ? ? 248 ALA A CB    1 
+ATOM   3369 N N     . ALA C 3 255 ? 78.164  27.061 128.913 1.00 73.85  ? ? ? ? ? ? 249 ALA A N     1 
+ATOM   3370 C CA    . ALA C 3 255 ? 77.031  26.214 128.555 1.00 71.90  ? ? ? ? ? ? 249 ALA A CA    1 
+ATOM   3371 C C     . ALA C 3 255 ? 76.664  26.357 127.083 1.00 72.46  ? ? ? ? ? ? 249 ALA A C     1 
+ATOM   3372 O O     . ALA C 3 255 ? 75.830  27.184 126.706 1.00 71.49  ? ? ? ? ? ? 249 ALA A O     1 
+ATOM   3373 C CB    . ALA C 3 255 ? 75.834  26.517 129.452 1.00 72.50  ? ? ? ? ? ? 249 ALA A CB    1 
+ATOM   3374 N N     . PRO C 3 256 ? 77.311  25.544 126.257 1.00 66.15  ? ? ? ? ? ? 250 PRO A N     1 
+ATOM   3375 C CA    . PRO C 3 256 ? 77.091  25.569 124.819 1.00 64.36  ? ? ? ? ? ? 250 PRO A CA    1 
+ATOM   3376 C C     . PRO C 3 256 ? 75.628  25.330 124.452 1.00 68.10  ? ? ? ? ? ? 250 PRO A C     1 
+ATOM   3377 O O     . PRO C 3 256 ? 74.796  25.072 125.321 1.00 71.25  ? ? ? ? ? ? 250 PRO A O     1 
+ATOM   3378 C CB    . PRO C 3 256 ? 78.001  24.447 124.323 1.00 65.92  ? ? ? ? ? ? 250 PRO A CB    1 
+ATOM   3379 C CG    . PRO C 3 256 ? 79.147  24.434 125.319 1.00 70.43  ? ? ? ? ? ? 250 PRO A CG    1 
+ATOM   3380 C CD    . PRO C 3 256 ? 78.683  25.117 126.585 1.00 66.08  ? ? ? ? ? ? 250 PRO A CD    1 
+ATOM   3381 N N     . SER C 3 257 ? 75.307  25.433 123.169 1.00 61.28  ? ? ? ? ? ? 251 SER A N     1 
+ATOM   3382 C CA    . SER C 3 257 ? 73.933  25.234 122.736 1.00 61.31  ? ? ? ? ? ? 251 SER A CA    1 
+ATOM   3383 C C     . SER C 3 257 ? 73.794  25.283 121.211 1.00 73.59  ? ? ? ? ? ? 251 SER A C     1 
+ATOM   3384 O O     . SER C 3 257 ? 74.226  26.239 120.570 1.00 74.65  ? ? ? ? ? ? 251 SER A O     1 
+ATOM   3385 C CB    . SER C 3 257 ? 73.035  26.297 123.381 1.00 61.92  ? ? ? ? ? ? 251 SER A CB    1 
+ATOM   3386 O OG    . SER C 3 257 ? 71.747  25.790 123.701 1.00 69.35  ? ? ? ? ? ? 251 SER A OG    1 
+ATOM   3387 N N     . ALA C 3 258 ? 73.185  24.263 120.618 1.00 72.14  ? ? ? ? ? ? 252 ALA A N     1 
+ATOM   3388 C CA    . ALA C 3 258 ? 72.990  24.297 119.178 1.00 71.65  ? ? ? ? ? ? 252 ALA A CA    1 
+ATOM   3389 C C     . ALA C 3 258 ? 71.566  24.812 118.997 1.00 75.23  ? ? ? ? ? ? 252 ALA A C     1 
+ATOM   3390 O O     . ALA C 3 258 ? 71.047  24.922 117.887 1.00 77.47  ? ? ? ? ? ? 252 ALA A O     1 
+ATOM   3391 C CB    . ALA C 3 258 ? 73.132  22.890 118.596 1.00 72.34  ? ? ? ? ? ? 252 ALA A CB    1 
+ATOM   3392 N N     . THR C 3 259 ? 70.937  25.145 120.118 1.00 69.24  ? ? ? ? ? ? 253 THR A N     1 
+ATOM   3393 C CA    . THR C 3 259 ? 69.551  25.571 120.090 1.00 68.83  ? ? ? ? ? ? 253 THR A CA    1 
+ATOM   3394 C C     . THR C 3 259 ? 69.220  26.985 120.551 1.00 71.54  ? ? ? ? ? ? 253 THR A C     1 
+ATOM   3395 O O     . THR C 3 259 ? 68.187  27.546 120.172 1.00 69.59  ? ? ? ? ? ? 253 THR A O     1 
+ATOM   3396 C CB    . THR C 3 259 ? 68.692  24.557 120.851 1.00 86.64  ? ? ? ? ? ? 253 THR A CB    1 
+ATOM   3397 O OG1   . THR C 3 259 ? 68.102  23.652 119.914 1.00 92.25  ? ? ? ? ? ? 253 THR A OG1   1 
+ATOM   3398 C CG2   . THR C 3 259 ? 67.596  25.248 121.648 1.00 90.43  ? ? ? ? ? ? 253 THR A CG2   1 
+ATOM   3399 N N     . SER C 3 260 ? 70.083  27.556 121.382 1.00 66.56  ? ? ? ? ? ? 254 SER A N     1 
+ATOM   3400 C CA    . SER C 3 260 ? 69.857  28.900 121.879 1.00 63.42  ? ? ? ? ? ? 254 SER A CA    1 
+ATOM   3401 C C     . SER C 3 260 ? 71.078  29.756 121.588 1.00 65.48  ? ? ? ? ? ? 254 SER A C     1 
+ATOM   3402 O O     . SER C 3 260 ? 72.215  29.291 121.679 1.00 64.33  ? ? ? ? ? ? 254 SER A O     1 
+ATOM   3403 C CB    . SER C 3 260 ? 69.599  28.857 123.381 1.00 65.39  ? ? ? ? ? ? 254 SER A CB    1 
+ATOM   3404 O OG    . SER C 3 260 ? 68.873  29.995 123.779 1.00 82.18  ? ? ? ? ? ? 254 SER A OG    1 
+ATOM   3405 N N     . GLN C 3 261 ? 70.841  31.004 121.205 1.00 60.26  ? ? ? ? ? ? 255 GLN A N     1 
+ATOM   3406 C CA    . GLN C 3 261 ? 71.967  31.872 120.946 1.00 60.26  ? ? ? ? ? ? 255 GLN A CA    1 
+ATOM   3407 C C     . GLN C 3 261 ? 71.938  32.958 122.007 1.00 63.49  ? ? ? ? ? ? 255 GLN A C     1 
+ATOM   3408 O O     . GLN C 3 261 ? 70.910  33.187 122.656 1.00 63.02  ? ? ? ? ? ? 255 GLN A O     1 
+ATOM   3409 C CB    . GLN C 3 261 ? 71.987  32.426 119.516 1.00 61.86  ? ? ? ? ? ? 255 GLN A CB    1 
+ATOM   3410 C CG    . GLN C 3 261 ? 70.635  32.750 118.916 1.00 64.25  ? ? ? ? ? ? 255 GLN A CG    1 
+ATOM   3411 C CD    . GLN C 3 261 ? 70.813  33.396 117.566 1.00 66.81  ? ? ? ? ? ? 255 GLN A CD    1 
+ATOM   3412 O OE1   . GLN C 3 261 ? 71.001  32.710 116.582 1.00 62.47  ? ? ? ? ? ? 255 GLN A OE1   1 
+ATOM   3413 N NE2   . GLN C 3 261 ? 70.703  34.721 117.543 1.00 59.05  ? ? ? ? ? ? 255 GLN A NE2   1 
+ATOM   3414 N N     . LEU C 3 262 ? 73.085  33.591 122.217 1.00 55.98  ? ? ? ? ? ? 256 LEU A N     1 
+ATOM   3415 C CA    . LEU C 3 262 ? 73.148  34.650 123.196 1.00 53.13  ? ? ? ? ? ? 256 LEU A CA    1 
+ATOM   3416 C C     . LEU C 3 262 ? 72.214  35.727 122.663 1.00 55.57  ? ? ? ? ? ? 256 LEU A C     1 
+ATOM   3417 O O     . LEU C 3 262 ? 72.162  35.974 121.457 1.00 54.79  ? ? ? ? ? ? 256 LEU A O     1 
+ATOM   3418 C CB    . LEU C 3 262 ? 74.574  35.179 123.293 1.00 52.44  ? ? ? ? ? ? 256 LEU A CB    1 
+ATOM   3419 C CG    . LEU C 3 262 ? 75.151  35.128 124.704 1.00 55.64  ? ? ? ? ? ? 256 LEU A CG    1 
+ATOM   3420 C CD1   . LEU C 3 262 ? 76.363  36.042 124.790 1.00 55.62  ? ? ? ? ? ? 256 LEU A CD1   1 
+ATOM   3421 C CD2   . LEU C 3 262 ? 74.085  35.557 125.696 1.00 56.49  ? ? ? ? ? ? 256 LEU A CD2   1 
+ATOM   3422 N N     . SER C 3 263 ? 71.467  36.350 123.563 1.00 51.68  ? ? ? ? ? ? 257 SER A N     1 
+ATOM   3423 C CA    . SER C 3 263 ? 70.547  37.419 123.206 1.00 48.87  ? ? ? ? ? ? 257 SER A CA    1 
+ATOM   3424 C C     . SER C 3 263 ? 71.379  38.594 122.684 1.00 52.69  ? ? ? ? ? ? 257 SER A C     1 
+ATOM   3425 O O     . SER C 3 263 ? 72.568  38.714 123.003 1.00 51.49  ? ? ? ? ? ? 257 SER A O     1 
+ATOM   3426 C CB    . SER C 3 263 ? 69.815  37.869 124.465 1.00 45.99  ? ? ? ? ? ? 257 SER A CB    1 
+ATOM   3427 O OG    . SER C 3 263 ? 70.651  38.738 125.202 1.00 41.61  ? ? ? ? ? ? 257 SER A OG    1 
+ATOM   3428 N N     . THR C 3 264 ? 70.760  39.454 121.878 1.00 49.35  ? ? ? ? ? ? 258 THR A N     1 
+ATOM   3429 C CA    . THR C 3 264 ? 71.482  40.604 121.343 1.00 49.62  ? ? ? ? ? ? 258 THR A CA    1 
+ATOM   3430 C C     . THR C 3 264 ? 71.666  41.558 122.518 1.00 50.52  ? ? ? ? ? ? 258 THR A C     1 
+ATOM   3431 O O     . THR C 3 264 ? 72.627  42.332 122.569 1.00 48.54  ? ? ? ? ? ? 258 THR A O     1 
+ATOM   3432 C CB    . THR C 3 264 ? 70.718  41.277 120.172 1.00 50.40  ? ? ? ? ? ? 258 THR A CB    1 
+ATOM   3433 O OG1   . THR C 3 264 ? 69.311  41.200 120.430 1.00 53.83  ? ? ? ? ? ? 258 THR A OG1   1 
+ATOM   3434 C CG2   . THR C 3 264 ? 71.022  40.584 118.840 1.00 36.78  ? ? ? ? ? ? 258 THR A CG2   1 
+ATOM   3435 N N     . ARG C 3 265 ? 70.736  41.461 123.467 1.00 46.34  ? ? ? ? ? ? 259 ARG A N     1 
+ATOM   3436 C CA    . ARG C 3 265 ? 70.789  42.248 124.703 1.00 44.99  ? ? ? ? ? ? 259 ARG A CA    1 
+ATOM   3437 C C     . ARG C 3 265 ? 72.096  41.929 125.450 1.00 47.25  ? ? ? ? ? ? 259 ARG A C     1 
+ATOM   3438 O O     . ARG C 3 265 ? 72.816  42.840 125.884 1.00 46.61  ? ? ? ? ? ? 259 ARG A O     1 
+ATOM   3439 C CB    . ARG C 3 265 ? 69.583  41.902 125.588 1.00 41.96  ? ? ? ? ? ? 259 ARG A CB    1 
+ATOM   3440 C CG    . ARG C 3 265 ? 69.328  42.899 126.707 1.00 39.63  ? ? ? ? ? ? 259 ARG A CG    1 
+ATOM   3441 C CD    . ARG C 3 265 ? 69.098  44.272 126.139 1.00 39.46  ? ? ? ? ? ? 259 ARG A CD    1 
+ATOM   3442 N NE    . ARG C 3 265 ? 68.991  45.291 127.177 1.00 40.24  ? ? ? ? ? ? 259 ARG A NE    1 
+ATOM   3443 C CZ    . ARG C 3 265 ? 70.023  46.005 127.610 1.00 60.52  ? ? ? ? ? ? 259 ARG A CZ    1 
+ATOM   3444 N NH1   . ARG C 3 265 ? 71.232  45.799 127.097 1.00 49.93  ? ? ? ? ? ? 259 ARG A NH1   1 
+ATOM   3445 N NH2   . ARG C 3 265 ? 69.847  46.913 128.561 1.00 57.50  ? ? ? ? ? ? 259 ARG A NH2   1 
+ATOM   3446 N N     . ALA C 3 266 ? 72.409  40.640 125.556 1.00 43.32  ? ? ? ? ? ? 260 ALA A N     1 
+ATOM   3447 C CA    . ALA C 3 266 ? 73.615  40.140 126.224 1.00 42.89  ? ? ? ? ? ? 260 ALA A CA    1 
+ATOM   3448 C C     . ALA C 3 266 ? 74.915  40.655 125.572 1.00 52.25  ? ? ? ? ? ? 260 ALA A C     1 
+ATOM   3449 O O     . ALA C 3 266 ? 75.922  40.983 126.255 1.00 51.66  ? ? ? ? ? ? 260 ALA A O     1 
+ATOM   3450 C CB    . ALA C 3 266 ? 73.581  38.616 126.189 1.00 42.10  ? ? ? ? ? ? 260 ALA A CB    1 
+ATOM   3451 N N     . LEU C 3 267 ? 74.862  40.786 124.255 1.00 50.36  ? ? ? ? ? ? 261 LEU A N     1 
+ATOM   3452 C CA    . LEU C 3 267 ? 76.000  41.264 123.446 1.00 48.41  ? ? ? ? ? ? 261 LEU A CA    1 
+ATOM   3453 C C     . LEU C 3 267 ? 76.099  42.771 123.625 1.00 48.61  ? ? ? ? ? ? 261 LEU A C     1 
+ATOM   3454 O O     . LEU C 3 267 ? 77.189  43.341 123.589 1.00 47.45  ? ? ? ? ? ? 261 LEU A O     1 
+ATOM   3455 C CB    . LEU C 3 267 ? 75.801  40.888 121.973 1.00 48.25  ? ? ? ? ? ? 261 LEU A CB    1 
+ATOM   3456 C CG    . LEU C 3 267 ? 75.680  39.387 121.696 1.00 53.49  ? ? ? ? ? ? 261 LEU A CG    1 
+ATOM   3457 C CD1   . LEU C 3 267 ? 74.987  39.140 120.359 1.00 52.70  ? ? ? ? ? ? 261 LEU A CD1   1 
+ATOM   3458 C CD2   . LEU C 3 267 ? 77.055  38.713 121.742 1.00 58.02  ? ? ? ? ? ? 261 LEU A CD2   1 
+ATOM   3459 N N     . GLU C 3 268 ? 74.957  43.407 123.823 1.00 43.58  ? ? ? ? ? ? 262 GLU A N     1 
+ATOM   3460 C CA    . GLU C 3 268 ? 74.975  44.835 124.063 1.00 45.24  ? ? ? ? ? ? 262 GLU A CA    1 
+ATOM   3461 C C     . GLU C 3 268 ? 75.578  44.996 125.461 1.00 50.51  ? ? ? ? ? ? 262 GLU A C     1 
+ATOM   3462 O O     . GLU C 3 268 ? 76.308  45.956 125.728 1.00 48.22  ? ? ? ? ? ? 262 GLU A O     1 
+ATOM   3463 C CB    . GLU C 3 268 ? 73.549  45.388 124.018 1.00 47.64  ? ? ? ? ? ? 262 GLU A CB    1 
+ATOM   3464 C CG    . GLU C 3 268 ? 72.822  45.132 122.702 1.00 64.46  ? ? ? ? ? ? 262 GLU A CG    1 
+ATOM   3465 C CD    . GLU C 3 268 ? 71.488  45.851 122.630 1.00 76.22  ? ? ? ? ? ? 262 GLU A CD    1 
+ATOM   3466 O OE1   . GLU C 3 268 ? 70.622  45.609 123.496 1.00 72.83  ? ? ? ? ? ? 262 GLU A OE1   1 
+ATOM   3467 O OE2   . GLU C 3 268 ? 71.302  46.676 121.712 1.00 64.10  ? ? ? ? ? ? 262 GLU A OE2   1 
+ATOM   3468 N N     . GLY C 3 269 ? 75.273  44.039 126.339 1.00 47.53  ? ? ? ? ? ? 263 GLY A N     1 
+ATOM   3469 C CA    . GLY C 3 269 ? 75.780  44.015 127.712 1.00 47.05  ? ? ? ? ? ? 263 GLY A CA    1 
+ATOM   3470 C C     . GLY C 3 269 ? 77.305  43.972 127.762 1.00 47.04  ? ? ? ? ? ? 263 GLY A C     1 
+ATOM   3471 O O     . GLY C 3 269 ? 77.934  44.803 128.417 1.00 47.81  ? ? ? ? ? ? 263 GLY A O     1 
+ATOM   3472 N N     . ILE C 3 270 ? 77.890  43.012 127.051 1.00 41.67  ? ? ? ? ? ? 264 ILE A N     1 
+ATOM   3473 C CA    . ILE C 3 270 ? 79.340  42.897 127.002 1.00 42.69  ? ? ? ? ? ? 264 ILE A CA    1 
+ATOM   3474 C C     . ILE C 3 270 ? 79.974  44.218 126.586 1.00 52.52  ? ? ? ? ? ? 264 ILE A C     1 
+ATOM   3475 O O     . ILE C 3 270 ? 81.093  44.519 126.996 1.00 56.87  ? ? ? ? ? ? 264 ILE A O     1 
+ATOM   3476 C CB    . ILE C 3 270 ? 79.826  41.811 126.015 1.00 45.22  ? ? ? ? ? ? 264 ILE A CB    1 
+ATOM   3477 C CG1   . ILE C 3 270 ? 79.165  40.453 126.299 1.00 45.02  ? ? ? ? ? ? 264 ILE A CG1   1 
+ATOM   3478 C CG2   . ILE C 3 270 ? 81.349  41.734 126.015 1.00 43.74  ? ? ? ? ? ? 264 ILE A CG2   1 
+ATOM   3479 C CD1   . ILE C 3 270 ? 79.336  39.410 125.196 1.00 34.69  ? ? ? ? ? ? 264 ILE A CD1   1 
+ATOM   3480 N N     . PHE C 3 271 ? 79.280  45.011 125.775 1.00 48.55  ? ? ? ? ? ? 265 PHE A N     1 
+ATOM   3481 C CA    . PHE C 3 271 ? 79.838  46.289 125.350 1.00 48.88  ? ? ? ? ? ? 265 PHE A CA    1 
+ATOM   3482 C C     . PHE C 3 271 ? 79.738  47.307 126.465 1.00 51.50  ? ? ? ? ? ? 265 PHE A C     1 
+ATOM   3483 O O     . PHE C 3 271 ? 80.668  48.075 126.696 1.00 52.94  ? ? ? ? ? ? 265 PHE A O     1 
+ATOM   3484 C CB    . PHE C 3 271 ? 79.147  46.832 124.096 1.00 51.11  ? ? ? ? ? ? 265 PHE A CB    1 
+ATOM   3485 C CG    . PHE C 3 271 ? 79.937  46.629 122.831 1.00 52.84  ? ? ? ? ? ? 265 PHE A CG    1 
+ATOM   3486 C CD1   . PHE C 3 271 ? 79.448  45.814 121.825 1.00 55.03  ? ? ? ? ? ? 265 PHE A CD1   1 
+ATOM   3487 C CD2   . PHE C 3 271 ? 81.170  47.239 122.656 1.00 55.99  ? ? ? ? ? ? 265 PHE A CD2   1 
+ATOM   3488 C CE1   . PHE C 3 271 ? 80.169  45.608 120.668 1.00 57.55  ? ? ? ? ? ? 265 PHE A CE1   1 
+ATOM   3489 C CE2   . PHE C 3 271 ? 81.900  47.034 121.502 1.00 57.36  ? ? ? ? ? ? 265 PHE A CE2   1 
+ATOM   3490 C CZ    . PHE C 3 271 ? 81.401  46.211 120.509 1.00 55.93  ? ? ? ? ? ? 265 PHE A CZ    1 
+ATOM   3491 N N     . GLU C 3 272 ? 78.591  47.313 127.133 1.00 46.46  ? ? ? ? ? ? 266 GLU A N     1 
+ATOM   3492 C CA    . GLU C 3 272 ? 78.338  48.246 128.220 1.00 46.56  ? ? ? ? ? ? 266 GLU A CA    1 
+ATOM   3493 C C     . GLU C 3 272 ? 79.220  47.913 129.414 1.00 51.34  ? ? ? ? ? ? 266 GLU A C     1 
+ATOM   3494 O O     . GLU C 3 272 ? 79.817  48.804 130.021 1.00 51.72  ? ? ? ? ? ? 266 GLU A O     1 
+ATOM   3495 C CB    . GLU C 3 272 ? 76.869  48.214 128.650 1.00 47.62  ? ? ? ? ? ? 266 GLU A CB    1 
+ATOM   3496 C CG    . GLU C 3 272 ? 76.500  49.387 129.547 1.00 60.71  ? ? ? ? ? ? 266 GLU A CG    1 
+ATOM   3497 C CD    . GLU C 3 272 ? 75.441  49.037 130.575 1.00 96.48  ? ? ? ? ? ? 266 GLU A CD    1 
+ATOM   3498 O OE1   . GLU C 3 272 ? 74.344  48.603 130.175 1.00 100.00 ? ? ? ? ? ? 266 GLU A OE1   1 
+ATOM   3499 O OE2   . GLU C 3 272 ? 75.704  49.188 131.786 1.00 100.00 ? ? ? ? ? ? 266 GLU A OE2   1 
+ATOM   3500 N N     . ALA C 3 273 ? 79.269  46.625 129.747 1.00 45.60  ? ? ? ? ? ? 267 ALA A N     1 
+ATOM   3501 C CA    . ALA C 3 273 ? 80.081  46.122 130.852 1.00 44.38  ? ? ? ? ? ? 267 ALA A CA    1 
+ATOM   3502 C C     . ALA C 3 273 ? 81.521  46.555 130.617 1.00 50.10  ? ? ? ? ? ? 267 ALA A C     1 
+ATOM   3503 O O     . ALA C 3 273 ? 82.164  47.188 131.457 1.00 49.15  ? ? ? ? ? ? 267 ALA A O     1 
+ATOM   3504 C CB    . ALA C 3 273 ? 80.004  44.604 130.892 1.00 44.11  ? ? ? ? ? ? 267 ALA A CB    1 
+ATOM   3505 N N     . THR C 3 274 ? 82.015  46.201 129.444 1.00 49.46  ? ? ? ? ? ? 268 THR A N     1 
+ATOM   3506 C CA    . THR C 3 274 ? 83.374  46.523 129.064 1.00 49.86  ? ? ? ? ? ? 268 THR A CA    1 
+ATOM   3507 C C     . THR C 3 274 ? 83.745  47.995 129.195 1.00 55.19  ? ? ? ? ? ? 268 THR A C     1 
+ATOM   3508 O O     . THR C 3 274 ? 84.871  48.320 129.560 1.00 58.19  ? ? ? ? ? ? 268 THR A O     1 
+ATOM   3509 C CB    . THR C 3 274 ? 83.687  45.999 127.660 1.00 58.99  ? ? ? ? ? ? 268 THR A CB    1 
+ATOM   3510 O OG1   . THR C 3 274 ? 83.892  44.578 127.715 1.00 58.92  ? ? ? ? ? ? 268 THR A OG1   1 
+ATOM   3511 C CG2   . THR C 3 274 ? 84.926  46.681 127.112 1.00 59.76  ? ? ? ? ? ? 268 THR A CG2   1 
+ATOM   3512 N N     . HIS C 3 275 ? 82.814  48.897 128.915 1.00 51.28  ? ? ? ? ? ? 269 HIS A N     1 
+ATOM   3513 C CA    . HIS C 3 275 ? 83.099  50.330 129.003 1.00 49.65  ? ? ? ? ? ? 269 HIS A CA    1 
+ATOM   3514 C C     . HIS C 3 275 ? 83.058  50.792 130.448 1.00 54.71  ? ? ? ? ? ? 269 HIS A C     1 
+ATOM   3515 O O     . HIS C 3 275 ? 83.604  51.839 130.795 1.00 53.48  ? ? ? ? ? ? 269 HIS A O     1 
+ATOM   3516 C CB    . HIS C 3 275 ? 82.002  51.108 128.250 1.00 48.48  ? ? ? ? ? ? 269 HIS A CB    1 
+ATOM   3517 C CG    . HIS C 3 275 ? 82.307  52.555 128.032 1.00 48.94  ? ? ? ? ? ? 269 HIS A CG    1 
+ATOM   3518 N ND1   . HIS C 3 275 ? 81.724  53.564 128.770 1.00 48.71  ? ? ? ? ? ? 269 HIS A ND1   1 
+ATOM   3519 C CD2   . HIS C 3 275 ? 83.089  53.164 127.110 1.00 50.00  ? ? ? ? ? ? 269 HIS A CD2   1 
+ATOM   3520 C CE1   . HIS C 3 275 ? 82.149  54.732 128.325 1.00 48.35  ? ? ? ? ? ? 269 HIS A CE1   1 
+ATOM   3521 N NE2   . HIS C 3 275 ? 82.981  54.517 127.317 1.00 49.18  ? ? ? ? ? ? 269 HIS A NE2   1 
+ATOM   3522 N N     . ARG C 3 276 ? 82.342  50.039 131.272 1.00 53.84  ? ? ? ? ? ? 270 ARG A N     1 
+ATOM   3523 C CA    . ARG C 3 276 ? 82.211  50.405 132.672 1.00 58.09  ? ? ? ? ? ? 270 ARG A CA    1 
+ATOM   3524 C C     . ARG C 3 276 ? 83.534  50.068 133.360 1.00 68.16  ? ? ? ? ? ? 270 ARG A C     1 
+ATOM   3525 O O     . ARG C 3 276 ? 84.068  50.861 134.145 1.00 68.26  ? ? ? ? ? ? 270 ARG A O     1 
+ATOM   3526 C CB    . ARG C 3 276 ? 81.005  49.690 133.298 1.00 60.35  ? ? ? ? ? ? 270 ARG A CB    1 
+ATOM   3527 C CG    . ARG C 3 276 ? 81.254  49.027 134.644 1.00 68.95  ? ? ? ? ? ? 270 ARG A CG    1 
+ATOM   3528 C CD    . ARG C 3 276 ? 80.277  49.534 135.689 1.00 81.70  ? ? ? ? ? ? 270 ARG A CD    1 
+ATOM   3529 N NE    . ARG C 3 276 ? 80.141  48.619 136.820 1.00 98.79  ? ? ? ? ? ? 270 ARG A NE    1 
+ATOM   3530 C CZ    . ARG C 3 276 ? 80.524  48.895 138.063 1.00 100.00 ? ? ? ? ? ? 270 ARG A CZ    1 
+ATOM   3531 N NH1   . ARG C 3 276 ? 81.085  50.062 138.347 1.00 100.00 ? ? ? ? ? ? 270 ARG A NH1   1 
+ATOM   3532 N NH2   . ARG C 3 276 ? 80.353  48.000 139.025 1.00 82.58  ? ? ? ? ? ? 270 ARG A NH2   1 
+ATOM   3533 N N     . LEU C 3 277 ? 84.093  48.922 132.989 1.00 64.79  ? ? ? ? ? ? 271 LEU A N     1 
+ATOM   3534 C CA    . LEU C 3 277 ? 85.364  48.485 133.532 1.00 64.36  ? ? ? ? ? ? 271 LEU A CA    1 
+ATOM   3535 C C     . LEU C 3 277 ? 86.442  49.555 133.400 1.00 70.24  ? ? ? ? ? ? 271 LEU A C     1 
+ATOM   3536 O O     . LEU C 3 277 ? 87.315  49.679 134.258 1.00 73.34  ? ? ? ? ? ? 271 LEU A O     1 
+ATOM   3537 C CB    . LEU C 3 277 ? 85.828  47.234 132.798 1.00 63.86  ? ? ? ? ? ? 271 LEU A CB    1 
+ATOM   3538 C CG    . LEU C 3 277 ? 87.262  46.806 133.104 1.00 67.52  ? ? ? ? ? ? 271 LEU A CG    1 
+ATOM   3539 C CD1   . LEU C 3 277 ? 87.359  46.281 134.537 1.00 66.34  ? ? ? ? ? ? 271 LEU A CD1   1 
+ATOM   3540 C CD2   . LEU C 3 277 ? 87.712  45.762 132.087 1.00 67.60  ? ? ? ? ? ? 271 LEU A CD2   1 
+ATOM   3541 N N     . ILE C 3 278 ? 86.394  50.308 132.307 1.00 63.91  ? ? ? ? ? ? 272 ILE A N     1 
+ATOM   3542 C CA    . ILE C 3 278 ? 87.392  51.335 132.026 1.00 62.54  ? ? ? ? ? ? 272 ILE A CA    1 
+ATOM   3543 C C     . ILE C 3 278 ? 86.968  52.726 132.474 1.00 71.26  ? ? ? ? ? ? 272 ILE A C     1 
+ATOM   3544 O O     . ILE C 3 278 ? 87.784  53.517 132.948 1.00 73.80  ? ? ? ? ? ? 272 ILE A O     1 
+ATOM   3545 C CB    . ILE C 3 278 ? 87.714  51.386 130.506 1.00 62.38  ? ? ? ? ? ? 272 ILE A CB    1 
+ATOM   3546 C CG1   . ILE C 3 278 ? 88.471  50.132 130.060 1.00 61.64  ? ? ? ? ? ? 272 ILE A CG1   1 
+ATOM   3547 C CG2   . ILE C 3 278 ? 88.484  52.649 130.153 1.00 56.99  ? ? ? ? ? ? 272 ILE A CG2   1 
+ATOM   3548 C CD1   . ILE C 3 278 ? 89.104  50.266 128.686 1.00 58.78  ? ? ? ? ? ? 272 ILE A CD1   1 
+ATOM   3549 N N     . TYR C 3 279 ? 85.697  53.048 132.305 1.00 67.09  ? ? ? ? ? ? 273 TYR A N     1 
+ATOM   3550 C CA    . TYR C 3 279 ? 85.269  54.391 132.653 1.00 66.66  ? ? ? ? ? ? 273 TYR A CA    1 
+ATOM   3551 C C     . TYR C 3 279 ? 84.330  54.509 133.850 1.00 70.49  ? ? ? ? ? ? 273 TYR A C     1 
+ATOM   3552 O O     . TYR C 3 279 ? 84.232  55.579 134.450 1.00 69.78  ? ? ? ? ? ? 273 TYR A O     1 
+ATOM   3553 C CB    . TYR C 3 279 ? 84.753  55.120 131.402 1.00 67.63  ? ? ? ? ? ? 273 TYR A CB    1 
+ATOM   3554 C CG    . TYR C 3 279 ? 85.639  55.015 130.164 1.00 67.23  ? ? ? ? ? ? 273 TYR A CG    1 
+ATOM   3555 C CD1   . TYR C 3 279 ? 85.635  53.875 129.367 1.00 68.20  ? ? ? ? ? ? 273 TYR A CD1   1 
+ATOM   3556 C CD2   . TYR C 3 279 ? 86.461  56.071 129.781 1.00 67.86  ? ? ? ? ? ? 273 TYR A CD2   1 
+ATOM   3557 C CE1   . TYR C 3 279 ? 86.432  53.778 128.234 1.00 69.31  ? ? ? ? ? ? 273 TYR A CE1   1 
+ATOM   3558 C CE2   . TYR C 3 279 ? 87.260  55.983 128.642 1.00 69.43  ? ? ? ? ? ? 273 TYR A CE2   1 
+ATOM   3559 C CZ    . TYR C 3 279 ? 87.243  54.835 127.868 1.00 78.00  ? ? ? ? ? ? 273 TYR A CZ    1 
+ATOM   3560 O OH    . TYR C 3 279 ? 88.036  54.751 126.738 1.00 77.32  ? ? ? ? ? ? 273 TYR A OH    1 
+ATOM   3561 N N     . GLY C 3 280 ? 83.618  53.443 134.188 1.00 68.01  ? ? ? ? ? ? 274 GLY A N     1 
+ATOM   3562 C CA    . GLY C 3 280 ? 82.734  53.467 135.342 1.00 69.48  ? ? ? ? ? ? 274 GLY A CA    1 
+ATOM   3563 C C     . GLY C 3 280 ? 81.255  53.739 135.148 1.00 78.58  ? ? ? ? ? ? 274 GLY A C     1 
+ATOM   3564 O O     . GLY C 3 280 ? 80.684  53.753 134.055 1.00 78.43  ? ? ? ? ? ? 274 GLY A O     1 
+ATOM   3565 N N     . ALA C 3 281 ? 80.671  53.998 136.308 1.00 79.63  ? ? ? ? ? ? 275 ALA A N     1 
+ATOM   3566 C CA    . ALA C 3 281 ? 79.260  54.260 136.511 1.00 80.58  ? ? ? ? ? ? 275 ALA A CA    1 
+ATOM   3567 C C     . ALA C 3 281 ? 78.647  55.070 135.377 1.00 83.88  ? ? ? ? ? ? 275 ALA A C     1 
+ATOM   3568 O O     . ALA C 3 281 ? 79.225  56.060 134.917 1.00 80.37  ? ? ? ? ? ? 275 ALA A O     1 
+ATOM   3569 C CB    . ALA C 3 281 ? 79.045  54.956 137.872 1.00 82.42  ? ? ? ? ? ? 275 ALA A CB    1 
+ATOM   3570 N N     . LYS C 3 282 ? 77.482  54.628 134.915 1.00 85.92  ? ? ? ? ? ? 276 LYS A N     1 
+ATOM   3571 C CA    . LYS C 3 282 ? 76.692  55.269 133.849 1.00 87.56  ? ? ? ? ? ? 276 LYS A CA    1 
+ATOM   3572 C C     . LYS C 3 282 ? 76.864  56.776 134.016 1.00 91.52  ? ? ? ? ? ? 276 LYS A C     1 
+ATOM   3573 O O     . LYS C 3 282 ? 76.637  57.297 135.127 1.00 90.39  ? ? ? ? ? ? 276 LYS A O     1 
+ATOM   3574 C CB    . LYS C 3 282 ? 75.215  54.841 133.924 1.00 91.93  ? ? ? ? ? ? 276 LYS A CB    1 
+ATOM   3575 C CG    . LYS C 3 282 ? 74.440  55.106 132.646 1.00 100.00 ? ? ? ? ? ? 276 LYS A CG    1 
+ATOM   3576 C CD    . LYS C 3 282 ? 75.079  54.391 131.467 1.00 100.00 ? ? ? ? ? ? 276 LYS A CD    1 
+ATOM   3577 C CE    . LYS C 3 282 ? 74.397  54.769 130.162 1.00 96.25  ? ? ? ? ? ? 276 LYS A CE    1 
+ATOM   3578 N NZ    . LYS C 3 282 ? 73.874  53.568 129.440 1.00 100.00 ? ? ? ? ? ? 276 LYS A NZ    1 
+ATOM   3579 N N     . ASP C 3 283 ? 77.116  57.490 132.944 1.00 90.20  ? ? ? ? ? ? 277 ASP A N     1 
+ATOM   3580 C CA    . ASP C 3 283 ? 77.451  58.892 133.068 1.00 91.39  ? ? ? ? ? ? 277 ASP A CA    1 
+ATOM   3581 C C     . ASP C 3 283 ? 76.409  60.007 132.943 1.00 96.76  ? ? ? ? ? ? 277 ASP A C     1 
+ATOM   3582 O O     . ASP C 3 283 ? 75.412  60.111 133.669 1.00 96.47  ? ? ? ? ? ? 277 ASP A O     1 
+ATOM   3583 C CB    . ASP C 3 283 ? 78.589  59.089 132.067 1.00 93.80  ? ? ? ? ? ? 277 ASP A CB    1 
+ATOM   3584 C CG    . ASP C 3 283 ? 79.039  57.757 131.441 1.00 100.00 ? ? ? ? ? ? 277 ASP A CG    1 
+ATOM   3585 O OD1   . ASP C 3 283 ? 79.152  56.751 132.190 1.00 100.00 ? ? ? ? ? ? 277 ASP A OD1   1 
+ATOM   3586 O OD2   . ASP C 3 283 ? 79.262  57.711 130.205 1.00 100.00 ? ? ? ? ? ? 277 ASP A OD2   1 
+ATOM   3587 N N     . ASP C 3 284 ? 76.729  60.827 131.942 1.00 94.60  ? ? ? ? ? ? 278 ASP A N     1 
+ATOM   3588 C CA    . ASP C 3 284 ? 76.043  62.025 131.433 1.00 95.36  ? ? ? ? ? ? 278 ASP A CA    1 
+ATOM   3589 C C     . ASP C 3 284 ? 74.513  61.988 131.123 1.00 99.91  ? ? ? ? ? ? 278 ASP A C     1 
+ATOM   3590 O O     . ASP C 3 284 ? 74.160  62.099 129.953 1.00 99.49  ? ? ? ? ? ? 278 ASP A O     1 
+ATOM   3591 C CB    . ASP C 3 284 ? 76.708  62.432 130.083 1.00 97.64  ? ? ? ? ? ? 278 ASP A CB    1 
+ATOM   3592 C CG    . ASP C 3 284 ? 77.887  63.468 130.210 1.00 100.00 ? ? ? ? ? ? 278 ASP A CG    1 
+ATOM   3593 O OD1   . ASP C 3 284 ? 78.551  63.541 131.272 1.00 100.00 ? ? ? ? ? ? 278 ASP A OD1   1 
+ATOM   3594 O OD2   . ASP C 3 284 ? 78.155  64.182 129.197 1.00 100.00 ? ? ? ? ? ? 278 ASP A OD2   1 
+ATOM   3595 N N     . SER C 3 285 ? 73.641  61.736 132.125 1.00 96.12  ? ? ? ? ? ? 279 SER A N     1 
+ATOM   3596 C CA    . SER C 3 285 ? 72.156  61.841 132.089 1.00 95.63  ? ? ? ? ? ? 279 SER A CA    1 
+ATOM   3597 C C     . SER C 3 285 ? 70.975  60.879 132.021 1.00 100.00 ? ? ? ? ? ? 279 SER A C     1 
+ATOM   3598 O O     . SER C 3 285 ? 69.962  61.048 132.710 1.00 100.00 ? ? ? ? ? ? 279 SER A O     1 
+ATOM   3599 C CB    . SER C 3 285 ? 71.756  62.931 131.112 1.00 98.44  ? ? ? ? ? ? 279 SER A CB    1 
+ATOM   3600 O OG    . SER C 3 285 ? 70.702  63.757 131.594 1.00 100.00 ? ? ? ? ? ? 279 SER A OG    1 
+ATOM   3601 N N     . GLY C 3 286 ? 71.059  59.934 131.094 1.00 95.73  ? ? ? ? ? ? 280 GLY A N     1 
+ATOM   3602 C CA    . GLY C 3 286 ? 69.922  59.050 130.820 1.00 94.21  ? ? ? ? ? ? 280 GLY A CA    1 
+ATOM   3603 C C     . GLY C 3 286 ? 69.918  59.145 129.301 1.00 95.38  ? ? ? ? ? ? 280 GLY A C     1 
+ATOM   3604 O O     . GLY C 3 286 ? 69.036  58.600 128.648 1.00 95.70  ? ? ? ? ? ? 280 GLY A O     1 
+ATOM   3605 N N     . GLN C 3 287 ? 70.926  59.820 128.744 1.00 89.47  ? ? ? ? ? ? 281 GLN A N     1 
+ATOM   3606 C CA    . GLN C 3 287 ? 71.075  59.946 127.294 1.00 87.96  ? ? ? ? ? ? 281 GLN A CA    1 
+ATOM   3607 C C     . GLN C 3 287 ? 71.420  58.573 126.727 1.00 88.07  ? ? ? ? ? ? 281 GLN A C     1 
+ATOM   3608 O O     . GLN C 3 287 ? 71.638  57.623 127.474 1.00 88.30  ? ? ? ? ? ? 281 GLN A O     1 
+ATOM   3609 C CB    . GLN C 3 287 ? 72.224  60.880 126.958 1.00 89.16  ? ? ? ? ? ? 281 GLN A CB    1 
+ATOM   3610 C CG    . GLN C 3 287 ? 72.007  62.387 126.873 1.00 99.25  ? ? ? ? ? ? 281 GLN A CG    1 
+ATOM   3611 C CD    . GLN C 3 287 ? 73.250  63.179 126.685 1.00 100.00 ? ? ? ? ? ? 281 GLN A CD    1 
+ATOM   3612 O OE1   . GLN C 3 287 ? 74.275  62.504 126.292 1.00 100.00 ? ? ? ? ? ? 281 GLN A OE1   1 
+ATOM   3613 N NE2   . GLN C 3 287 ? 73.240  64.451 126.898 1.00 97.61  ? ? ? ? ? ? 281 GLN A NE2   1 
+ATOM   3614 N N     . ARG C 3 288 ? 71.497  58.497 125.404 1.00 80.39  ? ? ? ? ? ? 282 ARG A N     1 
+ATOM   3615 C CA    . ARG C 3 288 ? 71.848  57.244 124.745 1.00 78.16  ? ? ? ? ? ? 282 ARG A CA    1 
+ATOM   3616 C C     . ARG C 3 288 ? 73.332  57.268 124.395 1.00 75.47  ? ? ? ? ? ? 282 ARG A C     1 
+ATOM   3617 O O     . ARG C 3 288 ? 73.979  58.315 124.481 1.00 72.70  ? ? ? ? ? ? 282 ARG A O     1 
+ATOM   3618 C CB    . ARG C 3 288 ? 71.003  57.031 123.485 1.00 77.45  ? ? ? ? ? ? 282 ARG A CB    1 
+ATOM   3619 C CG    . ARG C 3 288 ? 69.667  56.347 123.742 1.00 85.97  ? ? ? ? ? ? 282 ARG A CG    1 
+ATOM   3620 C CD    . ARG C 3 288 ? 69.075  55.831 122.447 1.00 100.00 ? ? ? ? ? ? 282 ARG A CD    1 
+ATOM   3621 N NE    . ARG C 3 288 ? 67.763  55.237 122.649 1.00 100.00 ? ? ? ? ? ? 282 ARG A NE    1 
+ATOM   3622 C CZ    . ARG C 3 288 ? 67.133  54.485 121.753 1.00 99.78  ? ? ? ? ? ? 282 ARG A CZ    1 
+ATOM   3623 N NH1   . ARG C 3 288 ? 67.676  54.239 120.568 1.00 74.24  ? ? ? ? ? ? 282 ARG A NH1   1 
+ATOM   3624 N NH2   . ARG C 3 288 ? 65.940  53.988 122.043 1.00 87.54  ? ? ? ? ? ? 282 ARG A NH2   1 
+ATOM   3625 N N     . TYR C 3 289 ? 73.863  56.107 124.018 1.00 69.57  ? ? ? ? ? ? 283 TYR A N     1 
+ATOM   3626 C CA    . TYR C 3 289 ? 75.265  55.980 123.629 1.00 68.26  ? ? ? ? ? ? 283 TYR A CA    1 
+ATOM   3627 C C     . TYR C 3 289 ? 76.251  56.619 124.603 1.00 69.61  ? ? ? ? ? ? 283 TYR A C     1 
+ATOM   3628 O O     . TYR C 3 289 ? 77.260  57.182 124.176 1.00 69.84  ? ? ? ? ? ? 283 TYR A O     1 
+ATOM   3629 C CB    . TYR C 3 289 ? 75.492  56.587 122.242 1.00 69.34  ? ? ? ? ? ? 283 TYR A CB    1 
+ATOM   3630 C CG    . TYR C 3 289 ? 74.576  56.052 121.169 1.00 70.94  ? ? ? ? ? ? 283 TYR A CG    1 
+ATOM   3631 C CD1   . TYR C 3 289 ? 73.793  56.910 120.409 1.00 71.40  ? ? ? ? ? ? 283 TYR A CD1   1 
+ATOM   3632 C CD2   . TYR C 3 289 ? 74.490  54.686 120.920 1.00 72.61  ? ? ? ? ? ? 283 TYR A CD2   1 
+ATOM   3633 C CE1   . TYR C 3 289 ? 72.956  56.420 119.429 1.00 72.42  ? ? ? ? ? ? 283 TYR A CE1   1 
+ATOM   3634 C CE2   . TYR C 3 289 ? 73.657  54.188 119.944 1.00 71.28  ? ? ? ? ? ? 283 TYR A CE2   1 
+ATOM   3635 C CZ    . TYR C 3 289 ? 72.891  55.058 119.204 1.00 76.92  ? ? ? ? ? ? 283 TYR A CZ    1 
+ATOM   3636 O OH    . TYR C 3 289 ? 72.069  54.553 118.229 1.00 74.17  ? ? ? ? ? ? 283 TYR A OH    1 
+ATOM   3637 N N     . LEU C 3 290 ? 75.974  56.547 125.901 1.00 62.09  ? ? ? ? ? ? 284 LEU A N     1 
+ATOM   3638 C CA    . LEU C 3 290 ? 76.893  57.129 126.872 1.00 59.06  ? ? ? ? ? ? 284 LEU A CA    1 
+ATOM   3639 C C     . LEU C 3 290 ? 78.102  56.211 127.011 1.00 61.71  ? ? ? ? ? ? 284 LEU A C     1 
+ATOM   3640 O O     . LEU C 3 290 ? 79.211  56.661 127.311 1.00 62.55  ? ? ? ? ? ? 284 LEU A O     1 
+ATOM   3641 C CB    . LEU C 3 290 ? 76.190  57.405 128.201 1.00 58.02  ? ? ? ? ? ? 284 LEU A CB    1 
+ATOM   3642 C CG    . LEU C 3 290 ? 75.279  58.633 128.053 1.00 60.34  ? ? ? ? ? ? 284 LEU A CG    1 
+ATOM   3643 C CD1   . LEU C 3 290 ? 74.616  59.059 129.351 1.00 59.43  ? ? ? ? ? ? 284 LEU A CD1   1 
+ATOM   3644 C CD2   . LEU C 3 290 ? 75.975  59.813 127.378 1.00 58.55  ? ? ? ? ? ? 284 LEU A CD2   1 
+ATOM   3645 N N     . ALA C 3 291 ? 77.875  54.925 126.741 1.00 55.07  ? ? ? ? ? ? 285 ALA A N     1 
+ATOM   3646 C CA    . ALA C 3 291 ? 78.914  53.895 126.771 1.00 53.54  ? ? ? ? ? ? 285 ALA A CA    1 
+ATOM   3647 C C     . ALA C 3 291 ? 79.061  53.302 125.374 1.00 60.89  ? ? ? ? ? ? 285 ALA A C     1 
+ATOM   3648 O O     . ALA C 3 291 ? 78.919  53.993 124.375 1.00 62.60  ? ? ? ? ? ? 285 ALA A O     1 
+ATOM   3649 C CB    . ALA C 3 291 ? 78.534  52.795 127.752 1.00 53.28  ? ? ? ? ? ? 285 ALA A CB    1 
+ATOM   3650 N N     . TRP C 3 292 ? 79.355  52.003 125.304 1.00 58.43  ? ? ? ? ? ? 286 TRP A N     1 
+ATOM   3651 C CA    . TRP C 3 292 ? 79.464  51.343 124.012 1.00 57.90  ? ? ? ? ? ? 286 TRP A CA    1 
+ATOM   3652 C C     . TRP C 3 292 ? 78.186  50.547 123.803 1.00 58.08  ? ? ? ? ? ? 286 TRP A C     1 
+ATOM   3653 O O     . TRP C 3 292 ? 77.579  50.087 124.771 1.00 55.97  ? ? ? ? ? ? 286 TRP A O     1 
+ATOM   3654 C CB    . TRP C 3 292 ? 80.677  50.414 123.969 1.00 57.51  ? ? ? ? ? ? 286 TRP A CB    1 
+ATOM   3655 C CG    . TRP C 3 292 ? 81.975  51.152 123.827 1.00 59.82  ? ? ? ? ? ? 286 TRP A CG    1 
+ATOM   3656 C CD1   . TRP C 3 292 ? 82.269  52.147 122.932 1.00 63.02  ? ? ? ? ? ? 286 TRP A CD1   1 
+ATOM   3657 C CD2   . TRP C 3 292 ? 83.145  50.975 124.628 1.00 59.90  ? ? ? ? ? ? 286 TRP A CD2   1 
+ATOM   3658 N NE1   . TRP C 3 292 ? 83.557  52.588 123.122 1.00 62.70  ? ? ? ? ? ? 286 TRP A NE1   1 
+ATOM   3659 C CE2   . TRP C 3 292 ? 84.116  51.887 124.159 1.00 64.38  ? ? ? ? ? ? 286 TRP A CE2   1 
+ATOM   3660 C CE3   . TRP C 3 292 ? 83.469  50.134 125.697 1.00 61.24  ? ? ? ? ? ? 286 TRP A CE3   1 
+ATOM   3661 C CZ2   . TRP C 3 292 ? 85.388  51.979 124.725 1.00 63.71  ? ? ? ? ? ? 286 TRP A CZ2   1 
+ATOM   3662 C CZ3   . TRP C 3 292 ? 84.729  50.227 126.256 1.00 63.09  ? ? ? ? ? ? 286 TRP A CZ3   1 
+ATOM   3663 C CH2   . TRP C 3 292 ? 85.678  51.138 125.764 1.00 63.72  ? ? ? ? ? ? 286 TRP A CH2   1 
+ATOM   3664 N N     . SER C 3 293 ? 77.768  50.410 122.546 1.00 52.10  ? ? ? ? ? ? 287 SER A N     1 
+ATOM   3665 C CA    . SER C 3 293 ? 76.563  49.655 122.210 1.00 47.79  ? ? ? ? ? ? 287 SER A CA    1 
+ATOM   3666 C C     . SER C 3 293 ? 76.934  48.708 121.087 1.00 51.18  ? ? ? ? ? ? 287 SER A C     1 
+ATOM   3667 O O     . SER C 3 293 ? 78.074  48.728 120.619 1.00 51.46  ? ? ? ? ? ? 287 SER A O     1 
+ATOM   3668 C CB    . SER C 3 293 ? 75.403  50.559 121.806 1.00 43.64  ? ? ? ? ? ? 287 SER A CB    1 
+ATOM   3669 O OG    . SER C 3 293 ? 75.877  51.678 121.076 1.00 47.60  ? ? ? ? ? ? 287 SER A OG    1 
+ATOM   3670 N N     . GLY C 3 294 ? 75.995  47.857 120.687 1.00 48.45  ? ? ? ? ? ? 288 GLY A N     1 
+ATOM   3671 C CA    . GLY C 3 294 ? 76.240  46.860 119.649 1.00 48.22  ? ? ? ? ? ? 288 GLY A CA    1 
+ATOM   3672 C C     . GLY C 3 294 ? 76.904  47.399 118.383 1.00 54.00  ? ? ? ? ? ? 288 GLY A C     1 
+ATOM   3673 O O     . GLY C 3 294 ? 77.689  46.716 117.726 1.00 53.32  ? ? ? ? ? ? 288 GLY A O     1 
+ATOM   3674 N N     . HIS C 3 295 ? 76.580  48.627 118.024 1.00 52.95  ? ? ? ? ? ? 289 HIS A N     1 
+ATOM   3675 C CA    . HIS C 3 295 ? 77.146  49.192 116.815 1.00 55.57  ? ? ? ? ? ? 289 HIS A CA    1 
+ATOM   3676 C C     . HIS C 3 295 ? 78.511  49.871 116.915 1.00 61.00  ? ? ? ? ? ? 289 HIS A C     1 
+ATOM   3677 O O     . HIS C 3 295 ? 79.092  50.229 115.887 1.00 60.95  ? ? ? ? ? ? 289 HIS A O     1 
+ATOM   3678 C CB    . HIS C 3 295 ? 76.117  50.111 116.164 1.00 58.24  ? ? ? ? ? ? 289 HIS A CB    1 
+ATOM   3679 C CG    . HIS C 3 295 ? 75.378  49.462 115.039 1.00 63.36  ? ? ? ? ? ? 289 HIS A CG    1 
+ATOM   3680 N ND1   . HIS C 3 295 ? 75.101  48.111 115.012 1.00 66.10  ? ? ? ? ? ? 289 HIS A ND1   1 
+ATOM   3681 C CD2   . HIS C 3 295 ? 74.906  49.968 113.875 1.00 65.69  ? ? ? ? ? ? 289 HIS A CD2   1 
+ATOM   3682 C CE1   . HIS C 3 295 ? 74.473  47.815 113.887 1.00 65.38  ? ? ? ? ? ? 289 HIS A CE1   1 
+ATOM   3683 N NE2   . HIS C 3 295 ? 74.341  48.925 113.182 1.00 65.73  ? ? ? ? ? ? 289 HIS A NE2   1 
+ATOM   3684 N N     . SER C 3 296 ? 79.010  50.052 118.138 1.00 56.06  ? ? ? ? ? ? 290 SER A N     1 
+ATOM   3685 C CA    . SER C 3 296 ? 80.290  50.714 118.393 1.00 52.53  ? ? ? ? ? ? 290 SER A CA    1 
+ATOM   3686 C C     . SER C 3 296 ? 81.469  50.169 117.594 1.00 53.29  ? ? ? ? ? ? 290 SER A C     1 
+ATOM   3687 O O     . SER C 3 296 ? 82.230  50.931 117.000 1.00 51.43  ? ? ? ? ? ? 290 SER A O     1 
+ATOM   3688 C CB    . SER C 3 296 ? 80.592  50.723 119.889 1.00 52.78  ? ? ? ? ? ? 290 SER A CB    1 
+ATOM   3689 O OG    . SER C 3 296 ? 79.570  51.427 120.580 1.00 57.45  ? ? ? ? ? ? 290 SER A OG    1 
+ATOM   3690 N N     . ALA C 3 297 ? 81.589  48.847 117.562 1.00 50.38  ? ? ? ? ? ? 291 ALA A N     1 
+ATOM   3691 C CA    . ALA C 3 297 ? 82.661  48.173 116.840 1.00 51.39  ? ? ? ? ? ? 291 ALA A CA    1 
+ATOM   3692 C C     . ALA C 3 297 ? 82.663  48.494 115.347 1.00 56.60  ? ? ? ? ? ? 291 ALA A C     1 
+ATOM   3693 O O     . ALA C 3 297 ? 83.714  48.668 114.732 1.00 53.96  ? ? ? ? ? ? 291 ALA A O     1 
+ATOM   3694 C CB    . ALA C 3 297 ? 82.551  46.673 117.048 1.00 52.07  ? ? ? ? ? ? 291 ALA A CB    1 
+ATOM   3695 N N     . ARG C 3 298 ? 81.474  48.533 114.758 1.00 56.98  ? ? ? ? ? ? 292 ARG A N     1 
+ATOM   3696 C CA    . ARG C 3 298 ? 81.351  48.837 113.341 1.00 56.52  ? ? ? ? ? ? 292 ARG A CA    1 
+ATOM   3697 C C     . ARG C 3 298 ? 81.678  50.305 113.101 1.00 59.19  ? ? ? ? ? ? 292 ARG A C     1 
+ATOM   3698 O O     . ARG C 3 298 ? 82.228  50.658 112.068 1.00 58.63  ? ? ? ? ? ? 292 ARG A O     1 
+ATOM   3699 C CB    . ARG C 3 298 ? 79.957  48.492 112.819 1.00 51.90  ? ? ? ? ? ? 292 ARG A CB    1 
+ATOM   3700 C CG    . ARG C 3 298 ? 79.802  47.015 112.534 1.00 50.28  ? ? ? ? ? ? 292 ARG A CG    1 
+ATOM   3701 C CD    . ARG C 3 298 ? 78.360  46.683 112.295 1.00 57.89  ? ? ? ? ? ? 292 ARG A CD    1 
+ATOM   3702 N NE    . ARG C 3 298 ? 77.737  47.632 111.378 1.00 57.31  ? ? ? ? ? ? 292 ARG A NE    1 
+ATOM   3703 C CZ    . ARG C 3 298 ? 77.425  47.331 110.122 1.00 62.52  ? ? ? ? ? ? 292 ARG A CZ    1 
+ATOM   3704 N NH1   . ARG C 3 298 ? 77.700  46.125 109.645 1.00 51.12  ? ? ? ? ? ? 292 ARG A NH1   1 
+ATOM   3705 N NH2   . ARG C 3 298 ? 76.847  48.220 109.329 1.00 60.24  ? ? ? ? ? ? 292 ARG A NH2   1 
+ATOM   3706 N N     . VAL C 3 299 ? 81.357  51.158 114.071 1.00 54.48  ? ? ? ? ? ? 293 VAL A N     1 
+ATOM   3707 C CA    . VAL C 3 299 ? 81.626  52.583 113.949 1.00 53.10  ? ? ? ? ? ? 293 VAL A CA    1 
+ATOM   3708 C C     . VAL C 3 299 ? 83.116  52.883 114.002 1.00 57.15  ? ? ? ? ? ? 293 VAL A C     1 
+ATOM   3709 O O     . VAL C 3 299 ? 83.631  53.678 113.216 1.00 56.26  ? ? ? ? ? ? 293 VAL A O     1 
+ATOM   3710 C CB    . VAL C 3 299 ? 80.945  53.365 115.085 1.00 55.74  ? ? ? ? ? ? 293 VAL A CB    1 
+ATOM   3711 C CG1   . VAL C 3 299 ? 81.554  54.751 115.221 1.00 55.13  ? ? ? ? ? ? 293 VAL A CG1   1 
+ATOM   3712 C CG2   . VAL C 3 299 ? 79.439  53.437 114.878 1.00 55.00  ? ? ? ? ? ? 293 VAL A CG2   1 
+ATOM   3713 N N     . GLY C 3 300 ? 83.805  52.246 114.941 1.00 57.62  ? ? ? ? ? ? 294 GLY A N     1 
+ATOM   3714 C CA    . GLY C 3 300 ? 85.238  52.452 115.120 1.00 58.19  ? ? ? ? ? ? 294 GLY A CA    1 
+ATOM   3715 C C     . GLY C 3 300 ? 86.083  51.806 114.027 1.00 62.47  ? ? ? ? ? ? 294 GLY A C     1 
+ATOM   3716 O O     . GLY C 3 300 ? 87.046  52.410 113.554 1.00 63.10  ? ? ? ? ? ? 294 GLY A O     1 
+ATOM   3717 N N     . ALA C 3 301 ? 85.732  50.577 113.651 1.00 59.61  ? ? ? ? ? ? 295 ALA A N     1 
+ATOM   3718 C CA    . ALA C 3 301 ? 86.437  49.835 112.608 1.00 59.17  ? ? ? ? ? ? 295 ALA A CA    1 
+ATOM   3719 C C     . ALA C 3 301 ? 86.565  50.733 111.386 1.00 65.16  ? ? ? ? ? ? 295 ALA A C     1 
+ATOM   3720 O O     . ALA C 3 301 ? 87.637  50.845 110.786 1.00 66.59  ? ? ? ? ? ? 295 ALA A O     1 
+ATOM   3721 C CB    . ALA C 3 301 ? 85.654  48.576 112.253 1.00 59.91  ? ? ? ? ? ? 295 ALA A CB    1 
+ATOM   3722 N N     . ALA C 3 302 ? 85.455  51.384 111.049 1.00 59.75  ? ? ? ? ? ? 296 ALA A N     1 
+ATOM   3723 C CA    . ALA C 3 302 ? 85.364  52.304 109.923 1.00 58.42  ? ? ? ? ? ? 296 ALA A CA    1 
+ATOM   3724 C C     . ALA C 3 302 ? 86.363  53.450 110.016 1.00 64.47  ? ? ? ? ? ? 296 ALA A C     1 
+ATOM   3725 O O     . ALA C 3 302 ? 87.243  53.579 109.162 1.00 67.60  ? ? ? ? ? ? 296 ALA A O     1 
+ATOM   3726 C CB    . ALA C 3 302 ? 83.961  52.862 109.833 1.00 58.71  ? ? ? ? ? ? 296 ALA A CB    1 
+ATOM   3727 N N     . ARG C 3 303 ? 86.200  54.301 111.025 1.00 58.18  ? ? ? ? ? ? 297 ARG A N     1 
+ATOM   3728 C CA    . ARG C 3 303 ? 87.105  55.430 111.206 1.00 58.27  ? ? ? ? ? ? 297 ARG A CA    1 
+ATOM   3729 C C     . ARG C 3 303 ? 88.573  54.999 111.178 1.00 65.08  ? ? ? ? ? ? 297 ARG A C     1 
+ATOM   3730 O O     . ARG C 3 303 ? 89.432  55.678 110.612 1.00 66.62  ? ? ? ? ? ? 297 ARG A O     1 
+ATOM   3731 C CB    . ARG C 3 303 ? 86.783  56.164 112.505 1.00 55.54  ? ? ? ? ? ? 297 ARG A CB    1 
+ATOM   3732 C CG    . ARG C 3 303 ? 85.306  56.481 112.667 1.00 59.46  ? ? ? ? ? ? 297 ARG A CG    1 
+ATOM   3733 C CD    . ARG C 3 303 ? 85.019  57.144 113.992 1.00 64.05  ? ? ? ? ? ? 297 ARG A CD    1 
+ATOM   3734 N NE    . ARG C 3 303 ? 85.945  58.233 114.324 1.00 71.28  ? ? ? ? ? ? 297 ARG A NE    1 
+ATOM   3735 C CZ    . ARG C 3 303 ? 85.599  59.516 114.399 1.00 100.00 ? ? ? ? ? ? 297 ARG A CZ    1 
+ATOM   3736 N NH1   . ARG C 3 303 ? 84.327  59.845 114.262 1.00 94.74  ? ? ? ? ? ? 297 ARG A NH1   1 
+ATOM   3737 N NH2   . ARG C 3 303 ? 86.467  60.432 114.754 1.00 100.00 ? ? ? ? ? ? 297 ARG A NH2   1 
+ATOM   3738 N N     . ASP C 3 304 ? 88.869  53.870 111.804 1.00 59.86  ? ? ? ? ? ? 298 ASP A N     1 
+ATOM   3739 C CA    . ASP C 3 304 ? 90.244  53.417 111.806 1.00 59.46  ? ? ? ? ? ? 298 ASP A CA    1 
+ATOM   3740 C C     . ASP C 3 304 ? 90.633  53.148 110.369 1.00 65.19  ? ? ? ? ? ? 298 ASP A C     1 
+ATOM   3741 O O     . ASP C 3 304 ? 91.695  53.567 109.919 1.00 64.95  ? ? ? ? ? ? 298 ASP A O     1 
+ATOM   3742 C CB    . ASP C 3 304 ? 90.388  52.187 112.685 1.00 61.01  ? ? ? ? ? ? 298 ASP A CB    1 
+ATOM   3743 C CG    . ASP C 3 304 ? 89.898  52.447 114.081 1.00 77.03  ? ? ? ? ? ? 298 ASP A CG    1 
+ATOM   3744 O OD1   . ASP C 3 304 ? 89.795  53.638 114.454 1.00 82.61  ? ? ? ? ? ? 298 ASP A OD1   1 
+ATOM   3745 O OD2   . ASP C 3 304 ? 89.604  51.466 114.796 1.00 78.92  ? ? ? ? ? ? 298 ASP A OD2   1 
+ATOM   3746 N N     . MET C 3 305 ? 89.730  52.478 109.657 1.00 64.87  ? ? ? ? ? ? 299 MET A N     1 
+ATOM   3747 C CA    . MET C 3 305 ? 89.891  52.148 108.241 1.00 66.22  ? ? ? ? ? ? 299 MET A CA    1 
+ATOM   3748 C C     . MET C 3 305 ? 89.899  53.399 107.357 1.00 72.30  ? ? ? ? ? ? 299 MET A C     1 
+ATOM   3749 O O     . MET C 3 305 ? 90.490  53.399 106.270 1.00 72.79  ? ? ? ? ? ? 299 MET A O     1 
+ATOM   3750 C CB    . MET C 3 305 ? 88.837  51.128 107.775 1.00 69.02  ? ? ? ? ? ? 299 MET A CB    1 
+ATOM   3751 C CG    . MET C 3 305 ? 89.474  49.819 107.196 1.00 74.74  ? ? ? ? ? ? 299 MET A CG    1 
+ATOM   3752 S SD    . MET C 3 305 ? 88.228  48.603 106.810 1.00 80.19  ? ? ? ? ? ? 299 MET A SD    1 
+ATOM   3753 C CE    . MET C 3 305 ? 87.032  49.770 107.434 1.00 76.76  ? ? ? ? ? ? 299 MET A CE    1 
+ATOM   3754 N N     . ALA C 3 306 ? 89.277  54.480 107.827 1.00 67.19  ? ? ? ? ? ? 300 ALA A N     1 
+ATOM   3755 C CA    . ALA C 3 306 ? 89.264  55.729 107.078 1.00 66.58  ? ? ? ? ? ? 300 ALA A CA    1 
+ATOM   3756 C C     . ALA C 3 306 ? 90.495  56.566 107.439 1.00 76.41  ? ? ? ? ? ? 300 ALA A C     1 
+ATOM   3757 O O     . ALA C 3 306 ? 91.031  57.304 106.609 1.00 78.85  ? ? ? ? ? ? 300 ALA A O     1 
+ATOM   3758 C CB    . ALA C 3 306 ? 87.985  56.495 107.368 1.00 66.59  ? ? ? ? ? ? 300 ALA A CB    1 
+ATOM   3759 N N     . ARG C 3 307 ? 90.949  56.438 108.681 1.00 72.34  ? ? ? ? ? ? 301 ARG A N     1 
+ATOM   3760 C CA    . ARG C 3 307 ? 92.096  57.193 109.159 1.00 70.96  ? ? ? ? ? ? 301 ARG A CA    1 
+ATOM   3761 C C     . ARG C 3 307 ? 93.394  56.794 108.479 1.00 81.37  ? ? ? ? ? ? 301 ARG A C     1 
+ATOM   3762 O O     . ARG C 3 307 ? 94.273  57.628 108.246 1.00 83.18  ? ? ? ? ? ? 301 ARG A O     1 
+ATOM   3763 C CB    . ARG C 3 307 ? 92.248  56.984 110.654 1.00 62.49  ? ? ? ? ? ? 301 ARG A CB    1 
+ATOM   3764 C CG    . ARG C 3 307 ? 91.542  58.017 111.486 1.00 60.35  ? ? ? ? ? ? 301 ARG A CG    1 
+ATOM   3765 C CD    . ARG C 3 307 ? 91.977  57.872 112.935 1.00 61.70  ? ? ? ? ? ? 301 ARG A CD    1 
+ATOM   3766 N NE    . ARG C 3 307 ? 90.889  57.474 113.778 1.00 55.03  ? ? ? ? ? ? 301 ARG A NE    1 
+ATOM   3767 C CZ    . ARG C 3 307 ? 90.087  58.318 114.375 1.00 76.17  ? ? ? ? ? ? 301 ARG A CZ    1 
+ATOM   3768 N NH1   . ARG C 3 307 ? 90.155  59.638 114.275 1.00 78.86  ? ? ? ? ? ? 301 ARG A NH1   1 
+ATOM   3769 N NH2   . ARG C 3 307 ? 89.144  57.660 114.988 1.00 73.51  ? ? ? ? ? ? 301 ARG A NH2   1 
+ATOM   3770 N N     . ALA C 3 308 ? 93.527  55.504 108.197 1.00 80.16  ? ? ? ? ? ? 302 ALA A N     1 
+ATOM   3771 C CA    . ALA C 3 308 ? 94.729  54.992 107.556 1.00 80.84  ? ? ? ? ? ? 302 ALA A CA    1 
+ATOM   3772 C C     . ALA C 3 308 ? 94.480  55.026 106.059 1.00 86.29  ? ? ? ? ? ? 302 ALA A C     1 
+ATOM   3773 O O     . ALA C 3 308 ? 95.074  54.267 105.292 1.00 85.19  ? ? ? ? ? ? 302 ALA A O     1 
+ATOM   3774 C CB    . ALA C 3 308 ? 95.011  53.571 108.018 0.00 81.55  ? ? ? ? ? ? 302 ALA A CB    1 
+ATOM   3775 N N     . GLY C 3 309 ? 93.555  55.893 105.664 1.00 84.30  ? ? ? ? ? ? 303 GLY A N     1 
+ATOM   3776 C CA    . GLY C 3 309 ? 93.198  56.033 104.264 1.00 84.90  ? ? ? ? ? ? 303 GLY A CA    1 
+ATOM   3777 C C     . GLY C 3 309 ? 93.089  54.648 103.638 1.00 92.16  ? ? ? ? ? ? 303 GLY A C     1 
+ATOM   3778 O O     . GLY C 3 309 ? 94.072  54.083 103.160 1.00 91.09  ? ? ? ? ? ? 303 GLY A O     1 
+ATOM   3779 N N     . VAL C 3 310 ? 91.885  54.094 103.669 1.00 91.75  ? ? ? ? ? ? 304 VAL A N     1 
+ATOM   3780 C CA    . VAL C 3 310 ? 91.611  52.792 103.077 1.00 91.95  ? ? ? ? ? ? 304 VAL A CA    1 
+ATOM   3781 C C     . VAL C 3 310 ? 90.332  52.971 102.254 1.00 97.07  ? ? ? ? ? ? 304 VAL A C     1 
+ATOM   3782 O O     . VAL C 3 310 ? 89.237  53.134 102.796 1.00 98.10  ? ? ? ? ? ? 304 VAL A O     1 
+ATOM   3783 C CB    . VAL C 3 310 ? 91.444  51.700 104.151 1.00 94.29  ? ? ? ? ? ? 304 VAL A CB    1 
+ATOM   3784 C CG1   . VAL C 3 310 ? 91.316  50.329 103.509 1.00 94.09  ? ? ? ? ? ? 304 VAL A CG1   1 
+ATOM   3785 C CG2   . VAL C 3 310 ? 92.618  51.723 105.118 1.00 93.59  ? ? ? ? ? ? 304 VAL A CG2   1 
+ATOM   3786 N N     . SER C 3 311 ? 90.493  53.037 100.938 1.00 90.49  ? ? ? ? ? ? 305 SER A N     1 
+ATOM   3787 C CA    . SER C 3 311 ? 89.390  53.227 100.016 1.00 88.02  ? ? ? ? ? ? 305 SER A CA    1 
+ATOM   3788 C C     . SER C 3 311 ? 87.984  53.008 100.540 1.00 88.22  ? ? ? ? ? ? 305 SER A C     1 
+ATOM   3789 O O     . SER C 3 311 ? 87.721  52.055 101.275 1.00 87.53  ? ? ? ? ? ? 305 SER A O     1 
+ATOM   3790 C CB    . SER C 3 311 ? 89.583  52.340 98.783  1.00 92.04  ? ? ? ? ? ? 305 SER A CB    1 
+ATOM   3791 O OG    . SER C 3 311 ? 89.871  50.995 99.138  1.00 100.00 ? ? ? ? ? ? 305 SER A OG    1 
+ATOM   3792 N N     . ILE C 3 312 ? 87.064  53.844 100.068 1.00 83.82  ? ? ? ? ? ? 306 ILE A N     1 
+ATOM   3793 C CA    . ILE C 3 312 ? 85.651  53.648 100.378 1.00 82.92  ? ? ? ? ? ? 306 ILE A CA    1 
+ATOM   3794 C C     . ILE C 3 312 ? 85.022  52.283 99.964  1.00 91.31  ? ? ? ? ? ? 306 ILE A C     1 
+ATOM   3795 O O     . ILE C 3 312 ? 83.803  52.115 100.020 1.00 90.12  ? ? ? ? ? ? 306 ILE A O     1 
+ATOM   3796 C CB    . ILE C 3 312 ? 84.768  54.898 100.106 1.00 84.03  ? ? ? ? ? ? 306 ILE A CB    1 
+ATOM   3797 C CG1   . ILE C 3 312 ? 85.377  56.140 100.761 1.00 82.62  ? ? ? ? ? ? 306 ILE A CG1   1 
+ATOM   3798 C CG2   . ILE C 3 312 ? 83.432  54.766 100.806 1.00 85.36  ? ? ? ? ? ? 306 ILE A CG2   1 
+ATOM   3799 C CD1   . ILE C 3 312 ? 84.476  56.759 101.815 1.00 70.54  ? ? ? ? ? ? 306 ILE A CD1   1 
+ATOM   3800 N N     . PRO C 3 313 ? 85.846  51.306 99.549  1.00 92.28  ? ? ? ? ? ? 307 PRO A N     1 
+ATOM   3801 C CA    . PRO C 3 313 ? 85.418  49.940 99.287  1.00 93.12  ? ? ? ? ? ? 307 PRO A CA    1 
+ATOM   3802 C C     . PRO C 3 313 ? 85.252  49.367 100.703 1.00 100.00 ? ? ? ? ? ? 307 PRO A C     1 
+ATOM   3803 O O     . PRO C 3 313 ? 84.257  49.719 101.315 1.00 100.00 ? ? ? ? ? ? 307 PRO A O     1 
+ATOM   3804 C CB    . PRO C 3 313 ? 86.610  49.382 98.508  0.00 94.41  ? ? ? ? ? ? 307 PRO A CB    1 
+ATOM   3805 C CG    . PRO C 3 313 ? 87.163  50.638 97.762  0.00 98.20  ? ? ? ? ? ? 307 PRO A CG    1 
+ATOM   3806 C CD    . PRO C 3 313 ? 86.396  51.835 98.292  0.00 93.12  ? ? ? ? ? ? 307 PRO A CD    1 
+ATOM   3807 N N     . GLU C 3 314 ? 86.219  48.653 101.296 1.00 97.28  ? ? ? ? ? ? 308 GLU A N     1 
+ATOM   3808 C CA    . GLU C 3 314 ? 86.079  48.163 102.687 1.00 96.65  ? ? ? ? ? ? 308 GLU A CA    1 
+ATOM   3809 C C     . GLU C 3 314 ? 85.762  49.240 103.722 1.00 99.71  ? ? ? ? ? ? 308 GLU A C     1 
+ATOM   3810 O O     . GLU C 3 314 ? 85.950  49.018 104.846 1.00 100.00 ? ? ? ? ? ? 308 GLU A O     1 
+ATOM   3811 C CB    . GLU C 3 314 ? 87.262  47.286 103.130 1.00 97.70  ? ? ? ? ? ? 308 GLU A CB    1 
+ATOM   3812 C CG    . GLU C 3 314 ? 87.470  45.993 102.338 1.00 100.00 ? ? ? ? ? ? 308 GLU A CG    1 
+ATOM   3813 C CD    . GLU C 3 314 ? 86.400  44.955 102.611 1.00 100.00 ? ? ? ? ? ? 308 GLU A CD    1 
+ATOM   3814 O OE1   . GLU C 3 314 ? 86.233  44.566 103.784 1.00 100.00 ? ? ? ? ? ? 308 GLU A OE1   1 
+ATOM   3815 O OE2   . GLU C 3 314 ? 85.707  44.543 101.656 1.00 100.00 ? ? ? ? ? ? 308 GLU A OE2   1 
+ATOM   3816 N N     . ILE C 3 315 ? 85.118  50.295 103.324 1.00 93.66  ? ? ? ? ? ? 309 ILE A N     1 
+ATOM   3817 C CA    . ILE C 3 315 ? 84.688  51.379 104.168 1.00 93.18  ? ? ? ? ? ? 309 ILE A CA    1 
+ATOM   3818 C C     . ILE C 3 315 ? 83.189  51.416 103.877 1.00 96.74  ? ? ? ? ? ? 309 ILE A C     1 
+ATOM   3819 O O     . ILE C 3 315 ? 82.480  50.722 104.596 1.00 97.51  ? ? ? ? ? ? 309 ILE A O     1 
+ATOM   3820 C CB    . ILE C 3 315 ? 85.595  52.618 104.026 1.00 96.41  ? ? ? ? ? ? 309 ILE A CB    1 
+ATOM   3821 C CG1   . ILE C 3 315 ? 87.000  52.249 104.517 1.00 96.69  ? ? ? ? ? ? 309 ILE A CG1   1 
+ATOM   3822 C CG2   . ILE C 3 315 ? 85.139  53.705 104.927 1.00 96.95  ? ? ? ? ? ? 309 ILE A CG2   1 
+ATOM   3823 C CD1   . ILE C 3 315 ? 87.681  53.355 105.311 1.00 100.00 ? ? ? ? ? ? 309 ILE A CD1   1 
+ATOM   3824 N N     . MET C 3 316 ? 82.692  51.986 102.781 1.00 91.71  ? ? ? ? ? ? 310 MET A N     1 
+ATOM   3825 C CA    . MET C 3 316 ? 81.251  51.856 102.543 1.00 90.57  ? ? ? ? ? ? 310 MET A CA    1 
+ATOM   3826 C C     . MET C 3 316 ? 80.926  50.436 102.051 1.00 93.53  ? ? ? ? ? ? 310 MET A C     1 
+ATOM   3827 O O     . MET C 3 316 ? 79.906  50.181 101.410 1.00 94.25  ? ? ? ? ? ? 310 MET A O     1 
+ATOM   3828 C CB    . MET C 3 316 ? 80.729  52.934 101.599 1.00 92.71  ? ? ? ? ? ? 310 MET A CB    1 
+ATOM   3829 C CG    . MET C 3 316 ? 80.983  52.655 100.145 1.00 96.42  ? ? ? ? ? ? 310 MET A CG    1 
+ATOM   3830 S SD    . MET C 3 316 ? 79.489  52.046 99.373  1.00 100.00 ? ? ? ? ? ? 310 MET A SD    1 
+ATOM   3831 C CE    . MET C 3 316 ? 80.172  50.789 98.308  1.00 96.28  ? ? ? ? ? ? 310 MET A CE    1 
+ATOM   3832 N N     . GLN C 3 317 ? 81.797  49.497 102.401 1.00 87.12  ? ? ? ? ? ? 311 GLN A N     1 
+ATOM   3833 C CA    . GLN C 3 317 ? 81.599  48.115 101.992 1.00 85.48  ? ? ? ? ? ? 311 GLN A CA    1 
+ATOM   3834 C C     . GLN C 3 317 ? 81.941  47.068 103.045 1.00 90.22  ? ? ? ? ? ? 311 GLN A C     1 
+ATOM   3835 O O     . GLN C 3 317 ? 81.114  46.209 103.342 1.00 92.45  ? ? ? ? ? ? 311 GLN A O     1 
+ATOM   3836 C CB    . GLN C 3 317 ? 82.337  47.839 100.688 0.00 86.46  ? ? ? ? ? ? 311 GLN A CB    1 
+ATOM   3837 C CG    . GLN C 3 317 ? 82.173  46.491 100.108 0.00 91.78  ? ? ? ? ? ? 311 GLN A CG    1 
+ATOM   3838 C CD    . GLN C 3 317 ? 82.204  46.544 98.608  0.00 100.00 ? ? ? ? ? ? 311 GLN A CD    1 
+ATOM   3839 O OE1   . GLN C 3 317 ? 82.559  47.551 97.989  0.00 95.69  ? ? ? ? ? ? 311 GLN A OE1   1 
+ATOM   3840 N NE2   . GLN C 3 317 ? 81.827  45.432 98.001  0.00 92.33  ? ? ? ? ? ? 311 GLN A NE2   1 
+ATOM   3841 N N     . ALA C 3 318 ? 83.148  47.116 103.598 0.00 84.64  ? ? ? ? ? ? 312 ALA A N     1 
+ATOM   3842 C CA    . ALA C 3 318 ? 83.553  46.131 104.600 0.00 83.68  ? ? ? ? ? ? 312 ALA A CA    1 
+ATOM   3843 C C     . ALA C 3 318 ? 82.497  45.638 105.602 0.00 86.09  ? ? ? ? ? ? 312 ALA A C     1 
+ATOM   3844 O O     . ALA C 3 318 ? 82.513  44.469 105.996 0.00 85.69  ? ? ? ? ? ? 312 ALA A O     1 
+ATOM   3845 C CB    . ALA C 3 318 ? 84.832  46.533 105.302 0.00 84.39  ? ? ? ? ? ? 312 ALA A CB    1 
+ATOM   3846 N N     . GLY C 3 319 ? 81.554  46.500 105.971 1.00 81.62  ? ? ? ? ? ? 313 GLY A N     1 
+ATOM   3847 C CA    . GLY C 3 319 ? 80.494  46.142 106.904 1.00 80.64  ? ? ? ? ? ? 313 GLY A CA    1 
+ATOM   3848 C C     . GLY C 3 319 ? 79.221  46.170 106.088 1.00 81.91  ? ? ? ? ? ? 313 GLY A C     1 
+ATOM   3849 O O     . GLY C 3 319 ? 78.214  46.747 106.496 1.00 82.10  ? ? ? ? ? ? 313 GLY A O     1 
+ATOM   3850 N N     . GLY C 3 320 ? 79.323  45.571 104.905 1.00 76.05  ? ? ? ? ? ? 314 GLY A N     1 
+ATOM   3851 C CA    . GLY C 3 320 ? 78.241  45.471 103.935 1.00 74.24  ? ? ? ? ? ? 314 GLY A CA    1 
+ATOM   3852 C C     . GLY C 3 320 ? 77.387  46.718 103.715 1.00 75.76  ? ? ? ? ? ? 314 GLY A C     1 
+ATOM   3853 O O     . GLY C 3 320 ? 76.170  46.609 103.616 1.00 76.24  ? ? ? ? ? ? 314 GLY A O     1 
+ATOM   3854 N N     . TRP C 3 321 ? 77.995  47.896 103.669 1.00 71.54  ? ? ? ? ? ? 315 TRP A N     1 
+ATOM   3855 C CA    . TRP C 3 321 ? 77.159  49.061 103.424 1.00 72.26  ? ? ? ? ? ? 315 TRP A CA    1 
+ATOM   3856 C C     . TRP C 3 321 ? 77.132  49.352 101.925 1.00 85.95  ? ? ? ? ? ? 315 TRP A C     1 
+ATOM   3857 O O     . TRP C 3 321 ? 77.566  50.432 101.516 1.00 90.73  ? ? ? ? ? ? 315 TRP A O     1 
+ATOM   3858 C CB    . TRP C 3 321 ? 77.671  50.325 104.135 1.00 68.55  ? ? ? ? ? ? 315 TRP A CB    1 
+ATOM   3859 C CG    . TRP C 3 321 ? 77.461  50.506 105.625 1.00 66.98  ? ? ? ? ? ? 315 TRP A CG    1 
+ATOM   3860 C CD1   . TRP C 3 321 ? 76.349  50.968 106.266 1.00 69.76  ? ? ? ? ? ? 315 TRP A CD1   1 
+ATOM   3861 C CD2   . TRP C 3 321 ? 78.487  50.446 106.617 1.00 65.79  ? ? ? ? ? ? 315 TRP A CD2   1 
+ATOM   3862 N NE1   . TRP C 3 321 ? 76.595  51.110 107.613 1.00 69.01  ? ? ? ? ? ? 315 TRP A NE1   1 
+ATOM   3863 C CE2   . TRP C 3 321 ? 77.911  50.808 107.852 1.00 70.01  ? ? ? ? ? ? 315 TRP A CE2   1 
+ATOM   3864 C CE3   . TRP C 3 321 ? 79.838  50.102 106.581 1.00 66.43  ? ? ? ? ? ? 315 TRP A CE3   1 
+ATOM   3865 C CZ2   . TRP C 3 321 ? 78.646  50.826 109.041 1.00 68.97  ? ? ? ? ? ? 315 TRP A CZ2   1 
+ATOM   3866 C CZ3   . TRP C 3 321 ? 80.563  50.108 107.758 1.00 67.58  ? ? ? ? ? ? 315 TRP A CZ3   1 
+ATOM   3867 C CH2   . TRP C 3 321 ? 79.966  50.470 108.972 1.00 68.20  ? ? ? ? ? ? 315 TRP A CH2   1 
+ATOM   3868 N N     . THR C 3 322 ? 76.590  48.466 101.093 0.00 82.99  ? ? ? ? ? ? 316 THR A N     1 
+ATOM   3869 C CA    . THR C 3 322 ? 76.494  48.790 99.668  0.00 83.22  ? ? ? ? ? ? 316 THR A CA    1 
+ATOM   3870 C C     . THR C 3 322 ? 75.410  49.872 99.632  0.00 88.49  ? ? ? ? ? ? 316 THR A C     1 
+ATOM   3871 O O     . THR C 3 322 ? 74.340  49.661 99.058  0.00 88.08  ? ? ? ? ? ? 316 THR A O     1 
+ATOM   3872 C CB    . THR C 3 322 ? 76.055  47.555 98.837  0.00 91.20  ? ? ? ? ? ? 316 THR A CB    1 
+ATOM   3873 O OG1   . THR C 3 322 ? 75.553  47.978 97.563  0.00 90.78  ? ? ? ? ? ? 316 THR A OG1   1 
+ATOM   3874 C CG2   . THR C 3 322 ? 74.978  46.769 99.568  0.00 89.80  ? ? ? ? ? ? 316 THR A CG2   1 
+ATOM   3875 N N     . ASN C 3 323 ? 75.686  51.022 100.258 1.00 86.31  ? ? ? ? ? ? 317 ASN A N     1 
+ATOM   3876 C CA    . ASN C 3 323 ? 74.679  52.062 100.412 1.00 86.17  ? ? ? ? ? ? 317 ASN A CA    1 
+ATOM   3877 C C     . ASN C 3 323 ? 75.033  53.305 101.277 1.00 92.53  ? ? ? ? ? ? 317 ASN A C     1 
+ATOM   3878 O O     . ASN C 3 323 ? 74.370  53.537 102.281 1.00 91.30  ? ? ? ? ? ? 317 ASN A O     1 
+ATOM   3879 C CB    . ASN C 3 323 ? 73.505  51.364 101.107 0.00 85.42  ? ? ? ? ? ? 317 ASN A CB    1 
+ATOM   3880 C CG    . ASN C 3 323 ? 72.247  52.180 101.075 0.00 100.00 ? ? ? ? ? ? 317 ASN A CG    1 
+ATOM   3881 O OD1   . ASN C 3 323 ? 71.459  52.167 102.019 0.00 94.42  ? ? ? ? ? ? 317 ASN A OD1   1 
+ATOM   3882 N ND2   . ASN C 3 323 ? 72.060  52.924 99.993  0.00 91.96  ? ? ? ? ? ? 317 ASN A ND2   1 
+ATOM   3883 N N     . VAL C 3 324 ? 76.029  54.116 100.911 1.00 91.80  ? ? ? ? ? ? 318 VAL A N     1 
+ATOM   3884 C CA    . VAL C 3 324 ? 76.501  55.318 101.671 1.00 91.44  ? ? ? ? ? ? 318 VAL A CA    1 
+ATOM   3885 C C     . VAL C 3 324 ? 75.691  56.429 102.444 1.00 92.41  ? ? ? ? ? ? 318 VAL A C     1 
+ATOM   3886 O O     . VAL C 3 324 ? 74.520  56.684 102.167 1.00 91.40  ? ? ? ? ? ? 318 VAL A O     1 
+ATOM   3887 C CB    . VAL C 3 324 ? 77.774  55.924 100.998 1.00 95.11  ? ? ? ? ? ? 318 VAL A CB    1 
+ATOM   3888 C CG1   . VAL C 3 324 ? 78.735  56.558 101.994 1.00 94.53  ? ? ? ? ? ? 318 VAL A CG1   1 
+ATOM   3889 C CG2   . VAL C 3 324 ? 78.509  54.866 100.199 1.00 94.62  ? ? ? ? ? ? 318 VAL A CG2   1 
+ATOM   3890 N N     . ASN C 3 325 ? 76.383  57.085 103.384 1.00 86.85  ? ? ? ? ? ? 319 ASN A N     1 
+ATOM   3891 C CA    . ASN C 3 325 ? 76.023  58.170 104.328 1.00 86.78  ? ? ? ? ? ? 319 ASN A CA    1 
+ATOM   3892 C C     . ASN C 3 325 ? 76.373  57.449 105.597 1.00 90.75  ? ? ? ? ? ? 319 ASN A C     1 
+ATOM   3893 O O     . ASN C 3 325 ? 76.731  58.042 106.619 1.00 92.93  ? ? ? ? ? ? 319 ASN A O     1 
+ATOM   3894 C CB    . ASN C 3 325 ? 74.562  58.623 104.448 1.00 88.07  ? ? ? ? ? ? 319 ASN A CB    1 
+ATOM   3895 C CG    . ASN C 3 325 ? 74.386  59.764 105.496 1.00 100.00 ? ? ? ? ? ? 319 ASN A CG    1 
+ATOM   3896 O OD1   . ASN C 3 325 ? 73.473  60.581 105.380 1.00 100.00 ? ? ? ? ? ? 319 ASN A OD1   1 
+ATOM   3897 N ND2   . ASN C 3 325 ? 75.278  59.839 106.485 1.00 83.94  ? ? ? ? ? ? 319 ASN A ND2   1 
+ATOM   3898 N N     . ILE C 3 326 ? 76.202  56.139 105.522 1.00 82.76  ? ? ? ? ? ? 320 ILE A N     1 
+ATOM   3899 C CA    . ILE C 3 326 ? 76.538  55.378 106.690 1.00 79.52  ? ? ? ? ? ? 320 ILE A CA    1 
+ATOM   3900 C C     . ILE C 3 326 ? 78.008  55.469 106.972 1.00 74.18  ? ? ? ? ? ? 320 ILE A C     1 
+ATOM   3901 O O     . ILE C 3 326 ? 78.396  56.208 107.871 1.00 73.28  ? ? ? ? ? ? 320 ILE A O     1 
+ATOM   3902 C CB    . ILE C 3 326 ? 75.741  54.098 106.980 1.00 82.78  ? ? ? ? ? ? 320 ILE A CB    1 
+ATOM   3903 C CG1   . ILE C 3 326 ? 74.245  54.399 106.849 1.00 83.06  ? ? ? ? ? ? 320 ILE A CG1   1 
+ATOM   3904 C CG2   . ILE C 3 326 ? 75.959  53.699 108.434 1.00 81.82  ? ? ? ? ? ? 320 ILE A CG2   1 
+ATOM   3905 C CD1   . ILE C 3 326 ? 73.753  55.446 107.834 1.00 77.02  ? ? ? ? ? ? 320 ILE A CD1   1 
+ATOM   3906 N N     . VAL C 3 327 ? 78.846  54.877 106.142 1.00 67.29  ? ? ? ? ? ? 321 VAL A N     1 
+ATOM   3907 C CA    . VAL C 3 327 ? 80.252  55.065 106.409 1.00 68.36  ? ? ? ? ? ? 321 VAL A CA    1 
+ATOM   3908 C C     . VAL C 3 327 ? 80.558  56.564 106.520 1.00 74.22  ? ? ? ? ? ? 321 VAL A C     1 
+ATOM   3909 O O     . VAL C 3 327 ? 81.536  56.962 107.140 1.00 73.58  ? ? ? ? ? ? 321 VAL A O     1 
+ATOM   3910 C CB    . VAL C 3 327 ? 81.097  54.482 105.295 1.00 72.47  ? ? ? ? ? ? 321 VAL A CB    1 
+ATOM   3911 C CG1   . VAL C 3 327 ? 82.504  54.987 105.451 1.00 71.38  ? ? ? ? ? ? 321 VAL A CG1   1 
+ATOM   3912 C CG2   . VAL C 3 327 ? 81.029  52.981 105.340 1.00 72.43  ? ? ? ? ? ? 321 VAL A CG2   1 
+ATOM   3913 N N     . MET C 3 328 ? 79.721  57.402 105.913 1.00 73.35  ? ? ? ? ? ? 322 MET A N     1 
+ATOM   3914 C CA    . MET C 3 328 ? 79.942  58.840 105.937 1.00 74.66  ? ? ? ? ? ? 322 MET A CA    1 
+ATOM   3915 C C     . MET C 3 328 ? 79.558  59.542 107.238 1.00 77.02  ? ? ? ? ? ? 322 MET A C     1 
+ATOM   3916 O O     . MET C 3 328 ? 80.255  60.452 107.677 1.00 78.78  ? ? ? ? ? ? 322 MET A O     1 
+ATOM   3917 C CB    . MET C 3 328 ? 79.260  59.488 104.733 1.00 78.95  ? ? ? ? ? ? 322 MET A CB    1 
+ATOM   3918 C CG    . MET C 3 328 ? 80.215  60.151 103.736 1.00 85.27  ? ? ? ? ? ? 322 MET A CG    1 
+ATOM   3919 S SD    . MET C 3 328 ? 81.715  59.229 103.289 1.00 91.27  ? ? ? ? ? ? 322 MET A SD    1 
+ATOM   3920 C CE    . MET C 3 328 ? 81.216  58.502 101.738 1.00 87.75  ? ? ? ? ? ? 322 MET A CE    1 
+ATOM   3921 N N     . ASN C 3 329 ? 78.458  59.130 107.857 1.00 72.56  ? ? ? ? ? ? 323 ASN A N     1 
+ATOM   3922 C CA    . ASN C 3 329 ? 78.016  59.748 109.109 1.00 73.14  ? ? ? ? ? ? 323 ASN A CA    1 
+ATOM   3923 C C     . ASN C 3 329 ? 78.988  59.312 110.219 1.00 70.56  ? ? ? ? ? ? 323 ASN A C     1 
+ATOM   3924 O O     . ASN C 3 329 ? 79.063  59.933 111.281 1.00 68.33  ? ? ? ? ? ? 323 ASN A O     1 
+ATOM   3925 C CB    . ASN C 3 329 ? 76.574  59.298 109.433 1.00 81.60  ? ? ? ? ? ? 323 ASN A CB    1 
+ATOM   3926 C CG    . ASN C 3 329 ? 75.679  60.427 109.964 0.00 100.00 ? ? ? ? ? ? 323 ASN A CG    1 
+ATOM   3927 O OD1   . ASN C 3 329 ? 74.501  60.516 109.611 0.00 94.39  ? ? ? ? ? ? 323 ASN A OD1   1 
+ATOM   3928 N ND2   . ASN C 3 329 ? 76.228  61.265 110.836 0.00 91.93  ? ? ? ? ? ? 323 ASN A ND2   1 
+ATOM   3929 N N     . TYR C 3 330 ? 79.748  58.255 109.942 1.00 63.18  ? ? ? ? ? ? 324 TYR A N     1 
+ATOM   3930 C CA    . TYR C 3 330 ? 80.687  57.701 110.919 1.00 61.33  ? ? ? ? ? ? 324 TYR A CA    1 
+ATOM   3931 C C     . TYR C 3 330 ? 82.075  58.316 110.875 1.00 68.45  ? ? ? ? ? ? 324 TYR A C     1 
+ATOM   3932 O O     . TYR C 3 330 ? 82.759  58.386 111.890 1.00 72.97  ? ? ? ? ? ? 324 TYR A O     1 
+ATOM   3933 C CB    . TYR C 3 330 ? 80.860  56.183 110.739 1.00 58.13  ? ? ? ? ? ? 324 TYR A CB    1 
+ATOM   3934 C CG    . TYR C 3 330 ? 79.632  55.347 111.020 1.00 53.73  ? ? ? ? ? ? 324 TYR A CG    1 
+ATOM   3935 C CD1   . TYR C 3 330 ? 79.586  54.002 110.674 1.00 52.26  ? ? ? ? ? ? 324 TYR A CD1   1 
+ATOM   3936 C CD2   . TYR C 3 330 ? 78.512  55.910 111.621 1.00 54.74  ? ? ? ? ? ? 324 TYR A CD2   1 
+ATOM   3937 C CE1   . TYR C 3 330 ? 78.459  53.239 110.923 1.00 52.60  ? ? ? ? ? ? 324 TYR A CE1   1 
+ATOM   3938 C CE2   . TYR C 3 330 ? 77.379  55.162 111.871 1.00 54.35  ? ? ? ? ? ? 324 TYR A CE2   1 
+ATOM   3939 C CZ    . TYR C 3 330 ? 77.356  53.826 111.522 1.00 62.65  ? ? ? ? ? ? 324 TYR A CZ    1 
+ATOM   3940 O OH    . TYR C 3 330 ? 76.213  53.095 111.789 1.00 67.57  ? ? ? ? ? ? 324 TYR A OH    1 
+ATOM   3941 N N     . ILE C 3 331 ? 82.522  58.714 109.696 1.00 60.87  ? ? ? ? ? ? 325 ILE A N     1 
+ATOM   3942 C CA    . ILE C 3 331 ? 83.863  59.246 109.575 1.00 59.03  ? ? ? ? ? ? 325 ILE A CA    1 
+ATOM   3943 C C     . ILE C 3 331 ? 83.902  60.751 109.363 1.00 67.04  ? ? ? ? ? ? 325 ILE A C     1 
+ATOM   3944 O O     . ILE C 3 331 ? 84.929  61.302 108.978 1.00 70.31  ? ? ? ? ? ? 325 ILE A O     1 
+ATOM   3945 C CB    . ILE C 3 331 ? 84.556  58.539 108.426 1.00 60.11  ? ? ? ? ? ? 325 ILE A CB    1 
+ATOM   3946 C CG1   . ILE C 3 331 ? 83.750  58.730 107.146 1.00 58.34  ? ? ? ? ? ? 325 ILE A CG1   1 
+ATOM   3947 C CG2   . ILE C 3 331 ? 84.610  57.053 108.710 1.00 61.31  ? ? ? ? ? ? 325 ILE A CG2   1 
+ATOM   3948 C CD1   . ILE C 3 331 ? 84.325  57.988 105.980 1.00 61.34  ? ? ? ? ? ? 325 ILE A CD1   1 
+ATOM   3949 N N     . ARG C 3 332 ? 82.798  61.429 109.650 1.00 63.71  ? ? ? ? ? ? 326 ARG A N     1 
+ATOM   3950 C CA    . ARG C 3 332 ? 82.692  62.876 109.449 1.00 63.95  ? ? ? ? ? ? 326 ARG A CA    1 
+ATOM   3951 C C     . ARG C 3 332 ? 83.633  63.814 110.208 1.00 68.74  ? ? ? ? ? ? 326 ARG A C     1 
+ATOM   3952 O O     . ARG C 3 332 ? 84.106  64.789 109.633 1.00 68.25  ? ? ? ? ? ? 326 ARG A O     1 
+ATOM   3953 C CB    . ARG C 3 332 ? 81.264  63.336 109.720 1.00 64.74  ? ? ? ? ? ? 326 ARG A CB    1 
+ATOM   3954 C CG    . ARG C 3 332 ? 80.983  63.351 111.214 1.00 83.83  ? ? ? ? ? ? 326 ARG A CG    1 
+ATOM   3955 C CD    . ARG C 3 332 ? 79.742  64.136 111.590 1.00 94.66  ? ? ? ? ? ? 326 ARG A CD    1 
+ATOM   3956 N NE    . ARG C 3 332 ? 78.905  63.389 112.529 1.00 100.00 ? ? ? ? ? ? 326 ARG A NE    1 
+ATOM   3957 C CZ    . ARG C 3 332 ? 77.589  63.532 112.650 1.00 100.00 ? ? ? ? ? ? 326 ARG A CZ    1 
+ATOM   3958 N NH1   . ARG C 3 332 ? 76.930  64.388 111.881 1.00 100.00 ? ? ? ? ? ? 326 ARG A NH1   1 
+ATOM   3959 N NH2   . ARG C 3 332 ? 76.937  62.796 113.540 1.00 100.00 ? ? ? ? ? ? 326 ARG A NH2   1 
+ATOM   3960 N N     . ASN C 3 333 ? 83.833  63.595 111.507 1.00 66.37  ? ? ? ? ? ? 327 ASN A N     1 
+ATOM   3961 C CA    . ASN C 3 333 ? 84.679  64.492 112.299 1.00 64.32  ? ? ? ? ? ? 327 ASN A CA    1 
+ATOM   3962 C C     . ASN C 3 333 ? 86.148  64.250 112.012 1.00 67.88  ? ? ? ? ? ? 327 ASN A C     1 
+ATOM   3963 O O     . ASN C 3 333 ? 87.012  65.034 112.399 1.00 67.35  ? ? ? ? ? ? 327 ASN A O     1 
+ATOM   3964 C CB    . ASN C 3 333 ? 84.386  64.395 113.805 1.00 60.64  ? ? ? ? ? ? 327 ASN A CB    1 
+ATOM   3965 C CG    . ASN C 3 333 ? 84.181  62.970 114.279 1.00 69.96  ? ? ? ? ? ? 327 ASN A CG    1 
+ATOM   3966 O OD1   . ASN C 3 333 ? 84.438  62.034 113.541 1.00 67.79  ? ? ? ? ? ? 327 ASN A OD1   1 
+ATOM   3967 N ND2   . ASN C 3 333 ? 83.700  62.809 115.509 1.00 68.79  ? ? ? ? ? ? 327 ASN A ND2   1 
+ATOM   3968 N N     . LEU C 3 334 ? 86.411  63.157 111.306 1.00 65.76  ? ? ? ? ? ? 328 LEU A N     1 
+ATOM   3969 C CA    . LEU C 3 334 ? 87.768  62.791 110.941 1.00 66.71  ? ? ? ? ? ? 328 LEU A CA    1 
+ATOM   3970 C C     . LEU C 3 334 ? 88.436  63.920 110.157 1.00 75.52  ? ? ? ? ? ? 328 LEU A C     1 
+ATOM   3971 O O     . LEU C 3 334 ? 87.763  64.768 109.567 1.00 79.00  ? ? ? ? ? ? 328 LEU A O     1 
+ATOM   3972 C CB    . LEU C 3 334 ? 87.752  61.488 110.138 1.00 66.31  ? ? ? ? ? ? 328 LEU A CB    1 
+ATOM   3973 C CG    . LEU C 3 334 ? 87.296  60.269 110.938 1.00 69.78  ? ? ? ? ? ? 328 LEU A CG    1 
+ATOM   3974 C CD1   . LEU C 3 334 ? 87.770  58.983 110.294 1.00 70.18  ? ? ? ? ? ? 328 LEU A CD1   1 
+ATOM   3975 C CD2   . LEU C 3 334 ? 87.947  60.393 112.280 1.00 67.33  ? ? ? ? ? ? 328 LEU A CD2   1 
+ATOM   3976 N N     . ASP C 3 335 ? 89.766  63.937 110.170 1.00 69.35  ? ? ? ? ? ? 329 ASP A N     1 
+ATOM   3977 C CA    . ASP C 3 335 ? 90.527  64.969 109.474 1.00 67.02  ? ? ? ? ? ? 329 ASP A CA    1 
+ATOM   3978 C C     . ASP C 3 335 ? 90.723  64.669 108.012 1.00 69.75  ? ? ? ? ? ? 329 ASP A C     1 
+ATOM   3979 O O     . ASP C 3 335 ? 90.927  65.583 107.215 1.00 68.23  ? ? ? ? ? ? 329 ASP A O     1 
+ATOM   3980 C CB    . ASP C 3 335 ? 91.883  65.177 110.129 1.00 67.79  ? ? ? ? ? ? 329 ASP A CB    1 
+ATOM   3981 C CG    . ASP C 3 335 ? 91.782  66.066 111.321 1.00 70.70  ? ? ? ? ? ? 329 ASP A CG    1 
+ATOM   3982 O OD1   . ASP C 3 335 ? 91.842  67.291 111.124 1.00 69.34  ? ? ? ? ? ? 329 ASP A OD1   1 
+ATOM   3983 O OD2   . ASP C 3 335 ? 91.595  65.564 112.449 1.00 82.24  ? ? ? ? ? ? 329 ASP A OD2   1 
+ATOM   3984 N N     . SER C 3 336 ? 90.672  63.388 107.663 1.00 66.84  ? ? ? ? ? ? 330 SER A N     1 
+ATOM   3985 C CA    . SER C 3 336 ? 90.853  62.953 106.286 1.00 65.19  ? ? ? ? ? ? 330 SER A CA    1 
+ATOM   3986 C C     . SER C 3 336 ? 89.628  63.320 105.473 1.00 64.78  ? ? ? ? ? ? 330 SER A C     1 
+ATOM   3987 O O     . SER C 3 336 ? 89.708  63.415 104.252 1.00 64.27  ? ? ? ? ? ? 330 SER A O     1 
+ATOM   3988 C CB    . SER C 3 336 ? 91.074  61.441 106.222 1.00 71.97  ? ? ? ? ? ? 330 SER A CB    1 
+ATOM   3989 O OG    . SER C 3 336 ? 89.995  60.738 106.821 1.00 90.09  ? ? ? ? ? ? 330 SER A OG    1 
+ATOM   3990 N N     . GLU C 3 337 ? 88.504  63.511 106.163 1.00 61.34  ? ? ? ? ? ? 331 GLU A N     1 
+ATOM   3991 C CA    . GLU C 3 337 ? 87.205  63.864 105.573 1.00 60.21  ? ? ? ? ? ? 331 GLU A CA    1 
+ATOM   3992 C C     . GLU C 3 337 ? 86.871  65.328 105.852 1.00 66.32  ? ? ? ? ? ? 331 GLU A C     1 
+ATOM   3993 O O     . GLU C 3 337 ? 85.721  65.662 106.142 1.00 68.52  ? ? ? ? ? ? 331 GLU A O     1 
+ATOM   3994 C CB    . GLU C 3 337 ? 86.106  63.003 106.199 1.00 59.96  ? ? ? ? ? ? 331 GLU A CB    1 
+ATOM   3995 C CG    . GLU C 3 337 ? 86.370  61.521 106.090 1.00 65.81  ? ? ? ? ? ? 331 GLU A CG    1 
+ATOM   3996 C CD    . GLU C 3 337 ? 86.557  61.071 104.653 1.00 82.78  ? ? ? ? ? ? 331 GLU A CD    1 
+ATOM   3997 O OE1   . GLU C 3 337 ? 85.792  61.546 103.783 1.00 66.58  ? ? ? ? ? ? 331 GLU A OE1   1 
+ATOM   3998 O OE2   . GLU C 3 337 ? 87.470  60.256 104.400 1.00 61.68  ? ? ? ? ? ? 331 GLU A OE2   1 
+ATOM   3999 N N     . THR C 3 338 ? 87.873  66.198 105.783 1.00 60.51  ? ? ? ? ? ? 332 THR A N     1 
+ATOM   4000 C CA    . THR C 3 338 ? 87.668  67.608 106.077 1.00 58.25  ? ? ? ? ? ? 332 THR A CA    1 
+ATOM   4001 C C     . THR C 3 338 ? 87.060  68.441 104.949 1.00 58.66  ? ? ? ? ? ? 332 THR A C     1 
+ATOM   4002 O O     . THR C 3 338 ? 86.451  69.486 105.176 1.00 57.11  ? ? ? ? ? ? 332 THR A O     1 
+ATOM   4003 C CB    . THR C 3 338 ? 88.949  68.253 106.582 1.00 62.53  ? ? ? ? ? ? 332 THR A CB    1 
+ATOM   4004 O OG1   . THR C 3 338 ? 88.607  69.404 107.367 1.00 67.27  ? ? ? ? ? ? 332 THR A OG1   1 
+ATOM   4005 C CG2   . THR C 3 338 ? 89.829  68.654 105.406 1.00 60.66  ? ? ? ? ? ? 332 THR A CG2   1 
+ATOM   4006 N N     . GLY C 3 339 ? 87.213  67.970 103.720 1.00 54.53  ? ? ? ? ? ? 333 GLY A N     1 
+ATOM   4007 C CA    . GLY C 3 339 ? 86.644  68.672 102.574 1.00 53.47  ? ? ? ? ? ? 333 GLY A CA    1 
+ATOM   4008 C C     . GLY C 3 339 ? 87.661  69.450 101.750 1.00 57.08  ? ? ? ? ? ? 333 GLY A C     1 
+ATOM   4009 O O     . GLY C 3 339 ? 88.744  69.766 102.239 1.00 57.02  ? ? ? ? ? ? 333 GLY A O     1 
+ATOM   4010 N N     . ALA C 3 340 ? 87.293  69.780 100.513 1.00 53.27  ? ? ? ? ? ? 334 ALA A N     1 
+ATOM   4011 C CA    . ALA C 3 340 ? 88.156  70.521 99.587  1.00 50.41  ? ? ? ? ? ? 334 ALA A CA    1 
+ATOM   4012 C C     . ALA C 3 340 ? 88.455  71.994 99.908  1.00 50.76  ? ? ? ? ? ? 334 ALA A C     1 
+ATOM   4013 O O     . ALA C 3 340 ? 89.411  72.557 99.375  1.00 49.43  ? ? ? ? ? ? 334 ALA A O     1 
+ATOM   4014 C CB    . ALA C 3 340 ? 87.636  70.391 98.157  1.00 50.51  ? ? ? ? ? ? 334 ALA A CB    1 
+ATOM   4015 N N     . MET C 3 341 ? 87.636  72.629 100.741 1.00 45.99  ? ? ? ? ? ? 335 MET A N     1 
+ATOM   4016 C CA    . MET C 3 341 ? 87.854  74.032 101.084 1.00 43.80  ? ? ? ? ? ? 335 MET A CA    1 
+ATOM   4017 C C     . MET C 3 341 ? 89.027  74.187 102.054 1.00 45.29  ? ? ? ? ? ? 335 MET A C     1 
+ATOM   4018 O O     . MET C 3 341 ? 89.844  75.098 101.924 1.00 44.44  ? ? ? ? ? ? 335 MET A O     1 
+ATOM   4019 C CB    . MET C 3 341 ? 86.581  74.629 101.692 1.00 44.78  ? ? ? ? ? ? 335 MET A CB    1 
+ATOM   4020 C CG    . MET C 3 341 ? 85.970  75.801 100.925 1.00 46.61  ? ? ? ? ? ? 335 MET A CG    1 
+ATOM   4021 S SD    . MET C 3 341 ? 86.430  75.928 99.171  1.00 49.07  ? ? ? ? ? ? 335 MET A SD    1 
+ATOM   4022 C CE    . MET C 3 341 ? 87.147  77.577 99.117  1.00 45.61  ? ? ? ? ? ? 335 MET A CE    1 
+ATOM   4023 N N     . VAL C 3 342 ? 89.105  73.274 103.019 1.00 42.78  ? ? ? ? ? ? 336 VAL A N     1 
+ATOM   4024 C CA    . VAL C 3 342 ? 90.159  73.265 104.035 1.00 42.77  ? ? ? ? ? ? 336 VAL A CA    1 
+ATOM   4025 C C     . VAL C 3 342 ? 91.465  72.978 103.331 1.00 46.84  ? ? ? ? ? ? 336 VAL A C     1 
+ATOM   4026 O O     . VAL C 3 342 ? 92.490  73.606 103.587 1.00 47.01  ? ? ? ? ? ? 336 VAL A O     1 
+ATOM   4027 C CB    . VAL C 3 342 ? 89.952  72.124 105.050 1.00 45.63  ? ? ? ? ? ? 336 VAL A CB    1 
+ATOM   4028 C CG1   . VAL C 3 342 ? 91.292  71.653 105.585 1.00 46.62  ? ? ? ? ? ? 336 VAL A CG1   1 
+ATOM   4029 C CG2   . VAL C 3 342 ? 89.044  72.563 106.192 1.00 44.21  ? ? ? ? ? ? 336 VAL A CG2   1 
+ATOM   4030 N N     . ARG C 3 343 ? 91.388  72.026 102.413 1.00 43.64  ? ? ? ? ? ? 337 ARG A N     1 
+ATOM   4031 C CA    . ARG C 3 343 ? 92.519  71.645 101.593 1.00 44.11  ? ? ? ? ? ? 337 ARG A CA    1 
+ATOM   4032 C C     . ARG C 3 343 ? 93.053  72.811 100.743 1.00 48.94  ? ? ? ? ? ? 337 ARG A C     1 
+ATOM   4033 O O     . ARG C 3 343 ? 94.259  72.983 100.596 1.00 50.23  ? ? ? ? ? ? 337 ARG A O     1 
+ATOM   4034 C CB    . ARG C 3 343 ? 92.103  70.488 100.699 1.00 44.39  ? ? ? ? ? ? 337 ARG A CB    1 
+ATOM   4035 C CG    . ARG C 3 343 ? 93.266  69.734 100.130 1.00 62.17  ? ? ? ? ? ? 337 ARG A CG    1 
+ATOM   4036 C CD    . ARG C 3 343 ? 92.839  68.315 99.869  1.00 73.47  ? ? ? ? ? ? 337 ARG A CD    1 
+ATOM   4037 N NE    . ARG C 3 343 ? 91.862  68.321 98.793  1.00 79.17  ? ? ? ? ? ? 337 ARG A NE    1 
+ATOM   4038 C CZ    . ARG C 3 343 ? 90.648  67.794 98.882  1.00 77.64  ? ? ? ? ? ? 337 ARG A CZ    1 
+ATOM   4039 N NH1   . ARG C 3 343 ? 90.246  67.211 99.997  1.00 53.77  ? ? ? ? ? ? 337 ARG A NH1   1 
+ATOM   4040 N NH2   . ARG C 3 343 ? 89.833  67.860 97.844  1.00 56.42  ? ? ? ? ? ? 337 ARG A NH2   1 
+ATOM   4041 N N     . LEU C 3 344 ? 92.158  73.616 100.180 1.00 43.17  ? ? ? ? ? ? 338 LEU A N     1 
+ATOM   4042 C CA    . LEU C 3 344 ? 92.560  74.754 99.366  1.00 43.52  ? ? ? ? ? ? 338 LEU A CA    1 
+ATOM   4043 C C     . LEU C 3 344 ? 93.057  75.895 100.236 1.00 45.57  ? ? ? ? ? ? 338 LEU A C     1 
+ATOM   4044 O O     . LEU C 3 344 ? 94.020  76.575 99.892  1.00 45.57  ? ? ? ? ? ? 338 LEU A O     1 
+ATOM   4045 C CB    . LEU C 3 344 ? 91.356  75.282 98.584  1.00 45.67  ? ? ? ? ? ? 338 LEU A CB    1 
+ATOM   4046 C CG    . LEU C 3 344 ? 90.892  74.572 97.317  1.00 51.78  ? ? ? ? ? ? 338 LEU A CG    1 
+ATOM   4047 C CD1   . LEU C 3 344 ? 90.557  75.623 96.275  1.00 50.25  ? ? ? ? ? ? 338 LEU A CD1   1 
+ATOM   4048 C CD2   . LEU C 3 344 ? 92.015  73.676 96.824  1.00 61.13  ? ? ? ? ? ? 338 LEU A CD2   1 
+ATOM   4049 N N     . LEU C 3 345 ? 92.362  76.155 101.337 1.00 42.55  ? ? ? ? ? ? 339 LEU A N     1 
+ATOM   4050 C CA    . LEU C 3 345 ? 92.759  77.251 102.224 1.00 41.69  ? ? ? ? ? ? 339 LEU A CA    1 
+ATOM   4051 C C     . LEU C 3 345 ? 94.137  76.958 102.828 1.00 45.90  ? ? ? ? ? ? 339 LEU A C     1 
+ATOM   4052 O O     . LEU C 3 345 ? 94.944  77.857 103.086 1.00 44.61  ? ? ? ? ? ? 339 LEU A O     1 
+ATOM   4053 C CB    . LEU C 3 345 ? 91.722  77.480 103.333 1.00 39.10  ? ? ? ? ? ? 339 LEU A CB    1 
+ATOM   4054 C CG    . LEU C 3 345 ? 90.431  78.231 102.993 1.00 37.22  ? ? ? ? ? ? 339 LEU A CG    1 
+ATOM   4055 C CD1   . LEU C 3 345 ? 89.362  77.861 104.003 1.00 34.92  ? ? ? ? ? ? 339 LEU A CD1   1 
+ATOM   4056 C CD2   . LEU C 3 345 ? 90.668  79.725 102.996 1.00 35.77  ? ? ? ? ? ? 339 LEU A CD2   1 
+ATOM   4057 N N     . GLU C 3 346 ? 94.414  75.681 103.034 1.00 40.29  ? ? ? ? ? ? 340 GLU A N     1 
+ATOM   4058 C CA    . GLU C 3 346 ? 95.687  75.281 103.591 1.00 37.17  ? ? ? ? ? ? 340 GLU A CA    1 
+ATOM   4059 C C     . GLU C 3 346 ? 96.721  74.972 102.522 1.00 50.92  ? ? ? ? ? ? 340 GLU A C     1 
+ATOM   4060 O O     . GLU C 3 346 ? 97.656  74.227 102.813 1.00 56.94  ? ? ? ? ? ? 340 GLU A O     1 
+ATOM   4061 C CB    . GLU C 3 346 ? 95.476  74.068 104.483 1.00 35.73  ? ? ? ? ? ? 340 GLU A CB    1 
+ATOM   4062 C CG    . GLU C 3 346 ? 94.678  74.453 105.698 1.00 29.11  ? ? ? ? ? ? 340 GLU A CG    1 
+ATOM   4063 C CD    . GLU C 3 346 ? 94.435  73.304 106.631 1.00 47.85  ? ? ? ? ? ? 340 GLU A CD    1 
+ATOM   4064 O OE1   . GLU C 3 346 ? 94.968  72.208 106.389 1.00 41.26  ? ? ? ? ? ? 340 GLU A OE1   1 
+ATOM   4065 O OE2   . GLU C 3 346 ? 93.721  73.526 107.626 1.00 46.80  ? ? ? ? ? ? 340 GLU A OE2   1 
+ATOM   4066 N N     . ASP C 3 347 ? 96.524  75.532 101.323 1.00 48.11  ? ? ? ? ? ? 341 ASP A N     1 
+ATOM   4067 C CA    . ASP C 3 347 ? 97.363  75.380 100.124 1.00 61.21  ? ? ? ? ? ? 341 ASP A CA    1 
+ATOM   4068 C C     . ASP C 3 347 ? 96.753  74.475 99.071  1.00 100.00 ? ? ? ? ? ? 341 ASP A C     1 
+ATOM   4069 O O     . ASP C 3 347 ? 97.487  73.758 98.388  1.00 100.00 ? ? ? ? ? ? 341 ASP A O     1 
+ATOM   4070 C CB    . ASP C 3 347 ? 98.792  74.898 100.386 1.00 63.80  ? ? ? ? ? ? 341 ASP A CB    1 
+ATOM   4071 C CG    . ASP C 3 347 ? 99.816  75.989 100.204 1.00 94.75  ? ? ? ? ? ? 341 ASP A CG    1 
+ATOM   4072 O OD1   . ASP C 3 347 ? 100.027 76.791 101.139 1.00 100.00 ? ? ? ? ? ? 341 ASP A OD1   1 
+ATOM   4073 O OD2   . ASP C 3 347 ? 100.418 76.047 99.114  1.00 100.00 ? ? ? ? ? ? 341 ASP A OD2   1 
+ATOM   4074 N N     . THR D 3 25  ? 34.292  47.507 80.892  1.00 80.87  ? ? ? ? ? ? 19  THR B N     1 
+ATOM   4075 C CA    . THR D 3 25  ? 33.395  46.374 81.048  1.00 79.50  ? ? ? ? ? ? 19  THR B CA    1 
+ATOM   4076 C C     . THR D 3 25  ? 33.386  45.459 79.805  1.00 81.97  ? ? ? ? ? ? 19  THR B C     1 
+ATOM   4077 O O     . THR D 3 25  ? 33.570  45.981 78.709  1.00 83.21  ? ? ? ? ? ? 19  THR B O     1 
+ATOM   4078 C CB    . THR D 3 25  ? 31.985  46.886 81.449  1.00 92.22  ? ? ? ? ? ? 19  THR B CB    1 
+ATOM   4079 O OG1   . THR D 3 25  ? 31.489  47.796 80.455  1.00 94.08  ? ? ? ? ? ? 19  THR B OG1   1 
+ATOM   4080 C CG2   . THR D 3 25  ? 32.058  47.605 82.790  1.00 91.06  ? ? ? ? ? ? 19  THR B CG2   1 
+ATOM   4081 N N     . SER D 3 26  ? 33.278  44.139 79.995  1.00 76.20  ? ? ? ? ? ? 20  SER B N     1 
+ATOM   4082 C CA    . SER D 3 26  ? 33.218  43.135 78.934  1.00 74.85  ? ? ? ? ? ? 20  SER B CA    1 
+ATOM   4083 C C     . SER D 3 26  ? 33.583  43.593 77.520  1.00 76.11  ? ? ? ? ? ? 20  SER B C     1 
+ATOM   4084 O O     . SER D 3 26  ? 34.442  42.988 76.884  1.00 74.98  ? ? ? ? ? ? 20  SER B O     1 
+ATOM   4085 C CB    . SER D 3 26  ? 31.813  42.536 78.931  1.00 79.26  ? ? ? ? ? ? 20  SER B CB    1 
+ATOM   4086 O OG    . SER D 3 26  ? 31.764  41.318 78.216  1.00 94.44  ? ? ? ? ? ? 20  SER B OG    1 
+ATOM   4087 N N     . ASP D 3 27  ? 32.904  44.624 77.015  1.00 72.64  ? ? ? ? ? ? 21  ASP B N     1 
+ATOM   4088 C CA    . ASP D 3 27  ? 33.164  45.180 75.684  1.00 71.36  ? ? ? ? ? ? 21  ASP B CA    1 
+ATOM   4089 C C     . ASP D 3 27  ? 34.519  45.875 75.694  1.00 71.67  ? ? ? ? ? ? 21  ASP B C     1 
+ATOM   4090 O O     . ASP D 3 27  ? 35.351  45.691 74.803  1.00 72.88  ? ? ? ? ? ? 21  ASP B O     1 
+ATOM   4091 C CB    . ASP D 3 27  ? 32.067  46.180 75.289  1.00 74.03  ? ? ? ? ? ? 21  ASP B CB    1 
+ATOM   4092 C CG    . ASP D 3 27  ? 30.807  45.493 74.780  1.00 88.84  ? ? ? ? ? ? 21  ASP B CG    1 
+ATOM   4093 O OD1   . ASP D 3 27  ? 30.928  44.526 73.999  1.00 87.09  ? ? ? ? ? ? 21  ASP B OD1   1 
+ATOM   4094 O OD2   . ASP D 3 27  ? 29.696  45.913 75.170  1.00 100.00 ? ? ? ? ? ? 21  ASP B OD2   1 
+ATOM   4095 N N     . GLU D 3 28  ? 34.702  46.673 76.744  1.00 63.94  ? ? ? ? ? ? 22  GLU B N     1 
+ATOM   4096 C CA    . GLU D 3 28  ? 35.910  47.451 77.047  1.00 63.30  ? ? ? ? ? ? 22  GLU B CA    1 
+ATOM   4097 C C     . GLU D 3 28  ? 37.165  46.568 77.241  1.00 70.76  ? ? ? ? ? ? 22  GLU B C     1 
+ATOM   4098 O O     . GLU D 3 28  ? 38.276  46.950 76.852  1.00 73.89  ? ? ? ? ? ? 22  GLU B O     1 
+ATOM   4099 C CB    . GLU D 3 28  ? 35.646  48.298 78.309  1.00 64.37  ? ? ? ? ? ? 22  GLU B CB    1 
+ATOM   4100 C CG    . GLU D 3 28  ? 36.089  49.768 78.311  0.00 74.87  ? ? ? ? ? ? 22  GLU B CG    1 
+ATOM   4101 C CD    . GLU D 3 28  ? 35.621  50.526 79.557  0.00 95.22  ? ? ? ? ? ? 22  GLU B CD    1 
+ATOM   4102 O OE1   . GLU D 3 28  ? 34.536  50.195 80.085  0.00 89.49  ? ? ? ? ? ? 22  GLU B OE1   1 
+ATOM   4103 O OE2   . GLU D 3 28  ? 36.333  51.448 80.002  0.00 89.23  ? ? ? ? ? ? 22  GLU B OE2   1 
+ATOM   4104 N N     . VAL D 3 29  ? 36.968  45.387 77.835  1.00 62.88  ? ? ? ? ? ? 23  VAL B N     1 
+ATOM   4105 C CA    . VAL D 3 29  ? 38.028  44.419 78.090  1.00 60.04  ? ? ? ? ? ? 23  VAL B CA    1 
+ATOM   4106 C C     . VAL D 3 29  ? 38.421  43.780 76.774  1.00 61.97  ? ? ? ? ? ? 23  VAL B C     1 
+ATOM   4107 O O     . VAL D 3 29  ? 39.604  43.658 76.477  1.00 62.81  ? ? ? ? ? ? 23  VAL B O     1 
+ATOM   4108 C CB    . VAL D 3 29  ? 37.633  43.347 79.122  1.00 62.42  ? ? ? ? ? ? 23  VAL B CB    1 
+ATOM   4109 C CG1   . VAL D 3 29  ? 38.568  42.155 79.022  1.00 62.47  ? ? ? ? ? ? 23  VAL B CG1   1 
+ATOM   4110 C CG2   . VAL D 3 29  ? 37.701  43.946 80.513  1.00 61.05  ? ? ? ? ? ? 23  VAL B CG2   1 
+ATOM   4111 N N     . ARG D 3 30  ? 37.422  43.410 75.980  1.00 57.20  ? ? ? ? ? ? 24  ARG B N     1 
+ATOM   4112 C CA    . ARG D 3 30  ? 37.644  42.803 74.679  1.00 56.38  ? ? ? ? ? ? 24  ARG B CA    1 
+ATOM   4113 C C     . ARG D 3 30  ? 38.392  43.820 73.820  1.00 61.00  ? ? ? ? ? ? 24  ARG B C     1 
+ATOM   4114 O O     . ARG D 3 30  ? 39.210  43.444 72.986  1.00 63.98  ? ? ? ? ? ? 24  ARG B O     1 
+ATOM   4115 C CB    . ARG D 3 30  ? 36.298  42.441 74.037  1.00 56.05  ? ? ? ? ? ? 24  ARG B CB    1 
+ATOM   4116 C CG    . ARG D 3 30  ? 36.303  41.174 73.193  1.00 75.52  ? ? ? ? ? ? 24  ARG B CG    1 
+ATOM   4117 C CD    . ARG D 3 30  ? 35.648  41.408 71.834  1.00 91.02  ? ? ? ? ? ? 24  ARG B CD    1 
+ATOM   4118 N NE    . ARG D 3 30  ? 34.207  41.634 71.937  1.00 96.37  ? ? ? ? ? ? 24  ARG B NE    1 
+ATOM   4119 C CZ    . ARG D 3 30  ? 33.622  42.819 71.781  1.00 100.00 ? ? ? ? ? ? 24  ARG B CZ    1 
+ATOM   4120 N NH1   . ARG D 3 30  ? 34.352  43.893 71.529  1.00 100.00 ? ? ? ? ? ? 24  ARG B NH1   1 
+ATOM   4121 N NH2   . ARG D 3 30  ? 32.304  42.923 71.888  1.00 100.00 ? ? ? ? ? ? 24  ARG B NH2   1 
+ATOM   4122 N N     . LYS D 3 31  ? 38.140  45.108 74.028  1.00 53.49  ? ? ? ? ? ? 25  LYS B N     1 
+ATOM   4123 C CA    . LYS D 3 31  ? 38.819  46.097 73.210  1.00 51.69  ? ? ? ? ? ? 25  LYS B CA    1 
+ATOM   4124 C C     . LYS D 3 31  ? 40.216  46.459 73.650  1.00 54.76  ? ? ? ? ? ? 25  LYS B C     1 
+ATOM   4125 O O     . LYS D 3 31  ? 41.071  46.753 72.816  1.00 52.34  ? ? ? ? ? ? 25  LYS B O     1 
+ATOM   4126 C CB    . LYS D 3 31  ? 38.003  47.364 73.039  1.00 54.15  ? ? ? ? ? ? 25  LYS B CB    1 
+ATOM   4127 C CG    . LYS D 3 31  ? 38.711  48.332 72.121  1.00 52.33  ? ? ? ? ? ? 25  LYS B CG    1 
+ATOM   4128 C CD    . LYS D 3 31  ? 38.567  49.760 72.576  1.00 61.15  ? ? ? ? ? ? 25  LYS B CD    1 
+ATOM   4129 C CE    . LYS D 3 31  ? 38.816  50.684 71.402  1.00 76.95  ? ? ? ? ? ? 25  LYS B CE    1 
+ATOM   4130 N NZ    . LYS D 3 31  ? 40.138  51.351 71.473  1.00 86.53  ? ? ? ? ? ? 25  LYS B NZ    1 
+ATOM   4131 N N     . ASN D 3 32  ? 40.414  46.461 74.965  1.00 52.72  ? ? ? ? ? ? 26  ASN B N     1 
+ATOM   4132 C CA    . ASN D 3 32  ? 41.696  46.765 75.582  1.00 51.96  ? ? ? ? ? ? 26  ASN B CA    1 
+ATOM   4133 C C     . ASN D 3 32  ? 42.634  45.624 75.216  1.00 58.64  ? ? ? ? ? ? 26  ASN B C     1 
+ATOM   4134 O O     . ASN D 3 32  ? 43.695  45.839 74.631  1.00 59.04  ? ? ? ? ? ? 26  ASN B O     1 
+ATOM   4135 C CB    . ASN D 3 32  ? 41.497  46.943 77.085  1.00 42.96  ? ? ? ? ? ? 26  ASN B CB    1 
+ATOM   4136 C CG    . ASN D 3 32  ? 40.896  48.288 77.397  1.00 50.37  ? ? ? ? ? ? 26  ASN B CG    1 
+ATOM   4137 O OD1   . ASN D 3 32  ? 40.127  48.465 78.342  1.00 56.16  ? ? ? ? ? ? 26  ASN B OD1   1 
+ATOM   4138 N ND2   . ASN D 3 32  ? 41.236  49.259 76.564  1.00 40.77  ? ? ? ? ? ? 26  ASN B ND2   1 
+ATOM   4139 N N     . LEU D 3 33  ? 42.175  44.400 75.449  1.00 55.24  ? ? ? ? ? ? 27  LEU B N     1 
+ATOM   4140 C CA    . LEU D 3 33  ? 42.950  43.226 75.084  1.00 54.29  ? ? ? ? ? ? 27  LEU B CA    1 
+ATOM   4141 C C     . LEU D 3 33  ? 43.200  43.277 73.587  1.00 59.04  ? ? ? ? ? ? 27  LEU B C     1 
+ATOM   4142 O O     . LEU D 3 33  ? 44.333  43.135 73.146  1.00 61.43  ? ? ? ? ? ? 27  LEU B O     1 
+ATOM   4143 C CB    . LEU D 3 33  ? 42.219  41.931 75.446  1.00 54.15  ? ? ? ? ? ? 27  LEU B CB    1 
+ATOM   4144 C CG    . LEU D 3 33  ? 42.905  41.132 76.556  1.00 59.92  ? ? ? ? ? ? 27  LEU B CG    1 
+ATOM   4145 C CD1   . LEU D 3 33  ? 43.495  42.096 77.576  1.00 60.04  ? ? ? ? ? ? 27  LEU B CD1   1 
+ATOM   4146 C CD2   . LEU D 3 33  ? 41.938  40.175 77.239  1.00 65.12  ? ? ? ? ? ? 27  LEU B CD2   1 
+ATOM   4147 N N     . MET D 3 34  ? 42.148  43.508 72.803  1.00 53.21  ? ? ? ? ? ? 28  MET B N     1 
+ATOM   4148 C CA    . MET D 3 34  ? 42.280  43.569 71.349  1.00 50.92  ? ? ? ? ? ? 28  MET B CA    1 
+ATOM   4149 C C     . MET D 3 34  ? 43.248  44.661 70.933  1.00 53.82  ? ? ? ? ? ? 28  MET B C     1 
+ATOM   4150 O O     . MET D 3 34  ? 44.071  44.468 70.042  1.00 53.47  ? ? ? ? ? ? 28  MET B O     1 
+ATOM   4151 C CB    . MET D 3 34  ? 40.926  43.775 70.672  0.00 53.13  ? ? ? ? ? ? 28  MET B CB    1 
+ATOM   4152 C CG    . MET D 3 34  ? 40.600  42.713 69.636  0.00 56.65  ? ? ? ? ? ? 28  MET B CG    1 
+ATOM   4153 S SD    . MET D 3 34  ? 38.943  42.037 69.838  0.00 60.79  ? ? ? ? ? ? 28  MET B SD    1 
+ATOM   4154 C CE    . MET D 3 34  ? 37.948  43.487 69.501  0.00 57.52  ? ? ? ? ? ? 28  MET B CE    1 
+ATOM   4155 N N     . ASP D 3 35  ? 43.168  45.804 71.597  1.00 49.89  ? ? ? ? ? ? 29  ASP B N     1 
+ATOM   4156 C CA    . ASP D 3 35  ? 44.063  46.898 71.261  1.00 51.32  ? ? ? ? ? ? 29  ASP B CA    1 
+ATOM   4157 C C     . ASP D 3 35  ? 45.509  46.507 71.550  1.00 59.81  ? ? ? ? ? ? 29  ASP B C     1 
+ATOM   4158 O O     . ASP D 3 35  ? 46.458  47.039 70.972  1.00 62.41  ? ? ? ? ? ? 29  ASP B O     1 
+ATOM   4159 C CB    . ASP D 3 35  ? 43.674  48.134 72.062  1.00 52.66  ? ? ? ? ? ? 29  ASP B CB    1 
+ATOM   4160 C CG    . ASP D 3 35  ? 42.535  48.905 71.429  1.00 55.77  ? ? ? ? ? ? 29  ASP B CG    1 
+ATOM   4161 O OD1   . ASP D 3 35  ? 42.128  48.592 70.288  1.00 56.23  ? ? ? ? ? ? 29  ASP B OD1   1 
+ATOM   4162 O OD2   . ASP D 3 35  ? 42.047  49.836 72.092  1.00 61.98  ? ? ? ? ? ? 29  ASP B OD2   1 
+ATOM   4163 N N     . MET D 3 36  ? 45.673  45.567 72.468  1.00 56.00  ? ? ? ? ? ? 30  MET B N     1 
+ATOM   4164 C CA    . MET D 3 36  ? 47.007  45.142 72.823  1.00 54.79  ? ? ? ? ? ? 30  MET B CA    1 
+ATOM   4165 C C     . MET D 3 36  ? 47.550  44.211 71.749  1.00 58.03  ? ? ? ? ? ? 30  MET B C     1 
+ATOM   4166 O O     . MET D 3 36  ? 48.696  44.349 71.323  1.00 56.93  ? ? ? ? ? ? 30  MET B O     1 
+ATOM   4167 C CB    . MET D 3 36  ? 46.988  44.451 74.181  1.00 57.29  ? ? ? ? ? ? 30  MET B CB    1 
+ATOM   4168 C CG    . MET D 3 36  ? 48.375  44.169 74.715  1.00 62.15  ? ? ? ? ? ? 30  MET B CG    1 
+ATOM   4169 S SD    . MET D 3 36  ? 48.439  43.850 76.489  1.00 66.90  ? ? ? ? ? ? 30  MET B SD    1 
+ATOM   4170 C CE    . MET D 3 36  ? 47.720  42.205 76.571  1.00 63.90  ? ? ? ? ? ? 30  MET B CE    1 
+ATOM   4171 N N     . PHE D 3 37  ? 46.722  43.271 71.301  1.00 55.16  ? ? ? ? ? ? 31  PHE B N     1 
+ATOM   4172 C CA    . PHE D 3 37  ? 47.140  42.327 70.274  1.00 54.65  ? ? ? ? ? ? 31  PHE B CA    1 
+ATOM   4173 C C     . PHE D 3 37  ? 47.425  42.975 68.927  1.00 55.76  ? ? ? ? ? ? 31  PHE B C     1 
+ATOM   4174 O O     . PHE D 3 37  ? 48.222  42.465 68.145  1.00 56.77  ? ? ? ? ? ? 31  PHE B O     1 
+ATOM   4175 C CB    . PHE D 3 37  ? 46.140  41.186 70.104  1.00 57.47  ? ? ? ? ? ? 31  PHE B CB    1 
+ATOM   4176 C CG    . PHE D 3 37  ? 46.357  40.398 68.847  1.00 61.55  ? ? ? ? ? ? 31  PHE B CG    1 
+ATOM   4177 C CD1   . PHE D 3 37  ? 47.272  39.357 68.818  1.00 66.70  ? ? ? ? ? ? 31  PHE B CD1   1 
+ATOM   4178 C CD2   . PHE D 3 37  ? 45.690  40.731 67.682  1.00 66.64  ? ? ? ? ? ? 31  PHE B CD2   1 
+ATOM   4179 C CE1   . PHE D 3 37  ? 47.501  38.645 67.658  1.00 69.31  ? ? ? ? ? ? 31  PHE B CE1   1 
+ATOM   4180 C CE2   . PHE D 3 37  ? 45.910  40.022 66.518  1.00 71.69  ? ? ? ? ? ? 31  PHE B CE2   1 
+ATOM   4181 C CZ    . PHE D 3 37  ? 46.819  38.975 66.506  1.00 70.44  ? ? ? ? ? ? 31  PHE B CZ    1 
+ATOM   4182 N N     . ARG D 3 38  ? 46.765  44.093 68.655  1.00 50.45  ? ? ? ? ? ? 32  ARG B N     1 
+ATOM   4183 C CA    . ARG D 3 38  ? 46.974  44.776 67.391  1.00 49.77  ? ? ? ? ? ? 32  ARG B CA    1 
+ATOM   4184 C C     . ARG D 3 38  ? 48.403  45.286 67.310  1.00 53.16  ? ? ? ? ? ? 32  ARG B C     1 
+ATOM   4185 O O     . ARG D 3 38  ? 49.116  45.001 66.349  1.00 54.14  ? ? ? ? ? ? 32  ARG B O     1 
+ATOM   4186 C CB    . ARG D 3 38  ? 45.993  45.935 67.223  1.00 51.52  ? ? ? ? ? ? 32  ARG B CB    1 
+ATOM   4187 C CG    . ARG D 3 38  ? 45.864  46.395 65.783  1.00 47.98  ? ? ? ? ? ? 32  ARG B CG    1 
+ATOM   4188 C CD    . ARG D 3 38  ? 44.948  47.587 65.658  1.00 38.88  ? ? ? ? ? ? 32  ARG B CD    1 
+ATOM   4189 N NE    . ARG D 3 38  ? 44.947  48.406 66.864  1.00 44.60  ? ? ? ? ? ? 32  ARG B NE    1 
+ATOM   4190 C CZ    . ARG D 3 38  ? 44.140  49.445 67.035  1.00 65.43  ? ? ? ? ? ? 32  ARG B CZ    1 
+ATOM   4191 N NH1   . ARG D 3 38  ? 43.285  49.776 66.075  1.00 44.95  ? ? ? ? ? ? 32  ARG B NH1   1 
+ATOM   4192 N NH2   . ARG D 3 38  ? 44.193  50.146 68.161  1.00 55.42  ? ? ? ? ? ? 32  ARG B NH2   1 
+ATOM   4193 N N     . ASP D 3 39  ? 48.820  46.060 68.306  1.00 49.17  ? ? ? ? ? ? 33  ASP B N     1 
+ATOM   4194 C CA    . ASP D 3 39  ? 50.169  46.616 68.321  1.00 48.87  ? ? ? ? ? ? 33  ASP B CA    1 
+ATOM   4195 C C     . ASP D 3 39  ? 51.084  45.779 69.206  1.00 51.96  ? ? ? ? ? ? 33  ASP B C     1 
+ATOM   4196 O O     . ASP D 3 39  ? 51.725  46.290 70.132  1.00 46.60  ? ? ? ? ? ? 33  ASP B O     1 
+ATOM   4197 C CB    . ASP D 3 39  ? 50.160  48.065 68.805  1.00 51.47  ? ? ? ? ? ? 33  ASP B CB    1 
+ATOM   4198 C CG    . ASP D 3 39  ? 49.660  49.030 67.749  1.00 59.85  ? ? ? ? ? ? 33  ASP B CG    1 
+ATOM   4199 O OD1   . ASP D 3 39  ? 50.131  48.952 66.595  1.00 61.42  ? ? ? ? ? ? 33  ASP B OD1   1 
+ATOM   4200 O OD2   . ASP D 3 39  ? 48.785  49.862 68.070  1.00 67.72  ? ? ? ? ? ? 33  ASP B OD2   1 
+ATOM   4201 N N     . ARG D 3 40  ? 51.121  44.485 68.886  1.00 54.68  ? ? ? ? ? ? 34  ARG B N     1 
+ATOM   4202 C CA    . ARG D 3 40  ? 51.924  43.458 69.561  1.00 54.54  ? ? ? ? ? ? 34  ARG B CA    1 
+ATOM   4203 C C     . ARG D 3 40  ? 53.372  43.915 69.712  1.00 54.95  ? ? ? ? ? ? 34  ARG B C     1 
+ATOM   4204 O O     . ARG D 3 40  ? 54.011  43.707 70.745  1.00 51.10  ? ? ? ? ? ? 34  ARG B O     1 
+ATOM   4205 C CB    . ARG D 3 40  ? 51.981  42.199 68.687  1.00 51.59  ? ? ? ? ? ? 34  ARG B CB    1 
+ATOM   4206 C CG    . ARG D 3 40  ? 50.931  41.147 68.945  1.00 58.30  ? ? ? ? ? ? 34  ARG B CG    1 
+ATOM   4207 C CD    . ARG D 3 40  ? 51.060  40.064 67.885  1.00 83.16  ? ? ? ? ? ? 34  ARG B CD    1 
+ATOM   4208 N NE    . ARG D 3 40  ? 50.136  40.211 66.760  1.00 92.91  ? ? ? ? ? ? 34  ARG B NE    1 
+ATOM   4209 C CZ    . ARG D 3 40  ? 50.473  40.064 65.480  1.00 100.00 ? ? ? ? ? ? 34  ARG B CZ    1 
+ATOM   4210 N NH1   . ARG D 3 40  ? 51.728  39.787 65.140  1.00 100.00 ? ? ? ? ? ? 34  ARG B NH1   1 
+ATOM   4211 N NH2   . ARG D 3 40  ? 49.548  40.202 64.540  1.00 95.00  ? ? ? ? ? ? 34  ARG B NH2   1 
+ATOM   4212 N N     . GLN D 3 41  ? 53.884  44.503 68.637  1.00 51.14  ? ? ? ? ? ? 35  GLN B N     1 
+ATOM   4213 C CA    . GLN D 3 41  ? 55.259  44.963 68.552  1.00 49.76  ? ? ? ? ? ? 35  GLN B CA    1 
+ATOM   4214 C C     . GLN D 3 41  ? 55.670  45.946 69.615  1.00 52.40  ? ? ? ? ? ? 35  GLN B C     1 
+ATOM   4215 O O     . GLN D 3 41  ? 56.858  46.115 69.855  1.00 54.98  ? ? ? ? ? ? 35  GLN B O     1 
+ATOM   4216 C CB    . GLN D 3 41  ? 55.522  45.581 67.186  1.00 52.61  ? ? ? ? ? ? 35  GLN B CB    1 
+ATOM   4217 C CG    . GLN D 3 41  ? 55.260  44.625 66.047  1.00 82.07  ? ? ? ? ? ? 35  GLN B CG    1 
+ATOM   4218 C CD    . GLN D 3 41  ? 56.394  43.646 65.854  1.00 100.00 ? ? ? ? ? ? 35  GLN B CD    1 
+ATOM   4219 O OE1   . GLN D 3 41  ? 57.154  43.734 64.887  1.00 97.54  ? ? ? ? ? ? 35  GLN B OE1   1 
+ATOM   4220 N NE2   . GLN D 3 41  ? 56.538  42.704 66.783  1.00 100.00 ? ? ? ? ? ? 35  GLN B NE2   1 
+ATOM   4221 N N     . ALA D 3 42  ? 54.706  46.617 70.230  1.00 47.22  ? ? ? ? ? ? 36  ALA B N     1 
+ATOM   4222 C CA    . ALA D 3 42  ? 54.997  47.588 71.280  1.00 44.78  ? ? ? ? ? ? 36  ALA B CA    1 
+ATOM   4223 C C     . ALA D 3 42  ? 55.874  46.983 72.382  1.00 46.24  ? ? ? ? ? ? 36  ALA B C     1 
+ATOM   4224 O O     . ALA D 3 42  ? 56.629  47.692 73.051  1.00 47.34  ? ? ? ? ? ? 36  ALA B O     1 
+ATOM   4225 C CB    . ALA D 3 42  ? 53.697  48.127 71.862  1.00 45.01  ? ? ? ? ? ? 36  ALA B CB    1 
+ATOM   4226 N N     . PHE D 3 43  ? 55.762  45.673 72.583  1.00 41.56  ? ? ? ? ? ? 37  PHE B N     1 
+ATOM   4227 C CA    . PHE D 3 43  ? 56.548  44.998 73.612  1.00 43.65  ? ? ? ? ? ? 37  PHE B CA    1 
+ATOM   4228 C C     . PHE D 3 43  ? 57.447  43.916 73.015  1.00 46.53  ? ? ? ? ? ? 37  PHE B C     1 
+ATOM   4229 O O     . PHE D 3 43  ? 57.254  43.490 71.874  1.00 47.26  ? ? ? ? ? ? 37  PHE B O     1 
+ATOM   4230 C CB    . PHE D 3 43  ? 55.661  44.354 74.693  1.00 47.43  ? ? ? ? ? ? 37  PHE B CB    1 
+ATOM   4231 C CG    . PHE D 3 43  ? 54.376  45.088 74.973  1.00 49.38  ? ? ? ? ? ? 37  PHE B CG    1 
+ATOM   4232 C CD1   . PHE D 3 43  ? 53.270  44.901 74.157  1.00 52.13  ? ? ? ? ? ? 37  PHE B CD1   1 
+ATOM   4233 C CD2   . PHE D 3 43  ? 54.266  45.939 76.061  1.00 50.38  ? ? ? ? ? ? 37  PHE B CD2   1 
+ATOM   4234 C CE1   . PHE D 3 43  ? 52.088  45.568 74.400  1.00 54.16  ? ? ? ? ? ? 37  PHE B CE1   1 
+ATOM   4235 C CE2   . PHE D 3 43  ? 53.088  46.604 76.307  1.00 51.98  ? ? ? ? ? ? 37  PHE B CE2   1 
+ATOM   4236 C CZ    . PHE D 3 43  ? 52.002  46.428 75.469  1.00 52.24  ? ? ? ? ? ? 37  PHE B CZ    1 
+ATOM   4237 N N     . SER D 3 44  ? 58.394  43.441 73.822  1.00 40.31  ? ? ? ? ? ? 38  SER B N     1 
+ATOM   4238 C CA    . SER D 3 44  ? 59.317  42.393 73.398  1.00 37.93  ? ? ? ? ? ? 38  SER B CA    1 
+ATOM   4239 C C     . SER D 3 44  ? 58.606  41.099 73.077  1.00 40.89  ? ? ? ? ? ? 38  SER B C     1 
+ATOM   4240 O O     . SER D 3 44  ? 57.677  40.705 73.781  1.00 42.04  ? ? ? ? ? ? 38  SER B O     1 
+ATOM   4241 C CB    . SER D 3 44  ? 60.300  42.036 74.515  1.00 41.91  ? ? ? ? ? ? 38  SER B CB    1 
+ATOM   4242 O OG    . SER D 3 44  ? 60.751  40.694 74.351  1.00 48.08  ? ? ? ? ? ? 38  SER B OG    1 
+ATOM   4243 N N     . GLU D 3 45  ? 59.121  40.391 72.080  1.00 36.01  ? ? ? ? ? ? 39  GLU B N     1 
+ATOM   4244 C CA    . GLU D 3 45  ? 58.614  39.076 71.706  1.00 36.40  ? ? ? ? ? ? 39  GLU B CA    1 
+ATOM   4245 C C     . GLU D 3 45  ? 58.605  38.179 72.947  1.00 40.37  ? ? ? ? ? ? 39  GLU B C     1 
+ATOM   4246 O O     . GLU D 3 45  ? 57.756  37.291 73.075  1.00 38.40  ? ? ? ? ? ? 39  GLU B O     1 
+ATOM   4247 C CB    . GLU D 3 45  ? 59.598  38.446 70.719  1.00 38.55  ? ? ? ? ? ? 39  GLU B CB    1 
+ATOM   4248 C CG    . GLU D 3 45  ? 60.977  38.240 71.355  1.00 53.64  ? ? ? ? ? ? 39  GLU B CG    1 
+ATOM   4249 C CD    . GLU D 3 45  ? 62.026  37.667 70.419  1.00 83.98  ? ? ? ? ? ? 39  GLU B CD    1 
+ATOM   4250 O OE1   . GLU D 3 45  ? 62.097  36.427 70.251  1.00 74.75  ? ? ? ? ? ? 39  GLU B OE1   1 
+ATOM   4251 O OE2   . GLU D 3 45  ? 62.793  38.484 69.876  1.00 92.59  ? ? ? ? ? ? 39  GLU B OE2   1 
+ATOM   4252 N N     . HIS D 3 46  ? 59.595  38.383 73.820  1.00 37.55  ? ? ? ? ? ? 40  HIS B N     1 
+ATOM   4253 C CA    . HIS D 3 46  ? 59.770  37.578 75.037  1.00 38.81  ? ? ? ? ? ? 40  HIS B CA    1 
+ATOM   4254 C C     . HIS D 3 46  ? 58.733  37.817 76.122  1.00 38.86  ? ? ? ? ? ? 40  HIS B C     1 
+ATOM   4255 O O     . HIS D 3 46  ? 58.433  36.918 76.912  1.00 32.98  ? ? ? ? ? ? 40  HIS B O     1 
+ATOM   4256 C CB    . HIS D 3 46  ? 61.188  37.757 75.640  1.00 40.16  ? ? ? ? ? ? 40  HIS B CB    1 
+ATOM   4257 C CG    . HIS D 3 46  ? 62.286  37.277 74.746  1.00 43.19  ? ? ? ? ? ? 40  HIS B CG    1 
+ATOM   4258 N ND1   . HIS D 3 46  ? 63.243  38.120 74.220  1.00 43.57  ? ? ? ? ? ? 40  HIS B ND1   1 
+ATOM   4259 C CD2   . HIS D 3 46  ? 62.553  36.045 74.252  1.00 43.34  ? ? ? ? ? ? 40  HIS B CD2   1 
+ATOM   4260 C CE1   . HIS D 3 46  ? 64.073  37.421 73.470  1.00 42.49  ? ? ? ? ? ? 40  HIS B CE1   1 
+ATOM   4261 N NE2   . HIS D 3 46  ? 63.673  36.161 73.467  1.00 43.18  ? ? ? ? ? ? 40  HIS B NE2   1 
+ATOM   4262 N N     . THR D 3 47  ? 58.222  39.042 76.174  1.00 41.22  ? ? ? ? ? ? 41  THR B N     1 
+ATOM   4263 C CA    . THR D 3 47  ? 57.202  39.406 77.147  1.00 41.40  ? ? ? ? ? ? 41  THR B CA    1 
+ATOM   4264 C C     . THR D 3 47  ? 55.949  38.607 76.791  1.00 44.53  ? ? ? ? ? ? 41  THR B C     1 
+ATOM   4265 O O     . THR D 3 47  ? 55.284  38.034 77.664  1.00 45.29  ? ? ? ? ? ? 41  THR B O     1 
+ATOM   4266 C CB    . THR D 3 47  ? 56.973  40.924 77.136  1.00 47.96  ? ? ? ? ? ? 41  THR B CB    1 
+ATOM   4267 O OG1   . THR D 3 47  ? 58.175  41.581 77.574  1.00 48.39  ? ? ? ? ? ? 41  THR B OG1   1 
+ATOM   4268 C CG2   . THR D 3 47  ? 55.814  41.307 78.038  1.00 47.35  ? ? ? ? ? ? 41  THR B CG2   1 
+ATOM   4269 N N     . TRP D 3 48  ? 55.691  38.505 75.491  1.00 38.78  ? ? ? ? ? ? 42  TRP B N     1 
+ATOM   4270 C CA    . TRP D 3 48  ? 54.568  37.746 74.966  1.00 40.82  ? ? ? ? ? ? 42  TRP B CA    1 
+ATOM   4271 C C     . TRP D 3 48  ? 54.696  36.254 75.268  1.00 45.01  ? ? ? ? ? ? 42  TRP B C     1 
+ATOM   4272 O O     . TRP D 3 48  ? 53.716  35.601 75.642  1.00 43.58  ? ? ? ? ? ? 42  TRP B O     1 
+ATOM   4273 C CB    . TRP D 3 48  ? 54.461  37.955 73.457  1.00 43.32  ? ? ? ? ? ? 42  TRP B CB    1 
+ATOM   4274 C CG    . TRP D 3 48  ? 53.681  39.159 73.142  1.00 49.29  ? ? ? ? ? ? 42  TRP B CG    1 
+ATOM   4275 C CD1   . TRP D 3 48  ? 54.161  40.334 72.649  1.00 53.13  ? ? ? ? ? ? 42  TRP B CD1   1 
+ATOM   4276 C CD2   . TRP D 3 48  ? 52.283  39.373 73.409  1.00 52.11  ? ? ? ? ? ? 42  TRP B CD2   1 
+ATOM   4277 N NE1   . TRP D 3 48  ? 53.145  41.260 72.561  1.00 55.42  ? ? ? ? ? ? 42  TRP B NE1   1 
+ATOM   4278 C CE2   . TRP D 3 48  ? 51.986  40.699 73.034  1.00 58.51  ? ? ? ? ? ? 42  TRP B CE2   1 
+ATOM   4279 C CE3   . TRP D 3 48  ? 51.253  38.570 73.926  1.00 54.59  ? ? ? ? ? ? 42  TRP B CE3   1 
+ATOM   4280 C CZ2   . TRP D 3 48  ? 50.696  41.234 73.133  1.00 58.51  ? ? ? ? ? ? 42  TRP B CZ2   1 
+ATOM   4281 C CZ3   . TRP D 3 48  ? 49.979  39.112 74.039  1.00 56.22  ? ? ? ? ? ? 42  TRP B CZ3   1 
+ATOM   4282 C CH2   . TRP D 3 48  ? 49.711  40.425 73.639  1.00 56.78  ? ? ? ? ? ? 42  TRP B CH2   1 
+ATOM   4283 N N     . LYS D 3 49  ? 55.901  35.716 75.077  1.00 42.58  ? ? ? ? ? ? 43  LYS B N     1 
+ATOM   4284 C CA    . LYS D 3 49  ? 56.173  34.295 75.312  1.00 40.26  ? ? ? ? ? ? 43  LYS B CA    1 
+ATOM   4285 C C     . LYS D 3 49  ? 55.907  33.989 76.778  1.00 36.46  ? ? ? ? ? ? 43  LYS B C     1 
+ATOM   4286 O O     . LYS D 3 49  ? 55.420  32.918 77.116  1.00 32.71  ? ? ? ? ? ? 43  LYS B O     1 
+ATOM   4287 C CB    . LYS D 3 49  ? 57.626  33.956 74.934  1.00 42.99  ? ? ? ? ? ? 43  LYS B CB    1 
+ATOM   4288 C CG    . LYS D 3 49  ? 58.004  32.460 74.885  1.00 63.35  ? ? ? ? ? ? 43  LYS B CG    1 
+ATOM   4289 C CD    . LYS D 3 49  ? 59.289  32.109 75.666  1.00 64.86  ? ? ? ? ? ? 43  LYS B CD    1 
+ATOM   4290 C CE    . LYS D 3 49  ? 60.443  31.623 74.766  1.00 58.95  ? ? ? ? ? ? 43  LYS B CE    1 
+ATOM   4291 N NZ    . LYS D 3 49  ? 60.483  30.166 74.407  1.00 35.17  ? ? ? ? ? ? 43  LYS B NZ    1 
+ATOM   4292 N N     . MET D 3 50  ? 56.238  34.937 77.648  1.00 32.84  ? ? ? ? ? ? 44  MET B N     1 
+ATOM   4293 C CA    . MET D 3 50  ? 56.011  34.732 79.071  1.00 32.74  ? ? ? ? ? ? 44  MET B CA    1 
+ATOM   4294 C C     . MET D 3 50  ? 54.549  34.994 79.468  1.00 34.78  ? ? ? ? ? ? 44  MET B C     1 
+ATOM   4295 O O     . MET D 3 50  ? 53.978  34.216 80.227  1.00 33.80  ? ? ? ? ? ? 44  MET B O     1 
+ATOM   4296 C CB    . MET D 3 50  ? 57.040  35.483 79.924  1.00 35.42  ? ? ? ? ? ? 44  MET B CB    1 
+ATOM   4297 C CG    . MET D 3 50  ? 58.465  34.879 79.941  1.00 37.68  ? ? ? ? ? ? 44  MET B CG    1 
+ATOM   4298 S SD    . MET D 3 50  ? 58.634  33.058 79.972  1.00 41.46  ? ? ? ? ? ? 44  MET B SD    1 
+ATOM   4299 C CE    . MET D 3 50  ? 58.224  32.705 81.706  1.00 38.46  ? ? ? ? ? ? 44  MET B CE    1 
+ATOM   4300 N N     . LEU D 3 51  ? 53.939  36.052 78.934  1.00 32.09  ? ? ? ? ? ? 45  LEU B N     1 
+ATOM   4301 C CA    . LEU D 3 51  ? 52.518  36.314 79.167  1.00 32.68  ? ? ? ? ? ? 45  LEU B CA    1 
+ATOM   4302 C C     . LEU D 3 51  ? 51.849  34.951 78.948  1.00 38.55  ? ? ? ? ? ? 45  LEU B C     1 
+ATOM   4303 O O     . LEU D 3 51  ? 51.225  34.370 79.836  1.00 38.55  ? ? ? ? ? ? 45  LEU B O     1 
+ATOM   4304 C CB    . LEU D 3 51  ? 52.008  37.292 78.094  1.00 33.15  ? ? ? ? ? ? 45  LEU B CB    1 
+ATOM   4305 C CG    . LEU D 3 51  ? 50.554  37.772 77.997  1.00 40.36  ? ? ? ? ? ? 45  LEU B CG    1 
+ATOM   4306 C CD1   . LEU D 3 51  ? 49.898  37.689 79.375  1.00 40.83  ? ? ? ? ? ? 45  LEU B CD1   1 
+ATOM   4307 C CD2   . LEU D 3 51  ? 50.464  39.197 77.437  1.00 41.53  ? ? ? ? ? ? 45  LEU B CD2   1 
+ATOM   4308 N N     . LEU D 3 52  ? 52.015  34.421 77.746  1.00 38.86  ? ? ? ? ? ? 46  LEU B N     1 
+ATOM   4309 C CA    . LEU D 3 52  ? 51.408  33.146 77.400  1.00 39.23  ? ? ? ? ? ? 46  LEU B CA    1 
+ATOM   4310 C C     . LEU D 3 52  ? 51.833  31.947 78.230  1.00 39.22  ? ? ? ? ? ? 46  LEU B C     1 
+ATOM   4311 O O     . LEU D 3 52  ? 51.020  31.046 78.456  1.00 37.53  ? ? ? ? ? ? 46  LEU B O     1 
+ATOM   4312 C CB    . LEU D 3 52  ? 51.587  32.839 75.908  1.00 40.55  ? ? ? ? ? ? 46  LEU B CB    1 
+ATOM   4313 C CG    . LEU D 3 52  ? 50.926  33.724 74.836  1.00 46.04  ? ? ? ? ? ? 46  LEU B CG    1 
+ATOM   4314 C CD1   . LEU D 3 52  ? 50.121  34.890 75.395  1.00 46.54  ? ? ? ? ? ? 46  LEU B CD1   1 
+ATOM   4315 C CD2   . LEU D 3 52  ? 51.929  34.216 73.802  1.00 47.48  ? ? ? ? ? ? 46  LEU B CD2   1 
+ATOM   4316 N N     . SER D 3 53  ? 53.102  31.883 78.633  1.00 34.98  ? ? ? ? ? ? 47  SER B N     1 
+ATOM   4317 C CA    . SER D 3 53  ? 53.544  30.721 79.396  1.00 31.39  ? ? ? ? ? ? 47  SER B CA    1 
+ATOM   4318 C C     . SER D 3 53  ? 52.916  30.736 80.770  1.00 32.07  ? ? ? ? ? ? 47  SER B C     1 
+ATOM   4319 O O     . SER D 3 53  ? 52.550  29.694 81.298  1.00 32.91  ? ? ? ? ? ? 47  SER B O     1 
+ATOM   4320 C CB    . SER D 3 53  ? 55.060  30.638 79.519  1.00 35.04  ? ? ? ? ? ? 47  SER B CB    1 
+ATOM   4321 O OG    . SER D 3 53  ? 55.444  29.383 80.052  1.00 38.62  ? ? ? ? ? ? 47  SER B OG    1 
+ATOM   4322 N N     . VAL D 3 54  ? 52.798  31.932 81.335  1.00 30.98  ? ? ? ? ? ? 48  VAL B N     1 
+ATOM   4323 C CA    . VAL D 3 54  ? 52.199  32.096 82.657  1.00 32.06  ? ? ? ? ? ? 48  VAL B CA    1 
+ATOM   4324 C C     . VAL D 3 54  ? 50.713  31.733 82.561  1.00 34.28  ? ? ? ? ? ? 48  VAL B C     1 
+ATOM   4325 O O     . VAL D 3 54  ? 50.236  30.858 83.285  1.00 31.60  ? ? ? ? ? ? 48  VAL B O     1 
+ATOM   4326 C CB    . VAL D 3 54  ? 52.429  33.528 83.238  1.00 33.09  ? ? ? ? ? ? 48  VAL B CB    1 
+ATOM   4327 C CG1   . VAL D 3 54  ? 51.553  33.776 84.478  1.00 30.73  ? ? ? ? ? ? 48  VAL B CG1   1 
+ATOM   4328 C CG2   . VAL D 3 54  ? 53.935  33.781 83.529  1.00 31.62  ? ? ? ? ? ? 48  VAL B CG2   1 
+ATOM   4329 N N     . CYS D 3 55  ? 50.007  32.359 81.618  1.00 34.13  ? ? ? ? ? ? 49  CYS B N     1 
+ATOM   4330 C CA    . CYS D 3 55  ? 48.589  32.084 81.395  1.00 33.42  ? ? ? ? ? ? 49  CYS B CA    1 
+ATOM   4331 C C     . CYS D 3 55  ? 48.393  30.591 81.194  1.00 38.76  ? ? ? ? ? ? 49  CYS B C     1 
+ATOM   4332 O O     . CYS D 3 55  ? 47.508  29.967 81.778  1.00 37.61  ? ? ? ? ? ? 49  CYS B O     1 
+ATOM   4333 C CB    . CYS D 3 55  ? 48.055  32.882 80.207  1.00 32.95  ? ? ? ? ? ? 49  CYS B CB    1 
+ATOM   4334 S SG    . CYS D 3 55  ? 47.948  34.663 80.553  1.00 38.29  ? ? ? ? ? ? 49  CYS B SG    1 
+ATOM   4335 N N     . ARG D 3 56  ? 49.260  29.961 80.411  1.00 39.04  ? ? ? ? ? ? 50  ARG B N     1 
+ATOM   4336 C CA    . ARG D 3 56  ? 49.101  28.511 80.260  1.00 39.92  ? ? ? ? ? ? 50  ARG B CA    1 
+ATOM   4337 C C     . ARG D 3 56  ? 49.126  27.841 81.627  1.00 46.01  ? ? ? ? ? ? 50  ARG B C     1 
+ATOM   4338 O O     . ARG D 3 56  ? 48.252  27.030 81.945  1.00 47.21  ? ? ? ? ? ? 50  ARG B O     1 
+ATOM   4339 C CB    . ARG D 3 56  ? 50.258  27.935 79.461  1.00 41.27  ? ? ? ? ? ? 50  ARG B CB    1 
+ATOM   4340 C CG    . ARG D 3 56  ? 50.008  27.611 77.996  1.00 44.95  ? ? ? ? ? ? 50  ARG B CG    1 
+ATOM   4341 C CD    . ARG D 3 56  ? 51.311  27.136 77.301  1.00 41.25  ? ? ? ? ? ? 50  ARG B CD    1 
+ATOM   4342 N NE    . ARG D 3 56  ? 51.738  28.062 76.249  1.00 44.31  ? ? ? ? ? ? 50  ARG B NE    1 
+ATOM   4343 C CZ    . ARG D 3 56  ? 52.953  28.591 76.122  1.00 55.46  ? ? ? ? ? ? 50  ARG B CZ    1 
+ATOM   4344 N NH1   . ARG D 3 56  ? 53.934  28.282 76.959  1.00 38.23  ? ? ? ? ? ? 50  ARG B NH1   1 
+ATOM   4345 N NH2   . ARG D 3 56  ? 53.189  29.441 75.132  1.00 65.47  ? ? ? ? ? ? 50  ARG B NH2   1 
+ATOM   4346 N N     . SER D 3 57  ? 50.124  28.198 82.436  1.00 41.30  ? ? ? ? ? ? 51  SER B N     1 
+ATOM   4347 C CA    . SER D 3 57  ? 50.266  27.674 83.801  1.00 37.92  ? ? ? ? ? ? 51  SER B CA    1 
+ATOM   4348 C C     . SER D 3 57  ? 49.041  27.918 84.707  1.00 34.28  ? ? ? ? ? ? 51  SER B C     1 
+ATOM   4349 O O     . SER D 3 57  ? 48.550  26.973 85.332  1.00 32.79  ? ? ? ? ? ? 51  SER B O     1 
+ATOM   4350 C CB    . SER D 3 57  ? 51.523  28.264 84.449  1.00 42.53  ? ? ? ? ? ? 51  SER B CB    1 
+ATOM   4351 O OG    . SER D 3 57  ? 51.875  27.561 85.628  1.00 64.33  ? ? ? ? ? ? 51  SER B OG    1 
+ATOM   4352 N N     . TRP D 3 58  ? 48.608  29.172 84.804  1.00 28.27  ? ? ? ? ? ? 52  TRP B N     1 
+ATOM   4353 C CA    . TRP D 3 58  ? 47.483  29.611 85.632  1.00 28.00  ? ? ? ? ? ? 52  TRP B CA    1 
+ATOM   4354 C C     . TRP D 3 58  ? 46.183  28.952 85.203  1.00 36.64  ? ? ? ? ? ? 52  TRP B C     1 
+ATOM   4355 O O     . TRP D 3 58  ? 45.391  28.494 86.036  1.00 36.71  ? ? ? ? ? ? 52  TRP B O     1 
+ATOM   4356 C CB    . TRP D 3 58  ? 47.368  31.123 85.440  1.00 26.18  ? ? ? ? ? ? 52  TRP B CB    1 
+ATOM   4357 C CG    . TRP D 3 58  ? 46.150  31.789 85.970  1.00 26.73  ? ? ? ? ? ? 52  TRP B CG    1 
+ATOM   4358 C CD1   . TRP D 3 58  ? 45.272  32.548 85.261  1.00 29.55  ? ? ? ? ? ? 52  TRP B CD1   1 
+ATOM   4359 C CD2   . TRP D 3 58  ? 45.761  31.898 87.345  1.00 26.27  ? ? ? ? ? ? 52  TRP B CD2   1 
+ATOM   4360 N NE1   . TRP D 3 58  ? 44.313  33.063 86.101  1.00 29.41  ? ? ? ? ? ? 52  TRP B NE1   1 
+ATOM   4361 C CE2   . TRP D 3 58  ? 44.580  32.666 87.384  1.00 30.65  ? ? ? ? ? ? 52  TRP B CE2   1 
+ATOM   4362 C CE3   . TRP D 3 58  ? 46.229  31.337 88.530  1.00 27.05  ? ? ? ? ? ? 52  TRP B CE3   1 
+ATOM   4363 C CZ2   . TRP D 3 58  ? 43.885  32.912 88.563  1.00 28.44  ? ? ? ? ? ? 52  TRP B CZ2   1 
+ATOM   4364 C CZ3   . TRP D 3 58  ? 45.534  31.578 89.692  1.00 28.85  ? ? ? ? ? ? 52  TRP B CZ3   1 
+ATOM   4365 C CH2   . TRP D 3 58  ? 44.379  32.361 89.702  1.00 28.69  ? ? ? ? ? ? 52  TRP B CH2   1 
+ATOM   4366 N N     . ALA D 3 59  ? 45.979  28.905 83.886  1.00 34.01  ? ? ? ? ? ? 53  ALA B N     1 
+ATOM   4367 C CA    . ALA D 3 59  ? 44.775  28.317 83.310  1.00 33.11  ? ? ? ? ? ? 53  ALA B CA    1 
+ATOM   4368 C C     . ALA D 3 59  ? 44.725  26.845 83.671  1.00 35.55  ? ? ? ? ? ? 53  ALA B C     1 
+ATOM   4369 O O     . ALA D 3 59  ? 43.669  26.280 83.952  1.00 37.82  ? ? ? ? ? ? 53  ALA B O     1 
+ATOM   4370 C CB    . ALA D 3 59  ? 44.747  28.506 81.795  1.00 33.14  ? ? ? ? ? ? 53  ALA B CB    1 
+ATOM   4371 N N     . ALA D 3 60  ? 45.902  26.244 83.707  1.00 30.01  ? ? ? ? ? ? 54  ALA B N     1 
+ATOM   4372 C CA    . ALA D 3 60  ? 46.003  24.842 84.055  1.00 28.93  ? ? ? ? ? ? 54  ALA B CA    1 
+ATOM   4373 C C     . ALA D 3 60  ? 45.670  24.646 85.514  1.00 39.58  ? ? ? ? ? ? 54  ALA B C     1 
+ATOM   4374 O O     . ALA D 3 60  ? 44.909  23.738 85.860  1.00 43.66  ? ? ? ? ? ? 54  ALA B O     1 
+ATOM   4375 C CB    . ALA D 3 60  ? 47.390  24.319 83.753  1.00 29.48  ? ? ? ? ? ? 54  ALA B CB    1 
+ATOM   4376 N N     . TRP D 3 61  ? 46.250  25.479 86.370  1.00 34.82  ? ? ? ? ? ? 55  TRP B N     1 
+ATOM   4377 C CA    . TRP D 3 61  ? 45.993  25.364 87.795  1.00 33.34  ? ? ? ? ? ? 55  TRP B CA    1 
+ATOM   4378 C C     . TRP D 3 61  ? 44.509  25.629 88.041  1.00 37.45  ? ? ? ? ? ? 55  TRP B C     1 
+ATOM   4379 O O     . TRP D 3 61  ? 43.889  25.040 88.926  1.00 32.72  ? ? ? ? ? ? 55  TRP B O     1 
+ATOM   4380 C CB    . TRP D 3 61  ? 46.811  26.395 88.567  1.00 31.08  ? ? ? ? ? ? 55  TRP B CB    1 
+ATOM   4381 C CG    . TRP D 3 61  ? 46.608  26.265 90.034  1.00 31.01  ? ? ? ? ? ? 55  TRP B CG    1 
+ATOM   4382 C CD1   . TRP D 3 61  ? 47.230  25.388 90.873  1.00 33.29  ? ? ? ? ? ? 55  TRP B CD1   1 
+ATOM   4383 C CD2   . TRP D 3 61  ? 45.673  26.993 90.834  1.00 30.92  ? ? ? ? ? ? 55  TRP B CD2   1 
+ATOM   4384 N NE1   . TRP D 3 61  ? 46.770  25.551 92.153  1.00 33.20  ? ? ? ? ? ? 55  TRP B NE1   1 
+ATOM   4385 C CE2   . TRP D 3 61  ? 45.813  26.532 92.158  1.00 33.79  ? ? ? ? ? ? 55  TRP B CE2   1 
+ATOM   4386 C CE3   . TRP D 3 61  ? 44.783  28.044 90.572  1.00 32.33  ? ? ? ? ? ? 55  TRP B CE3   1 
+ATOM   4387 C CZ2   . TRP D 3 61  ? 45.069  27.044 93.202  1.00 33.03  ? ? ? ? ? ? 55  TRP B CZ2   1 
+ATOM   4388 C CZ3   . TRP D 3 61  ? 44.036  28.541 91.608  1.00 33.72  ? ? ? ? ? ? 55  TRP B CZ3   1 
+ATOM   4389 C CH2   . TRP D 3 61  ? 44.169  28.028 92.905  1.00 34.17  ? ? ? ? ? ? 55  TRP B CH2   1 
+ATOM   4390 N N     . CYS D 3 62  ? 43.952  26.542 87.256  1.00 37.00  ? ? ? ? ? ? 56  CYS B N     1 
+ATOM   4391 C CA    . CYS D 3 62  ? 42.545  26.906 87.388  1.00 35.46  ? ? ? ? ? ? 56  CYS B CA    1 
+ATOM   4392 C C     . CYS D 3 62  ? 41.572  25.784 87.036  1.00 40.34  ? ? ? ? ? ? 56  CYS B C     1 
+ATOM   4393 O O     . CYS D 3 62  ? 40.600  25.535 87.751  1.00 36.76  ? ? ? ? ? ? 56  CYS B O     1 
+ATOM   4394 C CB    . CYS D 3 62  ? 42.251  28.125 86.521  1.00 34.73  ? ? ? ? ? ? 56  CYS B CB    1 
+ATOM   4395 S SG    . CYS D 3 62  ? 42.647  29.686 87.358  1.00 38.11  ? ? ? ? ? ? 56  CYS B SG    1 
+ATOM   4396 N N     . LYS D 3 63  ? 41.831  25.109 85.926  1.00 42.33  ? ? ? ? ? ? 57  LYS B N     1 
+ATOM   4397 C CA    . LYS D 3 63  ? 40.977  24.015 85.497  1.00 43.39  ? ? ? ? ? ? 57  LYS B CA    1 
+ATOM   4398 C C     . LYS D 3 63  ? 40.930  22.900 86.545  1.00 50.07  ? ? ? ? ? ? 57  LYS B C     1 
+ATOM   4399 O O     . LYS D 3 63  ? 39.871  22.384 86.896  1.00 53.49  ? ? ? ? ? ? 57  LYS B O     1 
+ATOM   4400 C CB    . LYS D 3 63  ? 41.522  23.471 84.172  1.00 45.16  ? ? ? ? ? ? 57  LYS B CB    1 
+ATOM   4401 C CG    . LYS D 3 63  ? 40.875  22.183 83.678  1.00 62.81  ? ? ? ? ? ? 57  LYS B CG    1 
+ATOM   4402 C CD    . LYS D 3 63  ? 41.270  21.870 82.246  1.00 80.51  ? ? ? ? ? ? 57  LYS B CD    1 
+ATOM   4403 C CE    . LYS D 3 63  ? 40.102  21.309 81.443  1.00 96.86  ? ? ? ? ? ? 57  LYS B CE    1 
+ATOM   4404 N NZ    . LYS D 3 63  ? 39.791  22.104 80.211  1.00 100.00 ? ? ? ? ? ? 57  LYS B NZ    1 
+ATOM   4405 N N     . LEU D 3 64  ? 42.095  22.516 87.033  1.00 46.22  ? ? ? ? ? ? 58  LEU B N     1 
+ATOM   4406 C CA    . LEU D 3 64  ? 42.209  21.439 88.001  1.00 47.08  ? ? ? ? ? ? 58  LEU B CA    1 
+ATOM   4407 C C     . LEU D 3 64  ? 41.453  21.652 89.299  1.00 51.59  ? ? ? ? ? ? 58  LEU B C     1 
+ATOM   4408 O O     . LEU D 3 64  ? 41.323  20.747 90.125  1.00 51.90  ? ? ? ? ? ? 58  LEU B O     1 
+ATOM   4409 C CB    . LEU D 3 64  ? 43.672  21.363 88.375  1.00 48.09  ? ? ? ? ? ? 58  LEU B CB    1 
+ATOM   4410 C CG    . LEU D 3 64  ? 44.185  19.992 88.769  1.00 55.07  ? ? ? ? ? ? 58  LEU B CG    1 
+ATOM   4411 C CD1   . LEU D 3 64  ? 44.496  19.229 87.474  1.00 57.72  ? ? ? ? ? ? 58  LEU B CD1   1 
+ATOM   4412 C CD2   . LEU D 3 64  ? 45.444  20.315 89.537  1.00 56.60  ? ? ? ? ? ? 58  LEU B CD2   1 
+ATOM   4413 N N     . ASN D 3 65  ? 41.044  22.895 89.511  1.00 48.50  ? ? ? ? ? ? 59  ASN B N     1 
+ATOM   4414 C CA    . ASN D 3 65  ? 40.406  23.311 90.757  1.00 48.18  ? ? ? ? ? ? 59  ASN B CA    1 
+ATOM   4415 C C     . ASN D 3 65  ? 39.078  23.972 90.469  1.00 51.54  ? ? ? ? ? ? 59  ASN B C     1 
+ATOM   4416 O O     . ASN D 3 65  ? 38.487  24.607 91.341  1.00 56.09  ? ? ? ? ? ? 59  ASN B O     1 
+ATOM   4417 C CB    . ASN D 3 65  ? 41.289  24.352 91.469  1.00 45.42  ? ? ? ? ? ? 59  ASN B CB    1 
+ATOM   4418 C CG    . ASN D 3 65  ? 42.522  23.743 92.111  1.00 51.00  ? ? ? ? ? ? 59  ASN B CG    1 
+ATOM   4419 O OD1   . ASN D 3 65  ? 42.424  22.945 93.045  1.00 47.89  ? ? ? ? ? ? 59  ASN B OD1   1 
+ATOM   4420 N ND2   . ASN D 3 65  ? 43.691  24.133 91.619  1.00 39.77  ? ? ? ? ? ? 59  ASN B ND2   1 
+ATOM   4421 N N     . ASN D 3 66  ? 38.624  23.824 89.241  1.00 41.49  ? ? ? ? ? ? 60  ASN B N     1 
+ATOM   4422 C CA    . ASN D 3 66  ? 37.431  24.502 88.826  1.00 40.37  ? ? ? ? ? ? 60  ASN B CA    1 
+ATOM   4423 C C     . ASN D 3 66  ? 37.264  25.952 89.155  1.00 42.97  ? ? ? ? ? ? 60  ASN B C     1 
+ATOM   4424 O O     . ASN D 3 66  ? 36.322  26.312 89.856  1.00 46.79  ? ? ? ? ? ? 60  ASN B O     1 
+ATOM   4425 C CB    . ASN D 3 66  ? 36.160  23.747 89.094  1.00 45.84  ? ? ? ? ? ? 60  ASN B CB    1 
+ATOM   4426 C CG    . ASN D 3 66  ? 35.388  23.644 87.830  1.00 100.00 ? ? ? ? ? ? 60  ASN B CG    1 
+ATOM   4427 O OD1   . ASN D 3 66  ? 34.363  24.296 87.646  1.00 100.00 ? ? ? ? ? ? 60  ASN B OD1   1 
+ATOM   4428 N ND2   . ASN D 3 66  ? 35.898  22.827 86.914  1.00 86.45  ? ? ? ? ? ? 60  ASN B ND2   1 
+ATOM   4429 N N     . ARG D 3 67  ? 38.201  26.790 88.701  1.00 35.28  ? ? ? ? ? ? 61  ARG B N     1 
+ATOM   4430 C CA    . ARG D 3 67  ? 38.149  28.226 88.963  1.00 30.92  ? ? ? ? ? ? 61  ARG B CA    1 
+ATOM   4431 C C     . ARG D 3 67  ? 38.253  28.981 87.663  1.00 37.33  ? ? ? ? ? ? 61  ARG B C     1 
+ATOM   4432 O O     . ARG D 3 67  ? 38.804  28.477 86.689  1.00 39.25  ? ? ? ? ? ? 61  ARG B O     1 
+ATOM   4433 C CB    . ARG D 3 67  ? 39.257  28.691 89.909  1.00 27.11  ? ? ? ? ? ? 61  ARG B CB    1 
+ATOM   4434 C CG    . ARG D 3 67  ? 39.710  27.647 90.906  1.00 26.68  ? ? ? ? ? ? 61  ARG B CG    1 
+ATOM   4435 C CD    . ARG D 3 67  ? 38.733  27.497 92.071  1.00 26.96  ? ? ? ? ? ? 61  ARG B CD    1 
+ATOM   4436 N NE    . ARG D 3 67  ? 38.363  28.769 92.683  1.00 33.24  ? ? ? ? ? ? 61  ARG B NE    1 
+ATOM   4437 C CZ    . ARG D 3 67  ? 37.385  28.922 93.574  1.00 45.67  ? ? ? ? ? ? 61  ARG B CZ    1 
+ATOM   4438 N NH1   . ARG D 3 67  ? 36.648  27.897 93.968  1.00 31.58  ? ? ? ? ? ? 61  ARG B NH1   1 
+ATOM   4439 N NH2   . ARG D 3 67  ? 37.134  30.117 94.078  1.00 26.45  ? ? ? ? ? ? 61  ARG B NH2   1 
+ATOM   4440 N N     . LYS D 3 68  ? 37.702  30.185 87.650  1.00 35.90  ? ? ? ? ? ? 62  LYS B N     1 
+ATOM   4441 C CA    . LYS D 3 68  ? 37.705  30.990 86.444  1.00 36.41  ? ? ? ? ? ? 62  LYS B CA    1 
+ATOM   4442 C C     . LYS D 3 68  ? 39.064  31.649 86.348  1.00 45.01  ? ? ? ? ? ? 62  LYS B C     1 
+ATOM   4443 O O     . LYS D 3 68  ? 39.484  32.363 87.257  1.00 47.03  ? ? ? ? ? ? 62  LYS B O     1 
+ATOM   4444 C CB    . LYS D 3 68  ? 36.603  32.049 86.518  1.00 39.47  ? ? ? ? ? ? 62  LYS B CB    1 
+ATOM   4445 C CG    . LYS D 3 68  ? 36.355  32.809 85.228  1.00 53.13  ? ? ? ? ? ? 62  LYS B CG    1 
+ATOM   4446 C CD    . LYS D 3 68  ? 34.867  32.917 84.909  1.00 67.35  ? ? ? ? ? ? 62  LYS B CD    1 
+ATOM   4447 C CE    . LYS D 3 68  ? 34.587  34.041 83.920  1.00 86.39  ? ? ? ? ? ? 62  LYS B CE    1 
+ATOM   4448 N NZ    . LYS D 3 68  ? 34.371  35.367 84.578  1.00 91.88  ? ? ? ? ? ? 62  LYS B NZ    1 
+ATOM   4449 N N     . TRP D 3 69  ? 39.760  31.419 85.243  1.00 42.90  ? ? ? ? ? ? 63  TRP B N     1 
+ATOM   4450 C CA    . TRP D 3 69  ? 41.060  32.048 85.096  1.00 44.80  ? ? ? ? ? ? 63  TRP B CA    1 
+ATOM   4451 C C     . TRP D 3 69  ? 41.068  33.553 84.773  1.00 43.85  ? ? ? ? ? ? 63  TRP B C     1 
+ATOM   4452 O O     . TRP D 3 69  ? 42.038  34.236 85.097  1.00 44.55  ? ? ? ? ? ? 63  TRP B O     1 
+ATOM   4453 C CB    . TRP D 3 69  ? 42.064  31.211 84.289  1.00 45.64  ? ? ? ? ? ? 63  TRP B CB    1 
+ATOM   4454 C CG    . TRP D 3 69  ? 41.997  31.463 82.826  1.00 49.55  ? ? ? ? ? ? 63  TRP B CG    1 
+ATOM   4455 C CD1   . TRP D 3 69  ? 41.227  30.794 81.925  1.00 53.46  ? ? ? ? ? ? 63  TRP B CD1   1 
+ATOM   4456 C CD2   . TRP D 3 69  ? 42.693  32.482 82.083  1.00 50.27  ? ? ? ? ? ? 63  TRP B CD2   1 
+ATOM   4457 N NE1   . TRP D 3 69  ? 41.390  31.334 80.671  1.00 54.13  ? ? ? ? ? ? 63  TRP B NE1   1 
+ATOM   4458 C CE2   . TRP D 3 69  ? 42.281  32.373 80.741  1.00 55.98  ? ? ? ? ? ? 63  TRP B CE2   1 
+ATOM   4459 C CE3   . TRP D 3 69  ? 43.626  33.472 82.419  1.00 50.66  ? ? ? ? ? ? 63  TRP B CE3   1 
+ATOM   4460 C CZ2   . TRP D 3 69  ? 42.779  33.207 79.733  1.00 54.95  ? ? ? ? ? ? 63  TRP B CZ2   1 
+ATOM   4461 C CZ3   . TRP D 3 69  ? 44.116  34.298 81.418  1.00 51.59  ? ? ? ? ? ? 63  TRP B CZ3   1 
+ATOM   4462 C CH2   . TRP D 3 69  ? 43.695  34.157 80.092  1.00 52.44  ? ? ? ? ? ? 63  TRP B CH2   1 
+ATOM   4463 N N     . PHE D 3 70  ? 40.004  34.099 84.182  1.00 36.06  ? ? ? ? ? ? 64  PHE B N     1 
+ATOM   4464 C CA    . PHE D 3 70  ? 39.980  35.539 83.890  1.00 35.12  ? ? ? ? ? ? 64  PHE B CA    1 
+ATOM   4465 C C     . PHE D 3 70  ? 38.574  36.154 83.907  1.00 41.92  ? ? ? ? ? ? 64  PHE B C     1 
+ATOM   4466 O O     . PHE D 3 70  ? 37.702  35.644 83.210  1.00 44.15  ? ? ? ? ? ? 64  PHE B O     1 
+ATOM   4467 C CB    . PHE D 3 70  ? 40.687  35.831 82.559  1.00 36.18  ? ? ? ? ? ? 64  PHE B CB    1 
+ATOM   4468 C CG    . PHE D 3 70  ? 40.880  37.296 82.287  1.00 38.09  ? ? ? ? ? ? 64  PHE B CG    1 
+ATOM   4469 C CD1   . PHE D 3 70  ? 41.850  38.023 82.957  1.00 42.68  ? ? ? ? ? ? 64  PHE B CD1   1 
+ATOM   4470 C CD2   . PHE D 3 70  ? 40.072  37.957 81.377  1.00 42.25  ? ? ? ? ? ? 64  PHE B CD2   1 
+ATOM   4471 C CE1   . PHE D 3 70  ? 42.014  39.383 82.719  1.00 43.44  ? ? ? ? ? ? 64  PHE B CE1   1 
+ATOM   4472 C CE2   . PHE D 3 70  ? 40.224  39.316 81.143  1.00 44.07  ? ? ? ? ? ? 64  PHE B CE2   1 
+ATOM   4473 C CZ    . PHE D 3 70  ? 41.195  40.031 81.817  1.00 41.77  ? ? ? ? ? ? 64  PHE B CZ    1 
+ATOM   4474 N N     . PRO D 3 71  ? 38.335  37.233 84.668  1.00 37.33  ? ? ? ? ? ? 65  PRO B N     1 
+ATOM   4475 C CA    . PRO D 3 71  ? 39.340  37.869 85.520  1.00 36.52  ? ? ? ? ? ? 65  PRO B CA    1 
+ATOM   4476 C C     . PRO D 3 71  ? 39.679  36.973 86.692  1.00 47.29  ? ? ? ? ? ? 65  PRO B C     1 
+ATOM   4477 O O     . PRO D 3 71  ? 38.852  36.179 87.154  1.00 47.32  ? ? ? ? ? ? 65  PRO B O     1 
+ATOM   4478 C CB    . PRO D 3 71  ? 38.616  39.107 86.045  1.00 34.86  ? ? ? ? ? ? 65  PRO B CB    1 
+ATOM   4479 C CG    . PRO D 3 71  ? 37.735  39.484 84.931  1.00 39.28  ? ? ? ? ? ? 65  PRO B CG    1 
+ATOM   4480 C CD    . PRO D 3 71  ? 37.351  38.221 84.199  1.00 35.80  ? ? ? ? ? ? 65  PRO B CD    1 
+ATOM   4481 N N     . ALA D 3 72  ? 40.923  37.095 87.140  1.00 43.65  ? ? ? ? ? ? 66  ALA B N     1 
+ATOM   4482 C CA    . ALA D 3 72  ? 41.438  36.295 88.230  1.00 42.43  ? ? ? ? ? ? 66  ALA B CA    1 
+ATOM   4483 C C     . ALA D 3 72  ? 40.985  36.867 89.566  1.00 42.46  ? ? ? ? ? ? 66  ALA B C     1 
+ATOM   4484 O O     . ALA D 3 72  ? 40.898  38.082 89.744  1.00 42.57  ? ? ? ? ? ? 66  ALA B O     1 
+ATOM   4485 C CB    . ALA D 3 72  ? 42.960  36.219 88.151  1.00 43.32  ? ? ? ? ? ? 66  ALA B CB    1 
+ATOM   4486 N N     . GLU D 3 73  ? 40.677  35.976 90.495  1.00 35.48  ? ? ? ? ? ? 67  GLU B N     1 
+ATOM   4487 C CA    . GLU D 3 73  ? 40.232  36.381 91.812  1.00 33.75  ? ? ? ? ? ? 67  GLU B CA    1 
+ATOM   4488 C C     . GLU D 3 73  ? 41.472  36.383 92.703  1.00 32.52  ? ? ? ? ? ? 67  GLU B C     1 
+ATOM   4489 O O     . GLU D 3 73  ? 42.206  35.390 92.743  1.00 29.71  ? ? ? ? ? ? 67  GLU B O     1 
+ATOM   4490 C CB    . GLU D 3 73  ? 39.253  35.319 92.333  1.00 35.75  ? ? ? ? ? ? 67  GLU B CB    1 
+ATOM   4491 C CG    . GLU D 3 73  ? 37.813  35.464 91.875  1.00 39.63  ? ? ? ? ? ? 67  GLU B CG    1 
+ATOM   4492 C CD    . GLU D 3 73  ? 37.188  36.743 92.368  1.00 46.41  ? ? ? ? ? ? 67  GLU B CD    1 
+ATOM   4493 O OE1   . GLU D 3 73  ? 37.530  37.212 93.487  1.00 40.07  ? ? ? ? ? ? 67  GLU B OE1   1 
+ATOM   4494 O OE2   . GLU D 3 73  ? 36.358  37.277 91.623  1.00 41.66  ? ? ? ? ? ? 67  GLU B OE2   1 
+ATOM   4495 N N     . PRO D 3 74  ? 41.688  37.475 93.432  1.00 30.87  ? ? ? ? ? ? 68  PRO B N     1 
+ATOM   4496 C CA    . PRO D 3 74  ? 42.827  37.572 94.332  1.00 29.00  ? ? ? ? ? ? 68  PRO B CA    1 
+ATOM   4497 C C     . PRO D 3 74  ? 43.045  36.296 95.125  1.00 32.12  ? ? ? ? ? ? 68  PRO B C     1 
+ATOM   4498 O O     . PRO D 3 74  ? 44.121  35.712 95.071  1.00 33.84  ? ? ? ? ? ? 68  PRO B O     1 
+ATOM   4499 C CB    . PRO D 3 74  ? 42.422  38.717 95.251  1.00 30.32  ? ? ? ? ? ? 68  PRO B CB    1 
+ATOM   4500 C CG    . PRO D 3 74  ? 41.716  39.641 94.314  1.00 35.09  ? ? ? ? ? ? 68  PRO B CG    1 
+ATOM   4501 C CD    . PRO D 3 74  ? 40.998  38.770 93.302  1.00 31.07  ? ? ? ? ? ? 68  PRO B CD    1 
+ATOM   4502 N N     . GLU D 3 75  ? 42.033  35.837 95.849  1.00 28.47  ? ? ? ? ? ? 69  GLU B N     1 
+ATOM   4503 C CA    . GLU D 3 75  ? 42.194  34.619 96.638  1.00 27.27  ? ? ? ? ? ? 69  GLU B CA    1 
+ATOM   4504 C C     . GLU D 3 75  ? 42.705  33.430 95.831  1.00 32.43  ? ? ? ? ? ? 69  GLU B C     1 
+ATOM   4505 O O     . GLU D 3 75  ? 43.370  32.540 96.367  1.00 33.68  ? ? ? ? ? ? 69  GLU B O     1 
+ATOM   4506 C CB    . GLU D 3 75  ? 40.882  34.245 97.333  1.00 28.58  ? ? ? ? ? ? 69  GLU B CB    1 
+ATOM   4507 C CG    . GLU D 3 75  ? 40.429  35.244 98.381  1.00 27.25  ? ? ? ? ? ? 69  GLU B CG    1 
+ATOM   4508 C CD    . GLU D 3 75  ? 41.320  35.203 99.601  1.00 41.17  ? ? ? ? ? ? 69  GLU B CD    1 
+ATOM   4509 O OE1   . GLU D 3 75  ? 41.759  34.098 99.970  1.00 29.37  ? ? ? ? ? ? 69  GLU B OE1   1 
+ATOM   4510 O OE2   . GLU D 3 75  ? 41.586  36.273 100.184 1.00 50.45  ? ? ? ? ? ? 69  GLU B OE2   1 
+ATOM   4511 N N     . ASP D 3 76  ? 42.329  33.396 94.556  1.00 31.72  ? ? ? ? ? ? 70  ASP B N     1 
+ATOM   4512 C CA    . ASP D 3 76  ? 42.710  32.317 93.647  1.00 32.44  ? ? ? ? ? ? 70  ASP B CA    1 
+ATOM   4513 C C     . ASP D 3 76  ? 44.175  32.499 93.226  1.00 30.69  ? ? ? ? ? ? 70  ASP B C     1 
+ATOM   4514 O O     . ASP D 3 76  ? 44.952  31.551 93.109  1.00 26.35  ? ? ? ? ? ? 70  ASP B O     1 
+ATOM   4515 C CB    . ASP D 3 76  ? 41.796  32.354 92.415  1.00 35.68  ? ? ? ? ? ? 70  ASP B CB    1 
+ATOM   4516 C CG    . ASP D 3 76  ? 40.520  31.566 92.609  1.00 43.09  ? ? ? ? ? ? 70  ASP B CG    1 
+ATOM   4517 O OD1   . ASP D 3 76  ? 40.290  31.017 93.715  1.00 45.03  ? ? ? ? ? ? 70  ASP B OD1   1 
+ATOM   4518 O OD2   . ASP D 3 76  ? 39.749  31.517 91.629  1.00 51.07  ? ? ? ? ? ? 70  ASP B OD2   1 
+ATOM   4519 N N     . VAL D 3 77  ? 44.532  33.751 92.978  1.00 29.61  ? ? ? ? ? ? 71  VAL B N     1 
+ATOM   4520 C CA    . VAL D 3 77  ? 45.887  34.106 92.592  1.00 29.92  ? ? ? ? ? ? 71  VAL B CA    1 
+ATOM   4521 C C     . VAL D 3 77  ? 46.793  33.701 93.767  1.00 32.92  ? ? ? ? ? ? 71  VAL B C     1 
+ATOM   4522 O O     . VAL D 3 77  ? 47.820  33.033 93.583  1.00 32.83  ? ? ? ? ? ? 71  VAL B O     1 
+ATOM   4523 C CB    . VAL D 3 77  ? 45.965  35.619 92.254  1.00 32.37  ? ? ? ? ? ? 71  VAL B CB    1 
+ATOM   4524 C CG1   . VAL D 3 77  ? 47.404  36.055 92.015  1.00 33.77  ? ? ? ? ? ? 71  VAL B CG1   1 
+ATOM   4525 C CG2   . VAL D 3 77  ? 45.104  35.929 91.028  1.00 29.60  ? ? ? ? ? ? 71  VAL B CG2   1 
+ATOM   4526 N N     . ARG D 3 78  ? 46.352  34.028 94.978  1.00 26.58  ? ? ? ? ? ? 72  ARG B N     1 
+ATOM   4527 C CA    . ARG D 3 78  ? 47.105  33.694 96.175  1.00 24.77  ? ? ? ? ? ? 72  ARG B CA    1 
+ATOM   4528 C C     . ARG D 3 78  ? 47.381  32.202 96.338  1.00 32.37  ? ? ? ? ? ? 72  ARG B C     1 
+ATOM   4529 O O     . ARG D 3 78  ? 48.524  31.813 96.547  1.00 34.29  ? ? ? ? ? ? 72  ARG B O     1 
+ATOM   4530 C CB    . ARG D 3 78  ? 46.490  34.361 97.408  1.00 20.73  ? ? ? ? ? ? 72  ARG B CB    1 
+ATOM   4531 C CG    . ARG D 3 78  ? 46.980  33.840 98.737  1.00 20.59  ? ? ? ? ? ? 72  ARG B CG    1 
+ATOM   4532 C CD    . ARG D 3 78  ? 46.343  34.583 99.915  1.00 27.15  ? ? ? ? ? ? 72  ARG B CD    1 
+ATOM   4533 N NE    . ARG D 3 78  ? 47.034  34.198 101.142 1.00 29.94  ? ? ? ? ? ? 72  ARG B NE    1 
+ATOM   4534 C CZ    . ARG D 3 78  ? 46.961  32.987 101.681 1.00 37.28  ? ? ? ? ? ? 72  ARG B CZ    1 
+ATOM   4535 N NH1   . ARG D 3 78  ? 46.149  32.083 101.149 1.00 33.95  ? ? ? ? ? ? 72  ARG B NH1   1 
+ATOM   4536 N NH2   . ARG D 3 78  ? 47.675  32.705 102.768 1.00 34.17  ? ? ? ? ? ? 72  ARG B NH2   1 
+ATOM   4537 N N     . ASP D 3 79  ? 46.379  31.343 96.181  1.00 31.27  ? ? ? ? ? ? 73  ASP B N     1 
+ATOM   4538 C CA    . ASP D 3 79  ? 46.639  29.904 96.294  1.00 32.00  ? ? ? ? ? ? 73  ASP B CA    1 
+ATOM   4539 C C     . ASP D 3 79  ? 47.546  29.446 95.171  1.00 37.29  ? ? ? ? ? ? 73  ASP B C     1 
+ATOM   4540 O O     . ASP D 3 79  ? 48.152  28.379 95.247  1.00 38.51  ? ? ? ? ? ? 73  ASP B O     1 
+ATOM   4541 C CB    . ASP D 3 79  ? 45.355  29.095 96.129  1.00 34.97  ? ? ? ? ? ? 73  ASP B CB    1 
+ATOM   4542 C CG    . ASP D 3 79  ? 44.331  29.427 97.176  1.00 44.02  ? ? ? ? ? ? 73  ASP B CG    1 
+ATOM   4543 O OD1   . ASP D 3 79  ? 44.727  29.712 98.326  1.00 46.64  ? ? ? ? ? ? 73  ASP B OD1   1 
+ATOM   4544 O OD2   . ASP D 3 79  ? 43.127  29.439 96.837  1.00 43.55  ? ? ? ? ? ? 73  ASP B OD2   1 
+ATOM   4545 N N     . TYR D 3 80  ? 47.565  30.208 94.084  1.00 36.23  ? ? ? ? ? ? 74  TYR B N     1 
+ATOM   4546 C CA    . TYR D 3 80  ? 48.368  29.856 92.919  1.00 32.09  ? ? ? ? ? ? 74  TYR B CA    1 
+ATOM   4547 C C     . TYR D 3 80  ? 49.839  30.127 93.216  1.00 33.49  ? ? ? ? ? ? 74  TYR B C     1 
+ATOM   4548 O O     . TYR D 3 80  ? 50.690  29.264 93.011  1.00 34.74  ? ? ? ? ? ? 74  TYR B O     1 
+ATOM   4549 C CB    . TYR D 3 80  ? 47.901  30.652 91.709  1.00 29.08  ? ? ? ? ? ? 74  TYR B CB    1 
+ATOM   4550 C CG    . TYR D 3 80  ? 48.755  30.420 90.485  1.00 26.54  ? ? ? ? ? ? 74  TYR B CG    1 
+ATOM   4551 C CD1   . TYR D 3 80  ? 48.937  29.143 89.973  1.00 27.37  ? ? ? ? ? ? 74  TYR B CD1   1 
+ATOM   4552 C CD2   . TYR D 3 80  ? 49.377  31.481 89.850  1.00 25.31  ? ? ? ? ? ? 74  TYR B CD2   1 
+ATOM   4553 C CE1   . TYR D 3 80  ? 49.711  28.935 88.858  1.00 23.97  ? ? ? ? ? ? 74  TYR B CE1   1 
+ATOM   4554 C CE2   . TYR D 3 80  ? 50.145  31.287 88.734  1.00 25.00  ? ? ? ? ? ? 74  TYR B CE2   1 
+ATOM   4555 C CZ    . TYR D 3 80  ? 50.314  30.013 88.256  1.00 28.69  ? ? ? ? ? ? 74  TYR B CZ    1 
+ATOM   4556 O OH    . TYR D 3 80  ? 51.108  29.820 87.156  1.00 32.24  ? ? ? ? ? ? 74  TYR B OH    1 
+ATOM   4557 N N     . LEU D 3 81  ? 50.131  31.304 93.749  1.00 29.42  ? ? ? ? ? ? 75  LEU B N     1 
+ATOM   4558 C CA    . LEU D 3 81  ? 51.500  31.638 94.124  1.00 27.80  ? ? ? ? ? ? 75  LEU B CA    1 
+ATOM   4559 C C     . LEU D 3 81  ? 51.973  30.622 95.161  1.00 30.02  ? ? ? ? ? ? 75  LEU B C     1 
+ATOM   4560 O O     . LEU D 3 81  ? 53.059  30.071 95.028  1.00 29.76  ? ? ? ? ? ? 75  LEU B O     1 
+ATOM   4561 C CB    . LEU D 3 81  ? 51.574  33.060 94.678  1.00 26.49  ? ? ? ? ? ? 75  LEU B CB    1 
+ATOM   4562 C CG    . LEU D 3 81  ? 50.986  34.122 93.751  1.00 29.84  ? ? ? ? ? ? 75  LEU B CG    1 
+ATOM   4563 C CD1   . LEU D 3 81  ? 51.161  35.511 94.345  1.00 30.68  ? ? ? ? ? ? 75  LEU B CD1   1 
+ATOM   4564 C CD2   . LEU D 3 81  ? 51.592  34.051 92.351  1.00 32.70  ? ? ? ? ? ? 75  LEU B CD2   1 
+ATOM   4565 N N     . LEU D 3 82  ? 51.145  30.317 96.160  1.00 27.87  ? ? ? ? ? ? 76  LEU B N     1 
+ATOM   4566 C CA    . LEU D 3 82  ? 51.525  29.338 97.184  1.00 27.05  ? ? ? ? ? ? 76  LEU B CA    1 
+ATOM   4567 C C     . LEU D 3 82  ? 51.782  27.971 96.609  1.00 33.88  ? ? ? ? ? ? 76  LEU B C     1 
+ATOM   4568 O O     . LEU D 3 82  ? 52.581  27.197 97.136  1.00 36.91  ? ? ? ? ? ? 76  LEU B O     1 
+ATOM   4569 C CB    . LEU D 3 82  ? 50.502  29.224 98.320  1.00 26.19  ? ? ? ? ? ? 76  LEU B CB    1 
+ATOM   4570 C CG    . LEU D 3 82  ? 50.438  30.408 99.284  1.00 29.44  ? ? ? ? ? ? 76  LEU B CG    1 
+ATOM   4571 C CD1   . LEU D 3 82  ? 49.138  30.408 100.097 1.00 26.34  ? ? ? ? ? ? 76  LEU B CD1   1 
+ATOM   4572 C CD2   . LEU D 3 82  ? 51.684  30.473 100.169 1.00 27.59  ? ? ? ? ? ? 76  LEU B CD2   1 
+ATOM   4573 N N     . TYR D 3 83  ? 51.094  27.683 95.516  1.00 29.28  ? ? ? ? ? ? 77  TYR B N     1 
+ATOM   4574 C CA    . TYR D 3 83  ? 51.241  26.400 94.864  1.00 27.14  ? ? ? ? ? ? 77  TYR B CA    1 
+ATOM   4575 C C     . TYR D 3 83  ? 52.570  26.378 94.085  1.00 32.07  ? ? ? ? ? ? 77  TYR B C     1 
+ATOM   4576 O O     . TYR D 3 83  ? 53.249  25.364 94.058  1.00 34.28  ? ? ? ? ? ? 77  TYR B O     1 
+ATOM   4577 C CB    . TYR D 3 83  ? 50.021  26.143 93.979  1.00 27.69  ? ? ? ? ? ? 77  TYR B CB    1 
+ATOM   4578 C CG    . TYR D 3 83  ? 50.305  25.204 92.845  1.00 27.79  ? ? ? ? ? ? 77  TYR B CG    1 
+ATOM   4579 C CD1   . TYR D 3 83  ? 50.214  23.838 93.023  1.00 30.05  ? ? ? ? ? ? 77  TYR B CD1   1 
+ATOM   4580 C CD2   . TYR D 3 83  ? 50.698  25.685 91.608  1.00 27.51  ? ? ? ? ? ? 77  TYR B CD2   1 
+ATOM   4581 C CE1   . TYR D 3 83  ? 50.497  22.980 91.980  1.00 32.51  ? ? ? ? ? ? 77  TYR B CE1   1 
+ATOM   4582 C CE2   . TYR D 3 83  ? 50.973  24.838 90.573  1.00 27.12  ? ? ? ? ? ? 77  TYR B CE2   1 
+ATOM   4583 C CZ    . TYR D 3 83  ? 50.880  23.487 90.764  1.00 32.73  ? ? ? ? ? ? 77  TYR B CZ    1 
+ATOM   4584 O OH    . TYR D 3 83  ? 51.134  22.652 89.707  1.00 45.79  ? ? ? ? ? ? 77  TYR B OH    1 
+ATOM   4585 N N     . LEU D 3 84  ? 52.959  27.491 93.472  1.00 28.30  ? ? ? ? ? ? 78  LEU B N     1 
+ATOM   4586 C CA    . LEU D 3 84  ? 54.228  27.587 92.742  1.00 26.70  ? ? ? ? ? ? 78  LEU B CA    1 
+ATOM   4587 C C     . LEU D 3 84  ? 55.331  27.442 93.788  1.00 36.07  ? ? ? ? ? ? 78  LEU B C     1 
+ATOM   4588 O O     . LEU D 3 84  ? 56.286  26.687 93.604  1.00 34.07  ? ? ? ? ? ? 78  LEU B O     1 
+ATOM   4589 C CB    . LEU D 3 84  ? 54.346  28.975 92.099  1.00 25.91  ? ? ? ? ? ? 78  LEU B CB    1 
+ATOM   4590 C CG    . LEU D 3 84  ? 53.410  29.331 90.941  1.00 25.89  ? ? ? ? ? ? 78  LEU B CG    1 
+ATOM   4591 C CD1   . LEU D 3 84  ? 53.710  30.715 90.377  1.00 21.58  ? ? ? ? ? ? 78  LEU B CD1   1 
+ATOM   4592 C CD2   . LEU D 3 84  ? 53.524  28.275 89.857  1.00 25.78  ? ? ? ? ? ? 78  LEU B CD2   1 
+ATOM   4593 N N     . GLN D 3 85  ? 55.174  28.171 94.889  1.00 35.59  ? ? ? ? ? ? 79  GLN B N     1 
+ATOM   4594 C CA    . GLN D 3 85  ? 56.115  28.100 95.995  1.00 34.77  ? ? ? ? ? ? 79  GLN B CA    1 
+ATOM   4595 C C     . GLN D 3 85  ? 56.340  26.656 96.450  1.00 40.32  ? ? ? ? ? ? 79  GLN B C     1 
+ATOM   4596 O O     . GLN D 3 85  ? 57.472  26.217 96.628  1.00 43.84  ? ? ? ? ? ? 79  GLN B O     1 
+ATOM   4597 C CB    . GLN D 3 85  ? 55.620  28.933 97.169  1.00 35.70  ? ? ? ? ? ? 79  GLN B CB    1 
+ATOM   4598 C CG    . GLN D 3 85  ? 56.723  29.168 98.175  1.00 47.98  ? ? ? ? ? ? 79  GLN B CG    1 
+ATOM   4599 C CD    . GLN D 3 85  ? 56.221  29.397 99.577  1.00 61.82  ? ? ? ? ? ? 79  GLN B CD    1 
+ATOM   4600 O OE1   . GLN D 3 85  ? 55.091  29.048 99.920  1.00 61.22  ? ? ? ? ? ? 79  GLN B OE1   1 
+ATOM   4601 N NE2   . GLN D 3 85  ? 57.066  29.989 100.406 1.00 50.56  ? ? ? ? ? ? 79  GLN B NE2   1 
+ATOM   4602 N N     . ALA D 3 86  ? 55.257  25.907 96.606  1.00 34.22  ? ? ? ? ? ? 80  ALA B N     1 
+ATOM   4603 C CA    . ALA D 3 86  ? 55.341  24.523 97.025  1.00 30.34  ? ? ? ? ? ? 80  ALA B CA    1 
+ATOM   4604 C C     . ALA D 3 86  ? 55.928  23.631 95.952  1.00 38.22  ? ? ? ? ? ? 80  ALA B C     1 
+ATOM   4605 O O     . ALA D 3 86  ? 56.323  22.508 96.244  1.00 45.62  ? ? ? ? ? ? 80  ALA B O     1 
+ATOM   4606 C CB    . ALA D 3 86  ? 53.977  24.026 97.420  1.00 30.06  ? ? ? ? ? ? 80  ALA B CB    1 
+ATOM   4607 N N     . ARG D 3 87  ? 55.958  24.090 94.707  1.00 34.63  ? ? ? ? ? ? 81  ARG B N     1 
+ATOM   4608 C CA    . ARG D 3 87  ? 56.520  23.276 93.628  1.00 35.85  ? ? ? ? ? ? 81  ARG B CA    1 
+ATOM   4609 C C     . ARG D 3 87  ? 58.041  23.439 93.646  1.00 42.32  ? ? ? ? ? ? 81  ARG B C     1 
+ATOM   4610 O O     . ARG D 3 87  ? 58.750  22.811 92.863  1.00 44.81  ? ? ? ? ? ? 81  ARG B O     1 
+ATOM   4611 C CB    . ARG D 3 87  ? 55.985  23.705 92.251  1.00 36.85  ? ? ? ? ? ? 81  ARG B CB    1 
+ATOM   4612 C CG    . ARG D 3 87  ? 54.568  23.265 91.923  1.00 39.73  ? ? ? ? ? ? 81  ARG B CG    1 
+ATOM   4613 C CD    . ARG D 3 87  ? 54.358  23.246 90.425  1.00 42.24  ? ? ? ? ? ? 81  ARG B CD    1 
+ATOM   4614 N NE    . ARG D 3 87  ? 55.554  22.722 89.783  1.00 67.26  ? ? ? ? ? ? 81  ARG B NE    1 
+ATOM   4615 C CZ    . ARG D 3 87  ? 56.143  23.263 88.723  1.00 65.83  ? ? ? ? ? ? 81  ARG B CZ    1 
+ATOM   4616 N NH1   . ARG D 3 87  ? 55.634  24.344 88.148  1.00 41.30  ? ? ? ? ? ? 81  ARG B NH1   1 
+ATOM   4617 N NH2   . ARG D 3 87  ? 57.243  22.711 88.233  1.00 46.89  ? ? ? ? ? ? 81  ARG B NH2   1 
+ATOM   4618 N N     . GLY D 3 88  ? 58.519  24.296 94.544  1.00 34.77  ? ? ? ? ? ? 82  GLY B N     1 
+ATOM   4619 C CA    . GLY D 3 88  ? 59.933  24.558 94.722  1.00 32.12  ? ? ? ? ? ? 82  GLY B CA    1 
+ATOM   4620 C C     . GLY D 3 88  ? 60.491  25.517 93.681  1.00 38.41  ? ? ? ? ? ? 82  GLY B C     1 
+ATOM   4621 O O     . GLY D 3 88  ? 61.658  25.409 93.324  1.00 42.89  ? ? ? ? ? ? 82  GLY B O     1 
+ATOM   4622 N N     . LEU D 3 89  ? 59.687  26.451 93.179  1.00 36.47  ? ? ? ? ? ? 83  LEU B N     1 
+ATOM   4623 C CA    . LEU D 3 89  ? 60.160  27.396 92.166  1.00 34.22  ? ? ? ? ? ? 83  LEU B CA    1 
+ATOM   4624 C C     . LEU D 3 89  ? 60.806  28.577 92.863  1.00 36.49  ? ? ? ? ? ? 83  LEU B C     1 
+ATOM   4625 O O     . LEU D 3 89  ? 60.573  28.806 94.048  1.00 37.75  ? ? ? ? ? ? 83  LEU B O     1 
+ATOM   4626 C CB    . LEU D 3 89  ? 59.027  27.872 91.243  1.00 33.85  ? ? ? ? ? ? 83  LEU B CB    1 
+ATOM   4627 C CG    . LEU D 3 89  ? 58.191  26.851 90.447  1.00 35.53  ? ? ? ? ? ? 83  LEU B CG    1 
+ATOM   4628 C CD1   . LEU D 3 89  ? 57.334  27.551 89.405  1.00 34.21  ? ? ? ? ? ? 83  LEU B CD1   1 
+ATOM   4629 C CD2   . LEU D 3 89  ? 59.060  25.813 89.761  1.00 35.50  ? ? ? ? ? ? 83  LEU B CD2   1 
+ATOM   4630 N N     . ALA D 3 90  ? 61.605  29.326 92.112  1.00 31.38  ? ? ? ? ? ? 84  ALA B N     1 
+ATOM   4631 C CA    . ALA D 3 90  ? 62.330  30.484 92.619  1.00 28.40  ? ? ? ? ? ? 84  ALA B CA    1 
+ATOM   4632 C C     . ALA D 3 90  ? 61.418  31.662 92.868  1.00 37.34  ? ? ? ? ? ? 84  ALA B C     1 
+ATOM   4633 O O     . ALA D 3 90  ? 60.417  31.840 92.182  1.00 43.87  ? ? ? ? ? ? 84  ALA B O     1 
+ATOM   4634 C CB    . ALA D 3 90  ? 63.389  30.893 91.627  1.00 28.23  ? ? ? ? ? ? 84  ALA B CB    1 
+ATOM   4635 N N     . VAL D 3 91  ? 61.804  32.505 93.813  1.00 33.25  ? ? ? ? ? ? 85  VAL B N     1 
+ATOM   4636 C CA    . VAL D 3 91  ? 61.005  33.672 94.133  1.00 31.56  ? ? ? ? ? ? 85  VAL B CA    1 
+ATOM   4637 C C     . VAL D 3 91  ? 60.791  34.478 92.858  1.00 39.97  ? ? ? ? ? ? 85  VAL B C     1 
+ATOM   4638 O O     . VAL D 3 91  ? 59.687  34.967 92.606  1.00 42.98  ? ? ? ? ? ? 85  VAL B O     1 
+ATOM   4639 C CB    . VAL D 3 91  ? 61.672  34.504 95.251  1.00 32.72  ? ? ? ? ? ? 85  VAL B CB    1 
+ATOM   4640 C CG1   . VAL D 3 91  ? 61.074  35.892 95.325  1.00 33.11  ? ? ? ? ? ? 85  VAL B CG1   1 
+ATOM   4641 C CG2   . VAL D 3 91  ? 61.524  33.795 96.576  1.00 32.54  ? ? ? ? ? ? 85  VAL B CG2   1 
+ATOM   4642 N N     . LYS D 3 92  ? 61.848  34.586 92.053  1.00 34.83  ? ? ? ? ? ? 86  LYS B N     1 
+ATOM   4643 C CA    . LYS D 3 92  ? 61.814  35.334 90.796  1.00 32.70  ? ? ? ? ? ? 86  LYS B CA    1 
+ATOM   4644 C C     . LYS D 3 92  ? 60.824  34.782 89.778  1.00 33.97  ? ? ? ? ? ? 86  LYS B C     1 
+ATOM   4645 O O     . LYS D 3 92  ? 60.175  35.530 89.046  1.00 33.01  ? ? ? ? ? ? 86  LYS B O     1 
+ATOM   4646 C CB    . LYS D 3 92  ? 63.204  35.387 90.169  1.00 34.07  ? ? ? ? ? ? 86  LYS B CB    1 
+ATOM   4647 C CG    . LYS D 3 92  ? 64.149  36.349 90.862  1.00 36.16  ? ? ? ? ? ? 86  LYS B CG    1 
+ATOM   4648 C CD    . LYS D 3 92  ? 63.941  37.751 90.316  1.00 42.66  ? ? ? ? ? ? 86  LYS B CD    1 
+ATOM   4649 C CE    . LYS D 3 92  ? 65.253  38.410 89.910  1.00 53.98  ? ? ? ? ? ? 86  LYS B CE    1 
+ATOM   4650 N NZ    . LYS D 3 92  ? 64.945  39.759 89.344  1.00 63.58  ? ? ? ? ? ? 86  LYS B NZ    1 
+ATOM   4651 N N     . THR D 3 93  ? 60.734  33.460 89.716  1.00 31.55  ? ? ? ? ? ? 87  THR B N     1 
+ATOM   4652 C CA    . THR D 3 93  ? 59.792  32.819 88.808  1.00 32.26  ? ? ? ? ? ? 87  THR B CA    1 
+ATOM   4653 C C     . THR D 3 93  ? 58.366  33.069 89.315  1.00 37.13  ? ? ? ? ? ? 87  THR B C     1 
+ATOM   4654 O O     . THR D 3 93  ? 57.467  33.414 88.540  1.00 36.73  ? ? ? ? ? ? 87  THR B O     1 
+ATOM   4655 C CB    . THR D 3 93  ? 60.167  31.347 88.566  1.00 32.84  ? ? ? ? ? ? 87  THR B CB    1 
+ATOM   4656 O OG1   . THR D 3 93  ? 59.053  30.477 88.805  1.00 36.14  ? ? ? ? ? ? 87  THR B OG1   1 
+ATOM   4657 C CG2   . THR D 3 93  ? 61.320  30.991 89.457  1.00 39.11  ? ? ? ? ? ? 87  THR B CG2   1 
+ATOM   4658 N N     . ILE D 3 94  ? 58.198  32.980 90.632  1.00 34.35  ? ? ? ? ? ? 88  ILE B N     1 
+ATOM   4659 C CA    . ILE D 3 94  ? 56.910  33.255 91.245  1.00 33.12  ? ? ? ? ? ? 88  ILE B CA    1 
+ATOM   4660 C C     . ILE D 3 94  ? 56.534  34.718 91.024  1.00 36.67  ? ? ? ? ? ? 88  ILE B C     1 
+ATOM   4661 O O     . ILE D 3 94  ? 55.390  35.039 90.744  1.00 37.10  ? ? ? ? ? ? 88  ILE B O     1 
+ATOM   4662 C CB    . ILE D 3 94  ? 56.885  32.891 92.722  1.00 33.96  ? ? ? ? ? ? 88  ILE B CB    1 
+ATOM   4663 C CG1   . ILE D 3 94  ? 57.059  31.376 92.849  1.00 30.02  ? ? ? ? ? ? 88  ILE B CG1   1 
+ATOM   4664 C CG2   . ILE D 3 94  ? 55.601  33.430 93.368  1.00 34.16  ? ? ? ? ? ? 88  ILE B CG2   1 
+ATOM   4665 C CD1   . ILE D 3 94  ? 57.401  30.899 94.238  1.00 32.58  ? ? ? ? ? ? 88  ILE B CD1   1 
+ATOM   4666 N N     . GLN D 3 95  ? 57.511  35.609 91.102  1.00 34.96  ? ? ? ? ? ? 89  GLN B N     1 
+ATOM   4667 C CA    . GLN D 3 95  ? 57.216  37.010 90.854  1.00 36.72  ? ? ? ? ? ? 89  GLN B CA    1 
+ATOM   4668 C C     . GLN D 3 95  ? 56.924  37.255 89.371  1.00 43.06  ? ? ? ? ? ? 89  GLN B C     1 
+ATOM   4669 O O     . GLN D 3 95  ? 56.302  38.259 89.037  1.00 46.95  ? ? ? ? ? ? 89  GLN B O     1 
+ATOM   4670 C CB    . GLN D 3 95  ? 58.347  37.924 91.329  1.00 37.48  ? ? ? ? ? ? 89  GLN B CB    1 
+ATOM   4671 C CG    . GLN D 3 95  ? 58.844  37.653 92.724  1.00 39.82  ? ? ? ? ? ? 89  GLN B CG    1 
+ATOM   4672 C CD    . GLN D 3 95  ? 59.792  38.754 93.164  1.00 88.66  ? ? ? ? ? ? 89  GLN B CD    1 
+ATOM   4673 O OE1   . GLN D 3 95  ? 60.499  39.317 92.343  1.00 90.06  ? ? ? ? ? ? 89  GLN B OE1   1 
+ATOM   4674 N NE2   . GLN D 3 95  ? 59.767  39.049 94.454  1.00 99.54  ? ? ? ? ? ? 89  GLN B NE2   1 
+ATOM   4675 N N     . GLN D 3 96  ? 57.370  36.347 88.495  1.00 36.58  ? ? ? ? ? ? 90  GLN B N     1 
+ATOM   4676 C CA    . GLN D 3 96  ? 57.135  36.483 87.054  1.00 33.55  ? ? ? ? ? ? 90  GLN B CA    1 
+ATOM   4677 C C     . GLN D 3 96  ? 55.681  36.139 86.735  1.00 33.19  ? ? ? ? ? ? 90  GLN B C     1 
+ATOM   4678 O O     . GLN D 3 96  ? 55.023  36.826 85.948  1.00 31.72  ? ? ? ? ? ? 90  GLN B O     1 
+ATOM   4679 C CB    . GLN D 3 96  ? 58.073  35.597 86.229  1.00 33.74  ? ? ? ? ? ? 90  GLN B CB    1 
+ATOM   4680 C CG    . GLN D 3 96  ? 57.816  35.679 84.713  1.00 30.94  ? ? ? ? ? ? 90  GLN B CG    1 
+ATOM   4681 C CD    . GLN D 3 96  ? 58.485  36.873 84.041  1.00 50.63  ? ? ? ? ? ? 90  GLN B CD    1 
+ATOM   4682 O OE1   . GLN D 3 96  ? 59.569  37.309 84.430  1.00 72.79  ? ? ? ? ? ? 90  GLN B OE1   1 
+ATOM   4683 N NE2   . GLN D 3 96  ? 57.827  37.412 83.025  1.00 37.67  ? ? ? ? ? ? 90  GLN B NE2   1 
+ATOM   4684 N N     . HIS D 3 97  ? 55.188  35.081 87.374  1.00 31.34  ? ? ? ? ? ? 91  HIS B N     1 
+ATOM   4685 C CA    . HIS D 3 97  ? 53.795  34.644 87.236  1.00 28.83  ? ? ? ? ? ? 91  HIS B CA    1 
+ATOM   4686 C C     . HIS D 3 97  ? 52.812  35.720 87.694  1.00 33.51  ? ? ? ? ? ? 91  HIS B C     1 
+ATOM   4687 O O     . HIS D 3 97  ? 51.877  36.071 86.972  1.00 32.70  ? ? ? ? ? ? 91  HIS B O     1 
+ATOM   4688 C CB    . HIS D 3 97  ? 53.580  33.304 87.927  1.00 26.97  ? ? ? ? ? ? 91  HIS B CB    1 
+ATOM   4689 C CG    . HIS D 3 97  ? 54.254  32.179 87.212  1.00 31.53  ? ? ? ? ? ? 91  HIS B CG    1 
+ATOM   4690 N ND1   . HIS D 3 97  ? 53.582  31.055 86.786  1.00 34.62  ? ? ? ? ? ? 91  HIS B ND1   1 
+ATOM   4691 C CD2   . HIS D 3 97  ? 55.541  32.019 86.818  1.00 32.66  ? ? ? ? ? ? 91  HIS B CD2   1 
+ATOM   4692 C CE1   . HIS D 3 97  ? 54.431  30.231 86.196  1.00 32.45  ? ? ? ? ? ? 91  HIS B CE1   1 
+ATOM   4693 N NE2   . HIS D 3 97  ? 55.626  30.796 86.198  1.00 32.10  ? ? ? ? ? ? 91  HIS B NE2   1 
+ATOM   4694 N N     . LEU D 3 98  ? 53.093  36.303 88.853  1.00 31.33  ? ? ? ? ? ? 92  LEU B N     1 
+ATOM   4695 C CA    . LEU D 3 98  ? 52.290  37.389 89.390  1.00 31.78  ? ? ? ? ? ? 92  LEU B CA    1 
+ATOM   4696 C C     . LEU D 3 98  ? 52.379  38.618 88.474  1.00 40.22  ? ? ? ? ? ? 92  LEU B C     1 
+ATOM   4697 O O     . LEU D 3 98  ? 51.390  39.309 88.232  1.00 42.49  ? ? ? ? ? ? 92  LEU B O     1 
+ATOM   4698 C CB    . LEU D 3 98  ? 52.821  37.754 90.784  1.00 32.14  ? ? ? ? ? ? 92  LEU B CB    1 
+ATOM   4699 C CG    . LEU D 3 98  ? 51.897  38.412 91.815  1.00 36.09  ? ? ? ? ? ? 92  LEU B CG    1 
+ATOM   4700 C CD1   . LEU D 3 98  ? 52.661  39.159 92.898  1.00 33.30  ? ? ? ? ? ? 92  LEU B CD1   1 
+ATOM   4701 C CD2   . LEU D 3 98  ? 50.807  39.281 91.196  1.00 31.73  ? ? ? ? ? ? 92  LEU B CD2   1 
+ATOM   4702 N N     . GLY D 3 99  ? 53.575  38.934 87.988  1.00 34.96  ? ? ? ? ? ? 93  GLY B N     1 
+ATOM   4703 C CA    . GLY D 3 99  ? 53.728  40.106 87.135  1.00 33.12  ? ? ? ? ? ? 93  GLY B CA    1 
+ATOM   4704 C C     . GLY D 3 99  ? 52.999  39.969 85.795  1.00 36.61  ? ? ? ? ? ? 93  GLY B C     1 
+ATOM   4705 O O     . GLY D 3 99  ? 52.455  40.947 85.283  1.00 34.07  ? ? ? ? ? ? 93  GLY B O     1 
+ATOM   4706 N N     . GLN D 3 100 ? 53.033  38.779 85.203  1.00 34.16  ? ? ? ? ? ? 94  GLN B N     1 
+ATOM   4707 C CA    . GLN D 3 100 ? 52.337  38.564 83.936  1.00 33.19  ? ? ? ? ? ? 94  GLN B CA    1 
+ATOM   4708 C C     . GLN D 3 100 ? 50.823  38.741 84.156  1.00 34.57  ? ? ? ? ? ? 94  GLN B C     1 
+ATOM   4709 O O     . GLN D 3 100 ? 50.165  39.427 83.378  1.00 32.69  ? ? ? ? ? ? 94  GLN B O     1 
+ATOM   4710 C CB    . GLN D 3 100 ? 52.633  37.177 83.360  1.00 33.88  ? ? ? ? ? ? 94  GLN B CB    1 
+ATOM   4711 C CG    . GLN D 3 100 ? 53.998  37.031 82.701  1.00 41.93  ? ? ? ? ? ? 94  GLN B CG    1 
+ATOM   4712 C CD    . GLN D 3 100 ? 54.352  38.145 81.706  1.00 43.83  ? ? ? ? ? ? 94  GLN B CD    1 
+ATOM   4713 O OE1   . GLN D 3 100 ? 53.484  38.764 81.114  1.00 39.29  ? ? ? ? ? ? 94  GLN B OE1   1 
+ATOM   4714 N NE2   . GLN D 3 100 ? 55.646  38.360 81.538  1.00 54.35  ? ? ? ? ? ? 94  GLN B NE2   1 
+ATOM   4715 N N     . LEU D 3 101 ? 50.287  38.123 85.217  1.00 31.30  ? ? ? ? ? ? 95  LEU B N     1 
+ATOM   4716 C CA    . LEU D 3 101 ? 48.869  38.223 85.590  1.00 28.76  ? ? ? ? ? ? 95  LEU B CA    1 
+ATOM   4717 C C     . LEU D 3 101 ? 48.526  39.680 85.836  1.00 32.78  ? ? ? ? ? ? 95  LEU B C     1 
+ATOM   4718 O O     . LEU D 3 101 ? 47.483  40.155 85.409  1.00 33.96  ? ? ? ? ? ? 95  LEU B O     1 
+ATOM   4719 C CB    . LEU D 3 101 ? 48.563  37.422 86.870  1.00 26.90  ? ? ? ? ? ? 95  LEU B CB    1 
+ATOM   4720 C CG    . LEU D 3 101 ? 48.520  35.901 86.697  1.00 28.64  ? ? ? ? ? ? 95  LEU B CG    1 
+ATOM   4721 C CD1   . LEU D 3 101 ? 48.155  35.192 87.978  1.00 25.86  ? ? ? ? ? ? 95  LEU B CD1   1 
+ATOM   4722 C CD2   . LEU D 3 101 ? 47.563  35.499 85.577  1.00 28.55  ? ? ? ? ? ? 95  LEU B CD2   1 
+ATOM   4723 N N     . ASN D 3 102 ? 49.409  40.396 86.525  1.00 30.68  ? ? ? ? ? ? 96  ASN B N     1 
+ATOM   4724 C CA    . ASN D 3 102 ? 49.146  41.795 86.805  1.00 31.80  ? ? ? ? ? ? 96  ASN B CA    1 
+ATOM   4725 C C     . ASN D 3 102 ? 49.031  42.584 85.504  1.00 40.65  ? ? ? ? ? ? 96  ASN B C     1 
+ATOM   4726 O O     . ASN D 3 102 ? 48.201  43.484 85.394  1.00 42.54  ? ? ? ? ? ? 96  ASN B O     1 
+ATOM   4727 C CB    . ASN D 3 102 ? 50.255  42.405 87.663  1.00 34.00  ? ? ? ? ? ? 96  ASN B CB    1 
+ATOM   4728 C CG    . ASN D 3 102 ? 50.120  42.075 89.126  1.00 42.61  ? ? ? ? ? ? 96  ASN B CG    1 
+ATOM   4729 O OD1   . ASN D 3 102 ? 49.084  41.592 89.588  1.00 38.16  ? ? ? ? ? ? 96  ASN B OD1   1 
+ATOM   4730 N ND2   . ASN D 3 102 ? 51.179  42.337 89.876  1.00 41.46  ? ? ? ? ? ? 96  ASN B ND2   1 
+ATOM   4731 N N     . MET D 3 103 ? 49.889  42.270 84.533  1.00 38.65  ? ? ? ? ? ? 97  MET B N     1 
+ATOM   4732 C CA    . MET D 3 103 ? 49.902  42.973 83.252  1.00 36.79  ? ? ? ? ? ? 97  MET B CA    1 
+ATOM   4733 C C     . MET D 3 103 ? 48.652  42.671 82.456  1.00 34.63  ? ? ? ? ? ? 97  MET B C     1 
+ATOM   4734 O O     . MET D 3 103 ? 48.078  43.566 81.853  1.00 34.01  ? ? ? ? ? ? 97  MET B O     1 
+ATOM   4735 C CB    . MET D 3 103 ? 51.129  42.602 82.418  1.00 40.35  ? ? ? ? ? ? 97  MET B CB    1 
+ATOM   4736 C CG    . MET D 3 103 ? 51.366  43.534 81.230  1.00 46.43  ? ? ? ? ? ? 97  MET B CG    1 
+ATOM   4737 S SD    . MET D 3 103 ? 52.047  42.726 79.748  1.00 54.13  ? ? ? ? ? ? 97  MET B SD    1 
+ATOM   4738 C CE    . MET D 3 103 ? 53.434  41.863 80.427  1.00 52.36  ? ? ? ? ? ? 97  MET B CE    1 
+ATOM   4739 N N     . LEU D 3 104 ? 48.254  41.404 82.423  1.00 32.20  ? ? ? ? ? ? 98  LEU B N     1 
+ATOM   4740 C CA    . LEU D 3 104 ? 47.041  41.009 81.704  1.00 31.39  ? ? ? ? ? ? 98  LEU B CA    1 
+ATOM   4741 C C     . LEU D 3 104 ? 45.863  41.840 82.188  1.00 36.01  ? ? ? ? ? ? 98  LEU B C     1 
+ATOM   4742 O O     . LEU D 3 104 ? 45.098  42.368 81.396  1.00 41.23  ? ? ? ? ? ? 98  LEU B O     1 
+ATOM   4743 C CB    . LEU D 3 104 ? 46.723  39.536 81.955  1.00 29.81  ? ? ? ? ? ? 98  LEU B CB    1 
+ATOM   4744 C CG    . LEU D 3 104 ? 45.549  38.946 81.185  1.00 32.03  ? ? ? ? ? ? 98  LEU B CG    1 
+ATOM   4745 C CD1   . LEU D 3 104 ? 45.828  39.119 79.710  1.00 32.21  ? ? ? ? ? ? 98  LEU B CD1   1 
+ATOM   4746 C CD2   . LEU D 3 104 ? 45.435  37.469 81.541  1.00 29.41  ? ? ? ? ? ? 98  LEU B CD2   1 
+ATOM   4747 N N     . HIS D 3 105 ? 45.733  41.953 83.502  1.00 29.26  ? ? ? ? ? ? 99  HIS B N     1 
+ATOM   4748 C CA    . HIS D 3 105 ? 44.655  42.710 84.119  1.00 27.28  ? ? ? ? ? ? 99  HIS B CA    1 
+ATOM   4749 C C     . HIS D 3 105 ? 44.771  44.228 83.933  1.00 36.62  ? ? ? ? ? ? 99  HIS B C     1 
+ATOM   4750 O O     . HIS D 3 105 ? 43.868  44.841 83.363  1.00 37.14  ? ? ? ? ? ? 99  HIS B O     1 
+ATOM   4751 C CB    . HIS D 3 105 ? 44.508  42.286 85.593  1.00 26.62  ? ? ? ? ? ? 99  HIS B CB    1 
+ATOM   4752 C CG    . HIS D 3 105 ? 44.012  40.881 85.756  1.00 31.63  ? ? ? ? ? ? 99  HIS B CG    1 
+ATOM   4753 N ND1   . HIS D 3 105 ? 44.791  39.779 85.475  1.00 34.47  ? ? ? ? ? ? 99  HIS B ND1   1 
+ATOM   4754 C CD2   . HIS D 3 105 ? 42.798  40.396 86.114  1.00 35.73  ? ? ? ? ? ? 99  HIS B CD2   1 
+ATOM   4755 C CE1   . HIS D 3 105 ? 44.084  38.676 85.664  1.00 35.14  ? ? ? ? ? ? 99  HIS B CE1   1 
+ATOM   4756 N NE2   . HIS D 3 105 ? 42.870  39.023 86.051  1.00 35.65  ? ? ? ? ? ? 99  HIS B NE2   1 
+ATOM   4757 N N     . ARG D 3 106 ? 45.874  44.826 84.383  1.00 36.18  ? ? ? ? ? ? 100 ARG B N     1 
+ATOM   4758 C CA    . ARG D 3 106 ? 46.091  46.273 84.256  1.00 35.27  ? ? ? ? ? ? 100 ARG B CA    1 
+ATOM   4759 C C     . ARG D 3 106 ? 45.871  46.719 82.810  1.00 43.00  ? ? ? ? ? ? 100 ARG B C     1 
+ATOM   4760 O O     . ARG D 3 106 ? 45.099  47.639 82.524  1.00 44.62  ? ? ? ? ? ? 100 ARG B O     1 
+ATOM   4761 C CB    . ARG D 3 106 ? 47.500  46.674 84.713  1.00 31.32  ? ? ? ? ? ? 100 ARG B CB    1 
+ATOM   4762 C CG    . ARG D 3 106 ? 47.635  48.164 85.039  1.00 41.30  ? ? ? ? ? ? 100 ARG B CG    1 
+ATOM   4763 C CD    . ARG D 3 106 ? 49.081  48.619 85.215  1.00 60.77  ? ? ? ? ? ? 100 ARG B CD    1 
+ATOM   4764 N NE    . ARG D 3 106 ? 49.885  48.187 84.082  1.00 88.17  ? ? ? ? ? ? 100 ARG B NE    1 
+ATOM   4765 C CZ    . ARG D 3 106 ? 50.645  47.102 84.057  1.00 97.82  ? ? ? ? ? ? 100 ARG B CZ    1 
+ATOM   4766 N NH1   . ARG D 3 106 ? 50.769  46.299 85.105  1.00 67.78  ? ? ? ? ? ? 100 ARG B NH1   1 
+ATOM   4767 N NH2   . ARG D 3 106 ? 51.282  46.809 82.945  1.00 84.87  ? ? ? ? ? ? 100 ARG B NH2   1 
+ATOM   4768 N N     . ARG D 3 107 ? 46.526  46.037 81.885  1.00 38.07  ? ? ? ? ? ? 101 ARG B N     1 
+ATOM   4769 C CA    . ARG D 3 107 ? 46.360  46.388 80.487  1.00 38.14  ? ? ? ? ? ? 101 ARG B CA    1 
+ATOM   4770 C C     . ARG D 3 107 ? 44.969  46.033 80.046  1.00 45.21  ? ? ? ? ? ? 101 ARG B C     1 
+ATOM   4771 O O     . ARG D 3 107 ? 44.572  46.348 78.927  1.00 44.60  ? ? ? ? ? ? 101 ARG B O     1 
+ATOM   4772 C CB    . ARG D 3 107 ? 47.339  45.608 79.628  1.00 38.00  ? ? ? ? ? ? 101 ARG B CB    1 
+ATOM   4773 C CG    . ARG D 3 107 ? 48.756  45.899 79.988  1.00 50.54  ? ? ? ? ? ? 101 ARG B CG    1 
+ATOM   4774 C CD    . ARG D 3 107 ? 49.401  46.601 78.837  1.00 45.77  ? ? ? ? ? ? 101 ARG B CD    1 
+ATOM   4775 N NE    . ARG D 3 107 ? 50.475  47.465 79.292  1.00 46.78  ? ? ? ? ? ? 101 ARG B NE    1 
+ATOM   4776 C CZ    . ARG D 3 107 ? 50.776  48.605 78.690  1.00 65.06  ? ? ? ? ? ? 101 ARG B CZ    1 
+ATOM   4777 N NH1   . ARG D 3 107 ? 50.060  48.985 77.642  1.00 57.53  ? ? ? ? ? ? 101 ARG B NH1   1 
+ATOM   4778 N NH2   . ARG D 3 107 ? 51.776  49.361 79.130  1.00 41.58  ? ? ? ? ? ? 101 ARG B NH2   1 
+ATOM   4779 N N     . SER D 3 108 ? 44.243  45.326 80.898  1.00 43.79  ? ? ? ? ? ? 102 SER B N     1 
+ATOM   4780 C CA    . SER D 3 108 ? 42.893  44.937 80.536  1.00 43.29  ? ? ? ? ? ? 102 SER B CA    1 
+ATOM   4781 C C     . SER D 3 108 ? 41.923  46.012 80.969  1.00 49.68  ? ? ? ? ? ? 102 SER B C     1 
+ATOM   4782 O O     . SER D 3 108 ? 40.771  46.029 80.540  1.00 49.18  ? ? ? ? ? ? 102 SER B O     1 
+ATOM   4783 C CB    . SER D 3 108 ? 42.509  43.628 81.209  1.00 44.08  ? ? ? ? ? ? 102 SER B CB    1 
+ATOM   4784 O OG    . SER D 3 108 ? 42.376  42.604 80.237  1.00 46.13  ? ? ? ? ? ? 102 SER B OG    1 
+ATOM   4785 N N     . GLY D 3 109 ? 42.399  46.908 81.821  1.00 48.33  ? ? ? ? ? ? 103 GLY B N     1 
+ATOM   4786 C CA    . GLY D 3 109 ? 41.570  47.972 82.350  1.00 48.78  ? ? ? ? ? ? 103 GLY B CA    1 
+ATOM   4787 C C     . GLY D 3 109 ? 40.894  47.402 83.591  1.00 56.81  ? ? ? ? ? ? 103 GLY B C     1 
+ATOM   4788 O O     . GLY D 3 109 ? 39.911  47.963 84.067  1.00 60.89  ? ? ? ? ? ? 103 GLY B O     1 
+ATOM   4789 N N     . LEU D 3 110 ? 41.402  46.272 84.091  1.00 51.24  ? ? ? ? ? ? 104 LEU B N     1 
+ATOM   4790 C CA    . LEU D 3 110 ? 40.882  45.617 85.299  1.00 48.56  ? ? ? ? ? ? 104 LEU B CA    1 
+ATOM   4791 C C     . LEU D 3 110 ? 41.892  45.742 86.441  1.00 54.14  ? ? ? ? ? ? 104 LEU B C     1 
+ATOM   4792 O O     . LEU D 3 110 ? 43.070  46.008 86.200  1.00 53.71  ? ? ? ? ? ? 104 LEU B O     1 
+ATOM   4793 C CB    . LEU D 3 110 ? 40.559  44.144 85.055  1.00 46.49  ? ? ? ? ? ? 104 LEU B CB    1 
+ATOM   4794 C CG    . LEU D 3 110 ? 39.654  43.874 83.859  1.00 48.83  ? ? ? ? ? ? 104 LEU B CG    1 
+ATOM   4795 C CD1   . LEU D 3 110 ? 39.714  42.407 83.452  1.00 48.81  ? ? ? ? ? ? 104 LEU B CD1   1 
+ATOM   4796 C CD2   . LEU D 3 110 ? 38.237  44.276 84.231  1.00 49.40  ? ? ? ? ? ? 104 LEU B CD2   1 
+ATOM   4797 N N     . PRO D 3 111 ? 41.429  45.595 87.682  1.00 52.69  ? ? ? ? ? ? 105 PRO B N     1 
+ATOM   4798 C CA    . PRO D 3 111 ? 42.327  45.723 88.833  1.00 51.50  ? ? ? ? ? ? 105 PRO B CA    1 
+ATOM   4799 C C     . PRO D 3 111 ? 43.444  44.681 88.741  1.00 50.65  ? ? ? ? ? ? 105 PRO B C     1 
+ATOM   4800 O O     . PRO D 3 111 ? 43.237  43.640 88.126  1.00 46.88  ? ? ? ? ? ? 105 PRO B O     1 
+ATOM   4801 C CB    . PRO D 3 111 ? 41.416  45.395 90.024  1.00 53.72  ? ? ? ? ? ? 105 PRO B CB    1 
+ATOM   4802 C CG    . PRO D 3 111 ? 39.994  45.442 89.511  1.00 58.03  ? ? ? ? ? ? 105 PRO B CG    1 
+ATOM   4803 C CD    . PRO D 3 111 ? 40.016  45.800 88.056  1.00 53.67  ? ? ? ? ? ? 105 PRO B CD    1 
+ATOM   4804 N N     . ARG D 3 112 ? 44.587  44.921 89.384  1.00 46.20  ? ? ? ? ? ? 106 ARG B N     1 
+ATOM   4805 C CA    . ARG D 3 112 ? 45.688  43.963 89.371  1.00 44.30  ? ? ? ? ? ? 106 ARG B CA    1 
+ATOM   4806 C C     . ARG D 3 112 ? 45.612  43.075 90.596  1.00 52.66  ? ? ? ? ? ? 106 ARG B C     1 
+ATOM   4807 O O     . ARG D 3 112 ? 45.279  43.551 91.690  1.00 57.49  ? ? ? ? ? ? 106 ARG B O     1 
+ATOM   4808 C CB    . ARG D 3 112 ? 47.036  44.678 89.363  1.00 37.77  ? ? ? ? ? ? 106 ARG B CB    1 
+ATOM   4809 C CG    . ARG D 3 112 ? 47.334  45.307 88.028  1.00 45.23  ? ? ? ? ? ? 106 ARG B CG    1 
+ATOM   4810 C CD    . ARG D 3 112 ? 48.576  46.141 88.111  1.00 41.62  ? ? ? ? ? ? 106 ARG B CD    1 
+ATOM   4811 N NE    . ARG D 3 112 ? 48.734  46.733 89.431  1.00 49.71  ? ? ? ? ? ? 106 ARG B NE    1 
+ATOM   4812 C CZ    . ARG D 3 112 ? 49.726  46.433 90.264  1.00 88.13  ? ? ? ? ? ? 106 ARG B CZ    1 
+ATOM   4813 N NH1   . ARG D 3 112 ? 50.642  45.535 89.920  1.00 87.67  ? ? ? ? ? ? 106 ARG B NH1   1 
+ATOM   4814 N NH2   . ARG D 3 112 ? 49.796  47.024 91.448  1.00 84.20  ? ? ? ? ? ? 106 ARG B NH2   1 
+ATOM   4815 N N     . PRO D 3 113 ? 45.887  41.787 90.423  1.00 44.39  ? ? ? ? ? ? 107 PRO B N     1 
+ATOM   4816 C CA    . PRO D 3 113 ? 45.871  40.896 91.573  1.00 42.25  ? ? ? ? ? ? 107 PRO B CA    1 
+ATOM   4817 C C     . PRO D 3 113 ? 46.666  41.547 92.705  1.00 39.84  ? ? ? ? ? ? 107 PRO B C     1 
+ATOM   4818 O O     . PRO D 3 113 ? 46.184  41.664 93.835  1.00 36.20  ? ? ? ? ? ? 107 PRO B O     1 
+ATOM   4819 C CB    . PRO D 3 113 ? 46.572  39.653 91.040  1.00 43.26  ? ? ? ? ? ? 107 PRO B CB    1 
+ATOM   4820 C CG    . PRO D 3 113 ? 46.084  39.590 89.618  1.00 46.73  ? ? ? ? ? ? 107 PRO B CG    1 
+ATOM   4821 C CD    . PRO D 3 113 ? 45.861  41.023 89.158  1.00 43.30  ? ? ? ? ? ? 107 PRO B CD    1 
+ATOM   4822 N N     . SER D 3 114 ? 47.872  42.002 92.388  1.00 35.33  ? ? ? ? ? ? 108 SER B N     1 
+ATOM   4823 C CA    . SER D 3 114 ? 48.688  42.641 93.405  1.00 37.14  ? ? ? ? ? ? 108 SER B CA    1 
+ATOM   4824 C C     . SER D 3 114 ? 47.983  43.800 94.110  1.00 45.02  ? ? ? ? ? ? 108 SER B C     1 
+ATOM   4825 O O     . SER D 3 114 ? 48.444  44.293 95.139  1.00 43.52  ? ? ? ? ? ? 108 SER B O     1 
+ATOM   4826 C CB    . SER D 3 114 ? 50.050  43.037 92.852  1.00 40.57  ? ? ? ? ? ? 108 SER B CB    1 
+ATOM   4827 O OG    . SER D 3 114 ? 50.920  41.920 92.911  1.00 53.31  ? ? ? ? ? ? 108 SER B OG    1 
+ATOM   4828 N N     . ASP D 3 115 ? 46.837  44.211 93.583  1.00 41.77  ? ? ? ? ? ? 109 ASP B N     1 
+ATOM   4829 C CA    . ASP D 3 115 ? 46.104  45.299 94.204  1.00 39.57  ? ? ? ? ? ? 109 ASP B CA    1 
+ATOM   4830 C C     . ASP D 3 115 ? 45.331  44.827 95.415  1.00 41.92  ? ? ? ? ? ? 109 ASP B C     1 
+ATOM   4831 O O     . ASP D 3 115 ? 44.640  45.610 96.053  1.00 41.73  ? ? ? ? ? ? 109 ASP B O     1 
+ATOM   4832 C CB    . ASP D 3 115 ? 45.156  45.931 93.205  1.00 41.03  ? ? ? ? ? ? 109 ASP B CB    1 
+ATOM   4833 C CG    . ASP D 3 115 ? 45.877  46.812 92.240  1.00 48.55  ? ? ? ? ? ? 109 ASP B CG    1 
+ATOM   4834 O OD1   . ASP D 3 115 ? 46.923  47.356 92.643  1.00 49.02  ? ? ? ? ? ? 109 ASP B OD1   1 
+ATOM   4835 O OD2   . ASP D 3 115 ? 45.403  46.965 91.096  1.00 60.15  ? ? ? ? ? ? 109 ASP B OD2   1 
+ATOM   4836 N N     . SER D 3 116 ? 45.466  43.555 95.754  1.00 37.95  ? ? ? ? ? ? 110 SER B N     1 
+ATOM   4837 C CA    . SER D 3 116 ? 44.751  43.043 96.905  1.00 37.88  ? ? ? ? ? ? 110 SER B CA    1 
+ATOM   4838 C C     . SER D 3 116 ? 45.700  42.550 97.983  1.00 40.46  ? ? ? ? ? ? 110 SER B C     1 
+ATOM   4839 O O     . SER D 3 116 ? 46.637  41.797 97.714  1.00 44.93  ? ? ? ? ? ? 110 SER B O     1 
+ATOM   4840 C CB    . SER D 3 116 ? 43.775  41.944 96.480  1.00 44.02  ? ? ? ? ? ? 110 SER B CB    1 
+ATOM   4841 O OG    . SER D 3 116 ? 44.441  40.728 96.198  1.00 63.85  ? ? ? ? ? ? 110 SER B OG    1 
+ATOM   4842 N N     . ASN D 3 117 ? 45.422  42.949 99.214  1.00 32.08  ? ? ? ? ? ? 111 ASN B N     1 
+ATOM   4843 C CA    . ASN D 3 117 ? 46.229  42.517 100.335 1.00 30.00  ? ? ? ? ? ? 111 ASN B CA    1 
+ATOM   4844 C C     . ASN D 3 117 ? 46.532  41.045 100.194 1.00 34.56  ? ? ? ? ? ? 111 ASN B C     1 
+ATOM   4845 O O     . ASN D 3 117 ? 47.657  40.623 100.409 1.00 36.83  ? ? ? ? ? ? 111 ASN B O     1 
+ATOM   4846 C CB    . ASN D 3 117 ? 45.475  42.716 101.648 1.00 34.70  ? ? ? ? ? ? 111 ASN B CB    1 
+ATOM   4847 C CG    . ASN D 3 117 ? 45.561  44.122 102.147 1.00 52.38  ? ? ? ? ? ? 111 ASN B CG    1 
+ATOM   4848 O OD1   . ASN D 3 117 ? 46.428  44.875 101.724 1.00 51.81  ? ? ? ? ? ? 111 ASN B OD1   1 
+ATOM   4849 N ND2   . ASN D 3 117 ? 44.679  44.487 103.064 1.00 55.69  ? ? ? ? ? ? 111 ASN B ND2   1 
+ATOM   4850 N N     . ALA D 3 118 ? 45.525  40.224 99.905  1.00 33.44  ? ? ? ? ? ? 112 ALA B N     1 
+ATOM   4851 C CA    . ALA D 3 118 ? 45.812  38.799 99.828  1.00 33.88  ? ? ? ? ? ? 112 ALA B CA    1 
+ATOM   4852 C C     . ALA D 3 118 ? 46.981  38.495 98.921  1.00 37.72  ? ? ? ? ? ? 112 ALA B C     1 
+ATOM   4853 O O     . ALA D 3 118 ? 47.789  37.629 99.235  1.00 39.06  ? ? ? ? ? ? 112 ALA B O     1 
+ATOM   4854 C CB    . ALA D 3 118 ? 44.599  37.985 99.410  1.00 33.75  ? ? ? ? ? ? 112 ALA B CB    1 
+ATOM   4855 N N     . VAL D 3 119 ? 47.045  39.157 97.772  1.00 31.84  ? ? ? ? ? ? 113 VAL B N     1 
+ATOM   4856 C CA    . VAL D 3 119 ? 48.115  38.868 96.828  1.00 30.48  ? ? ? ? ? ? 113 VAL B CA    1 
+ATOM   4857 C C     . VAL D 3 119 ? 49.398  39.602 97.190  1.00 33.45  ? ? ? ? ? ? 113 VAL B C     1 
+ATOM   4858 O O     . VAL D 3 119 ? 50.488  39.038 97.129  1.00 32.98  ? ? ? ? ? ? 113 VAL B O     1 
+ATOM   4859 C CB    . VAL D 3 119 ? 47.677  39.156 95.394  1.00 33.30  ? ? ? ? ? ? 113 VAL B CB    1 
+ATOM   4860 C CG1   . VAL D 3 119 ? 48.754  38.704 94.427  1.00 32.57  ? ? ? ? ? ? 113 VAL B CG1   1 
+ATOM   4861 C CG2   . VAL D 3 119 ? 46.383  38.420 95.109  1.00 32.42  ? ? ? ? ? ? 113 VAL B CG2   1 
+ATOM   4862 N N     . SER D 3 120 ? 49.243  40.862 97.582  1.00 30.05  ? ? ? ? ? ? 114 SER B N     1 
+ATOM   4863 C CA    . SER D 3 120 ? 50.347  41.700 98.026  1.00 27.43  ? ? ? ? ? ? 114 SER B CA    1 
+ATOM   4864 C C     . SER D 3 120 ? 51.141  41.012 99.125  1.00 35.32  ? ? ? ? ? ? 114 SER B C     1 
+ATOM   4865 O O     . SER D 3 120 ? 52.343  40.812 99.000  1.00 38.24  ? ? ? ? ? ? 114 SER B O     1 
+ATOM   4866 C CB    . SER D 3 120 ? 49.788  42.996 98.603  1.00 21.18  ? ? ? ? ? ? 114 SER B CB    1 
+ATOM   4867 O OG    . SER D 3 120 ? 49.222  43.741 97.551  1.00 45.44  ? ? ? ? ? ? 114 SER B OG    1 
+ATOM   4868 N N     . LEU D 3 121 ? 50.464  40.666 100.212 1.00 31.18  ? ? ? ? ? ? 115 LEU B N     1 
+ATOM   4869 C CA    . LEU D 3 121 ? 51.102  40.049 101.363 1.00 29.35  ? ? ? ? ? ? 115 LEU B CA    1 
+ATOM   4870 C C     . LEU D 3 121 ? 51.631  38.647 101.169 1.00 31.03  ? ? ? ? ? ? 115 LEU B C     1 
+ATOM   4871 O O     . LEU D 3 121 ? 52.582  38.263 101.845 1.00 34.40  ? ? ? ? ? ? 115 LEU B O     1 
+ATOM   4872 C CB    . LEU D 3 121 ? 50.163  40.042 102.569 1.00 29.81  ? ? ? ? ? ? 115 LEU B CB    1 
+ATOM   4873 C CG    . LEU D 3 121 ? 49.586  41.364 103.066 1.00 33.56  ? ? ? ? ? ? 115 LEU B CG    1 
+ATOM   4874 C CD1   . LEU D 3 121 ? 48.410  41.133 104.020 1.00 32.18  ? ? ? ? ? ? 115 LEU B CD1   1 
+ATOM   4875 C CD2   . LEU D 3 121 ? 50.688  42.206 103.705 1.00 32.53  ? ? ? ? ? ? 115 LEU B CD2   1 
+ATOM   4876 N N     . VAL D 3 122 ? 50.986  37.838 100.335 1.00 26.13  ? ? ? ? ? ? 116 VAL B N     1 
+ATOM   4877 C CA    . VAL D 3 122 ? 51.454  36.461 100.163 1.00 26.25  ? ? ? ? ? ? 116 VAL B CA    1 
+ATOM   4878 C C     . VAL D 3 122 ? 52.765  36.532 99.398  1.00 31.30  ? ? ? ? ? ? 116 VAL B C     1 
+ATOM   4879 O O     . VAL D 3 122 ? 53.649  35.706 99.607  1.00 30.44  ? ? ? ? ? ? 116 VAL B O     1 
+ATOM   4880 C CB    . VAL D 3 122 ? 50.442  35.548 99.399  1.00 28.90  ? ? ? ? ? ? 116 VAL B CB    1 
+ATOM   4881 C CG1   . VAL D 3 122 ? 50.617  35.678 97.876  1.00 30.47  ? ? ? ? ? ? 116 VAL B CG1   1 
+ATOM   4882 C CG2   . VAL D 3 122 ? 50.629  34.091 99.808  1.00 27.23  ? ? ? ? ? ? 116 VAL B CG2   1 
+ATOM   4883 N N     . MET D 3 123 ? 52.878  37.507 98.499  1.00 30.79  ? ? ? ? ? ? 117 MET B N     1 
+ATOM   4884 C CA    . MET D 3 123 ? 54.092  37.650 97.712  1.00 30.01  ? ? ? ? ? ? 117 MET B CA    1 
+ATOM   4885 C C     . MET D 3 123 ? 55.229  37.926 98.710  1.00 38.04  ? ? ? ? ? ? 117 MET B C     1 
+ATOM   4886 O O     . MET D 3 123 ? 56.202  37.166 98.778  1.00 38.56  ? ? ? ? ? ? 117 MET B O     1 
+ATOM   4887 C CB    . MET D 3 123 ? 53.938  38.740 96.644  1.00 29.45  ? ? ? ? ? ? 117 MET B CB    1 
+ATOM   4888 C CG    . MET D 3 123 ? 54.859  38.584 95.424  1.00 32.80  ? ? ? ? ? ? 117 MET B CG    1 
+ATOM   4889 S SD    . MET D 3 123 ? 55.138  36.925 94.704  1.00 39.52  ? ? ? ? ? ? 117 MET B SD    1 
+ATOM   4890 C CE    . MET D 3 123 ? 56.552  36.311 95.598  1.00 36.74  ? ? ? ? ? ? 117 MET B CE    1 
+ATOM   4891 N N     . ARG D 3 124 ? 55.070  38.973 99.520  1.00 34.22  ? ? ? ? ? ? 118 ARG B N     1 
+ATOM   4892 C CA    . ARG D 3 124 ? 56.045  39.343 100.541 1.00 30.33  ? ? ? ? ? ? 118 ARG B CA    1 
+ATOM   4893 C C     . ARG D 3 124 ? 56.424  38.128 101.350 1.00 34.92  ? ? ? ? ? ? 118 ARG B C     1 
+ATOM   4894 O O     . ARG D 3 124 ? 57.588  37.786 101.494 1.00 39.13  ? ? ? ? ? ? 118 ARG B O     1 
+ATOM   4895 C CB    . ARG D 3 124 ? 55.418  40.337 101.501 1.00 24.21  ? ? ? ? ? ? 118 ARG B CB    1 
+ATOM   4896 C CG    . ARG D 3 124 ? 55.341  41.736 100.963 1.00 28.86  ? ? ? ? ? ? 118 ARG B CG    1 
+ATOM   4897 C CD    . ARG D 3 124 ? 55.301  42.702 102.138 1.00 37.63  ? ? ? ? ? ? 118 ARG B CD    1 
+ATOM   4898 N NE    . ARG D 3 124 ? 56.466  43.587 102.172 1.00 71.21  ? ? ? ? ? ? 118 ARG B NE    1 
+ATOM   4899 C CZ    . ARG D 3 124 ? 57.431  43.530 103.088 1.00 93.19  ? ? ? ? ? ? 118 ARG B CZ    1 
+ATOM   4900 N NH1   . ARG D 3 124 ? 57.375  42.629 104.059 1.00 79.89  ? ? ? ? ? ? 118 ARG B NH1   1 
+ATOM   4901 N NH2   . ARG D 3 124 ? 58.451  44.378 103.038 1.00 83.76  ? ? ? ? ? ? 118 ARG B NH2   1 
+ATOM   4902 N N     . ARG D 3 125 ? 55.413  37.448 101.855 1.00 30.23  ? ? ? ? ? ? 119 ARG B N     1 
+ATOM   4903 C CA    . ARG D 3 125 ? 55.624  36.267 102.659 1.00 31.55  ? ? ? ? ? ? 119 ARG B CA    1 
+ATOM   4904 C C     . ARG D 3 125 ? 56.404  35.149 101.966 1.00 42.49  ? ? ? ? ? ? 119 ARG B C     1 
+ATOM   4905 O O     . ARG D 3 125 ? 57.252  34.502 102.582 1.00 42.62  ? ? ? ? ? ? 119 ARG B O     1 
+ATOM   4906 C CB    . ARG D 3 125 ? 54.266  35.759 103.152 1.00 29.23  ? ? ? ? ? ? 119 ARG B CB    1 
+ATOM   4907 C CG    . ARG D 3 125 ? 54.250  34.322 103.636 1.00 33.84  ? ? ? ? ? ? 119 ARG B CG    1 
+ATOM   4908 C CD    . ARG D 3 125 ? 52.848  33.919 104.025 1.00 43.28  ? ? ? ? ? ? 119 ARG B CD    1 
+ATOM   4909 N NE    . ARG D 3 125 ? 52.803  32.621 104.676 1.00 45.77  ? ? ? ? ? ? 119 ARG B NE    1 
+ATOM   4910 C CZ    . ARG D 3 125 ? 51.679  31.976 104.964 1.00 78.13  ? ? ? ? ? ? 119 ARG B CZ    1 
+ATOM   4911 N NH1   . ARG D 3 125 ? 50.503  32.509 104.650 1.00 69.36  ? ? ? ? ? ? 119 ARG B NH1   1 
+ATOM   4912 N NH2   . ARG D 3 125 ? 51.743  30.797 105.552 1.00 76.62  ? ? ? ? ? ? 119 ARG B NH2   1 
+ATOM   4913 N N     . ILE D 3 126 ? 56.089  34.876 100.706 1.00 41.72  ? ? ? ? ? ? 120 ILE B N     1 
+ATOM   4914 C CA    . ILE D 3 126 ? 56.776  33.798 100.006 1.00 41.17  ? ? ? ? ? ? 120 ILE B CA    1 
+ATOM   4915 C C     . ILE D 3 126 ? 58.248  34.188 99.838  1.00 42.97  ? ? ? ? ? ? 120 ILE B C     1 
+ATOM   4916 O O     . ILE D 3 126 ? 59.154  33.381 100.050 1.00 39.72  ? ? ? ? ? ? 120 ILE B O     1 
+ATOM   4917 C CB    . ILE D 3 126 ? 56.149  33.514 98.630  1.00 44.20  ? ? ? ? ? ? 120 ILE B CB    1 
+ATOM   4918 C CG1   . ILE D 3 126 ? 54.721  32.984 98.781  1.00 44.44  ? ? ? ? ? ? 120 ILE B CG1   1 
+ATOM   4919 C CG2   . ILE D 3 126 ? 56.969  32.471 97.894  1.00 44.95  ? ? ? ? ? ? 120 ILE B CG2   1 
+ATOM   4920 C CD1   . ILE D 3 126 ? 53.992  32.790 97.450  1.00 45.32  ? ? ? ? ? ? 120 ILE B CD1   1 
+ATOM   4921 N N     . ARG D 3 127 ? 58.470  35.436 99.440  1.00 38.36  ? ? ? ? ? ? 121 ARG B N     1 
+ATOM   4922 C CA    . ARG D 3 127 ? 59.819  35.960 99.254  1.00 40.71  ? ? ? ? ? ? 121 ARG B CA    1 
+ATOM   4923 C C     . ARG D 3 127 ? 60.589  35.836 100.565 1.00 49.42  ? ? ? ? ? ? 121 ARG B C     1 
+ATOM   4924 O O     . ARG D 3 127 ? 61.638  35.191 100.638 1.00 50.45  ? ? ? ? ? ? 121 ARG B O     1 
+ATOM   4925 C CB    . ARG D 3 127 ? 59.741  37.430 98.849  1.00 40.45  ? ? ? ? ? ? 121 ARG B CB    1 
+ATOM   4926 C CG    . ARG D 3 127 ? 61.045  37.987 98.342  1.00 44.59  ? ? ? ? ? ? 121 ARG B CG    1 
+ATOM   4927 C CD    . ARG D 3 127 ? 61.125  39.469 98.636  1.00 60.29  ? ? ? ? ? ? 121 ARG B CD    1 
+ATOM   4928 N NE    . ARG D 3 127 ? 61.147  40.302 97.435  1.00 76.06  ? ? ? ? ? ? 121 ARG B NE    1 
+ATOM   4929 C CZ    . ARG D 3 127 ? 62.143  40.326 96.551  1.00 95.13  ? ? ? ? ? ? 121 ARG B CZ    1 
+ATOM   4930 N NH1   . ARG D 3 127 ? 63.199  39.542 96.717  1.00 98.19  ? ? ? ? ? ? 121 ARG B NH1   1 
+ATOM   4931 N NH2   . ARG D 3 127 ? 62.081  41.125 95.494  1.00 68.48  ? ? ? ? ? ? 121 ARG B NH2   1 
+ATOM   4932 N N     . LYS D 3 128 ? 60.010  36.433 101.606 1.00 44.83  ? ? ? ? ? ? 122 LYS B N     1 
+ATOM   4933 C CA    . LYS D 3 128 ? 60.542  36.428 102.965 1.00 42.44  ? ? ? ? ? ? 122 LYS B CA    1 
+ATOM   4934 C C     . LYS D 3 128 ? 60.864  35.026 103.462 1.00 42.32  ? ? ? ? ? ? 122 LYS B C     1 
+ATOM   4935 O O     . LYS D 3 128 ? 61.959  34.784 103.956 1.00 43.03  ? ? ? ? ? ? 122 LYS B O     1 
+ATOM   4936 C CB    . LYS D 3 128 ? 59.580  37.138 103.922 1.00 44.16  ? ? ? ? ? ? 122 LYS B CB    1 
+ATOM   4937 C CG    . LYS D 3 128 ? 60.259  38.172 104.789 1.00 41.88  ? ? ? ? ? ? 122 LYS B CG    1 
+ATOM   4938 C CD    . LYS D 3 128 ? 59.292  39.167 105.387 1.00 44.71  ? ? ? ? ? ? 122 LYS B CD    1 
+ATOM   4939 C CE    . LYS D 3 128 ? 59.822  39.653 106.725 1.00 69.47  ? ? ? ? ? ? 122 LYS B CE    1 
+ATOM   4940 N NZ    . LYS D 3 128 ? 61.290  39.417 106.890 1.00 96.95  ? ? ? ? ? ? 122 LYS B NZ    1 
+ATOM   4941 N N     . GLU D 3 129 ? 59.944  34.082 103.304 1.00 38.62  ? ? ? ? ? ? 123 GLU B N     1 
+ATOM   4942 C CA    . GLU D 3 129 ? 60.193  32.712 103.751 1.00 39.12  ? ? ? ? ? ? 123 GLU B CA    1 
+ATOM   4943 C C     . GLU D 3 129 ? 61.200  31.982 102.872 1.00 53.41  ? ? ? ? ? ? 123 GLU B C     1 
+ATOM   4944 O O     . GLU D 3 129 ? 61.850  31.036 103.317 1.00 56.31  ? ? ? ? ? ? 123 GLU B O     1 
+ATOM   4945 C CB    . GLU D 3 129 ? 58.911  31.886 103.730 1.00 39.61  ? ? ? ? ? ? 123 GLU B CB    1 
+ATOM   4946 C CG    . GLU D 3 129 ? 57.847  32.308 104.704 1.00 48.03  ? ? ? ? ? ? 123 GLU B CG    1 
+ATOM   4947 C CD    . GLU D 3 129 ? 56.596  31.498 104.493 1.00 70.93  ? ? ? ? ? ? 123 GLU B CD    1 
+ATOM   4948 O OE1   . GLU D 3 129 ? 56.346  31.096 103.337 1.00 71.59  ? ? ? ? ? ? 123 GLU B OE1   1 
+ATOM   4949 O OE2   . GLU D 3 129 ? 55.882  31.249 105.482 1.00 77.28  ? ? ? ? ? ? 123 GLU B OE2   1 
+ATOM   4950 N N     . ASN D 3 130 ? 61.284  32.362 101.603 1.00 52.54  ? ? ? ? ? ? 124 ASN B N     1 
+ATOM   4951 C CA    . ASN D 3 130 ? 62.205  31.672 100.712 1.00 51.19  ? ? ? ? ? ? 124 ASN B CA    1 
+ATOM   4952 C C     . ASN D 3 130 ? 63.653  32.071 100.940 1.00 49.58  ? ? ? ? ? ? 124 ASN B C     1 
+ATOM   4953 O O     . ASN D 3 130 ? 64.536  31.214 101.090 1.00 45.37  ? ? ? ? ? ? 124 ASN B O     1 
+ATOM   4954 C CB    . ASN D 3 130 ? 61.759  31.761 99.252  1.00 49.77  ? ? ? ? ? ? 124 ASN B CB    1 
+ATOM   4955 C CG    . ASN D 3 130 ? 60.796  30.646 98.895  1.00 55.97  ? ? ? ? ? ? 124 ASN B CG    1 
+ATOM   4956 O OD1   . ASN D 3 130 ? 60.159  30.071 99.783  1.00 48.35  ? ? ? ? ? ? 124 ASN B OD1   1 
+ATOM   4957 N ND2   . ASN D 3 130 ? 60.707  30.301 97.614  1.00 40.38  ? ? ? ? ? ? 124 ASN B ND2   1 
+ATOM   4958 N N     . VAL D 3 131 ? 63.870  33.379 101.068 1.00 45.79  ? ? ? ? ? ? 125 VAL B N     1 
+ATOM   4959 C CA    . VAL D 3 131 ? 65.200  33.907 101.338 1.00 47.75  ? ? ? ? ? ? 125 VAL B CA    1 
+ATOM   4960 C C     . VAL D 3 131 ? 65.667  33.405 102.703 1.00 57.93  ? ? ? ? ? ? 125 VAL B C     1 
+ATOM   4961 O O     . VAL D 3 131 ? 66.752  32.833 102.822 1.00 60.81  ? ? ? ? ? ? 125 VAL B O     1 
+ATOM   4962 C CB    . VAL D 3 131 ? 65.234  35.438 101.357 1.00 51.74  ? ? ? ? ? ? 125 VAL B CB    1 
+ATOM   4963 C CG1   . VAL D 3 131 ? 64.912  36.017 99.985  1.00 49.79  ? ? ? ? ? ? 125 VAL B CG1   1 
+ATOM   4964 C CG2   . VAL D 3 131 ? 64.240  35.873 102.321 1.00 52.80  ? ? ? ? ? ? 125 VAL B CG2   1 
+ATOM   4965 N N     . ASP D 3 132 ? 64.823  33.552 103.725 1.00 53.23  ? ? ? ? ? ? 126 ASP B N     1 
+ATOM   4966 C CA    . ASP D 3 132 ? 65.173  33.114 105.069 1.00 50.70  ? ? ? ? ? ? 126 ASP B CA    1 
+ATOM   4967 C C     . ASP D 3 132 ? 65.374  31.612 105.142 1.00 54.61  ? ? ? ? ? ? 126 ASP B C     1 
+ATOM   4968 O O     . ASP D 3 132 ? 65.347  31.044 106.227 1.00 58.80  ? ? ? ? ? ? 126 ASP B O     1 
+ATOM   4969 C CB    . ASP D 3 132 ? 64.186  33.572 106.140 1.00 50.81  ? ? ? ? ? ? 126 ASP B CB    1 
+ATOM   4970 C CG    . ASP D 3 132 ? 64.036  35.074 106.205 1.00 61.11  ? ? ? ? ? ? 126 ASP B CG    1 
+ATOM   4971 O OD1   . ASP D 3 132 ? 64.742  35.790 105.459 1.00 61.83  ? ? ? ? ? ? 126 ASP B OD1   1 
+ATOM   4972 O OD2   . ASP D 3 132 ? 63.189  35.524 107.007 1.00 65.86  ? ? ? ? ? ? 126 ASP B OD2   1 
+ATOM   4973 N N     . ALA D 3 133 ? 65.439  30.958 103.997 1.00 46.90  ? ? ? ? ? ? 127 ALA B N     1 
+ATOM   4974 C CA    . ALA D 3 133 ? 65.710  29.530 104.004 1.00 46.43  ? ? ? ? ? ? 127 ALA B CA    1 
+ATOM   4975 C C     . ALA D 3 133 ? 66.913  29.400 103.093 1.00 51.80  ? ? ? ? ? ? 127 ALA B C     1 
+ATOM   4976 O O     . ALA D 3 133 ? 67.391  28.306 102.817 1.00 53.09  ? ? ? ? ? ? 127 ALA B O     1 
+ATOM   4977 C CB    . ALA D 3 133 ? 64.532  28.730 103.485 1.00 46.27  ? ? ? ? ? ? 127 ALA B CB    1 
+ATOM   4978 N N     . GLY D 3 134 ? 67.420  30.546 102.661 1.00 48.52  ? ? ? ? ? ? 128 GLY B N     1 
+ATOM   4979 C CA    . GLY D 3 134 ? 68.606  30.558 101.823 1.00 50.55  ? ? ? ? ? ? 128 GLY B CA    1 
+ATOM   4980 C C     . GLY D 3 134 ? 68.391  31.305 100.524 1.00 59.78  ? ? ? ? ? ? 128 GLY B C     1 
+ATOM   4981 O O     . GLY D 3 134 ? 68.857  32.428 100.355 1.00 62.30  ? ? ? ? ? ? 128 GLY B O     1 
+ATOM   4982 N N     . GLU D 3 135 ? 67.679  30.659 99.612  1.00 55.32  ? ? ? ? ? ? 129 GLU B N     1 
+ATOM   4983 C CA    . GLU D 3 135 ? 67.424  31.214 98.302  1.00 53.83  ? ? ? ? ? ? 129 GLU B CA    1 
+ATOM   4984 C C     . GLU D 3 135 ? 68.049  32.566 98.024  1.00 56.36  ? ? ? ? ? ? 129 GLU B C     1 
+ATOM   4985 O O     . GLU D 3 135 ? 67.749  33.554 98.691  1.00 50.75  ? ? ? ? ? ? 129 GLU B O     1 
+ATOM   4986 C CB    . GLU D 3 135 ? 65.931  31.223 97.962  1.00 55.35  ? ? ? ? ? ? 129 GLU B CB    1 
+ATOM   4987 C CG    . GLU D 3 135 ? 65.581  32.033 96.713  1.00 61.01  ? ? ? ? ? ? 129 GLU B CG    1 
+ATOM   4988 C CD    . GLU D 3 135 ? 64.493  31.396 95.858  1.00 60.81  ? ? ? ? ? ? 129 GLU B CD    1 
+ATOM   4989 O OE1   . GLU D 3 135 ? 63.918  30.366 96.267  1.00 57.37  ? ? ? ? ? ? 129 GLU B OE1   1 
+ATOM   4990 O OE2   . GLU D 3 135 ? 64.222  31.926 94.760  1.00 51.64  ? ? ? ? ? ? 129 GLU B OE2   1 
+ATOM   4991 N N     . ARG D 3 136 ? 68.873  32.591 96.977  1.00 59.94  ? ? ? ? ? ? 130 ARG B N     1 
+ATOM   4992 C CA    . ARG D 3 136 ? 69.493  33.797 96.440  1.00 60.79  ? ? ? ? ? ? 130 ARG B CA    1 
+ATOM   4993 C C     . ARG D 3 136 ? 69.513  33.695 94.908  1.00 59.73  ? ? ? ? ? ? 130 ARG B C     1 
+ATOM   4994 O O     . ARG D 3 136 ? 69.945  32.680 94.361  1.00 59.17  ? ? ? ? ? ? 130 ARG B O     1 
+ATOM   4995 C CB    . ARG D 3 136 ? 70.900  33.998 96.994  1.00 66.98  ? ? ? ? ? ? 130 ARG B CB    1 
+ATOM   4996 C CG    . ARG D 3 136 ? 71.050  35.342 97.668  1.00 88.74  ? ? ? ? ? ? 130 ARG B CG    1 
+ATOM   4997 C CD    . ARG D 3 136 ? 69.749  35.697 98.359  1.00 100.00 ? ? ? ? ? ? 130 ARG B CD    1 
+ATOM   4998 N NE    . ARG D 3 136 ? 69.981  36.384 99.617  1.00 100.00 ? ? ? ? ? ? 130 ARG B NE    1 
+ATOM   4999 C CZ    . ARG D 3 136 ? 69.608  35.902 100.792 1.00 98.83  ? ? ? ? ? ? 130 ARG B CZ    1 
+ATOM   5000 N NH1   . ARG D 3 136 ? 69.010  34.719 100.862 1.00 66.60  ? ? ? ? ? ? 130 ARG B NH1   1 
+ATOM   5001 N NH2   . ARG D 3 136 ? 69.852  36.587 101.900 1.00 89.85  ? ? ? ? ? ? 130 ARG B NH2   1 
+ATOM   5002 N N     . ALA D 3 137 ? 69.010  34.707 94.208  1.00 54.00  ? ? ? ? ? ? 131 ALA B N     1 
+ATOM   5003 C CA    . ALA D 3 137 ? 69.012  34.629 92.753  1.00 55.07  ? ? ? ? ? ? 131 ALA B CA    1 
+ATOM   5004 C C     . ALA D 3 137 ? 70.466  34.542 92.314  1.00 63.65  ? ? ? ? ? ? 131 ALA B C     1 
+ATOM   5005 O O     . ALA D 3 137 ? 71.313  35.270 92.826  1.00 68.31  ? ? ? ? ? ? 131 ALA B O     1 
+ATOM   5006 C CB    . ALA D 3 137 ? 68.348  35.849 92.147  1.00 56.14  ? ? ? ? ? ? 131 ALA B CB    1 
+ATOM   5007 N N     . LYS D 3 138 ? 70.757  33.661 91.361  1.00 57.55  ? ? ? ? ? ? 132 LYS B N     1 
+ATOM   5008 C CA    . LYS D 3 138 ? 72.123  33.468 90.898  1.00 55.40  ? ? ? ? ? ? 132 LYS B CA    1 
+ATOM   5009 C C     . LYS D 3 138 ? 72.603  34.322 89.731  1.00 58.58  ? ? ? ? ? ? 132 LYS B C     1 
+ATOM   5010 O O     . LYS D 3 138 ? 71.814  34.917 88.992  1.00 61.05  ? ? ? ? ? ? 132 LYS B O     1 
+ATOM   5011 C CB    . LYS D 3 138 ? 72.370  31.994 90.559  1.00 55.44  ? ? ? ? ? ? 132 LYS B CB    1 
+ATOM   5012 C CG    . LYS D 3 138 ? 71.762  30.976 91.528  1.00 62.08  ? ? ? ? ? ? 132 LYS B CG    1 
+ATOM   5013 C CD    . LYS D 3 138 ? 71.557  29.616 90.853  1.00 73.49  ? ? ? ? ? ? 132 LYS B CD    1 
+ATOM   5014 C CE    . LYS D 3 138 ? 70.926  28.634 91.827  1.00 87.17  ? ? ? ? ? ? 132 LYS B CE    1 
+ATOM   5015 N NZ    . LYS D 3 138 ? 71.742  28.521 93.075  1.00 90.99  ? ? ? ? ? ? 132 LYS B NZ    1 
+ATOM   5016 N N     . GLN D 3 139 ? 73.927  34.349 89.595  1.00 51.52  ? ? ? ? ? ? 133 GLN B N     1 
+ATOM   5017 C CA    . GLN D 3 139 ? 74.618  35.041 88.519  1.00 49.43  ? ? ? ? ? ? 133 GLN B CA    1 
+ATOM   5018 C C     . GLN D 3 139 ? 75.502  34.021 87.793  1.00 47.51  ? ? ? ? ? ? 133 GLN B C     1 
+ATOM   5019 O O     . GLN D 3 139 ? 75.880  32.993 88.355  1.00 45.72  ? ? ? ? ? ? 133 GLN B O     1 
+ATOM   5020 C CB    . GLN D 3 139 ? 75.351  36.314 88.990  1.00 51.30  ? ? ? ? ? ? 133 GLN B CB    1 
+ATOM   5021 C CG    . GLN D 3 139 ? 76.605  36.122 89.844  1.00 77.01  ? ? ? ? ? ? 133 GLN B CG    1 
+ATOM   5022 C CD    . GLN D 3 139 ? 77.293  37.440 90.203  1.00 100.00 ? ? ? ? ? ? 133 GLN B CD    1 
+ATOM   5023 O OE1   . GLN D 3 139 ? 78.376  37.751 89.705  1.00 100.00 ? ? ? ? ? ? 133 GLN B OE1   1 
+ATOM   5024 N NE2   . GLN D 3 139 ? 76.665  38.212 91.080  1.00 95.83  ? ? ? ? ? ? 133 GLN B NE2   1 
+ATOM   5025 N N     . ALA D 3 140 ? 75.734  34.257 86.510  1.00 41.37  ? ? ? ? ? ? 134 ALA B N     1 
+ATOM   5026 C CA    . ALA D 3 140 ? 76.493  33.334 85.688  1.00 38.89  ? ? ? ? ? ? 134 ALA B CA    1 
+ATOM   5027 C C     . ALA D 3 140 ? 77.961  33.230 86.048  1.00 42.57  ? ? ? ? ? ? 134 ALA B C     1 
+ATOM   5028 O O     . ALA D 3 140 ? 78.569  34.206 86.499  1.00 44.50  ? ? ? ? ? ? 134 ALA B O     1 
+ATOM   5029 C CB    . ALA D 3 140 ? 76.348  33.721 84.233  1.00 38.78  ? ? ? ? ? ? 134 ALA B CB    1 
+ATOM   5030 N N     . LEU D 3 141 ? 78.506  32.031 85.845  1.00 36.37  ? ? ? ? ? ? 135 LEU B N     1 
+ATOM   5031 C CA    . LEU D 3 141 ? 79.924  31.743 86.035  1.00 31.63  ? ? ? ? ? ? 135 LEU B CA    1 
+ATOM   5032 C C     . LEU D 3 141 ? 80.659  32.821 85.246  1.00 34.25  ? ? ? ? ? ? 135 LEU B C     1 
+ATOM   5033 O O     . LEU D 3 141 ? 80.377  33.030 84.064  1.00 33.38  ? ? ? ? ? ? 135 LEU B O     1 
+ATOM   5034 C CB    . LEU D 3 141 ? 80.237  30.412 85.356  1.00 29.28  ? ? ? ? ? ? 135 LEU B CB    1 
+ATOM   5035 C CG    . LEU D 3 141 ? 81.536  29.738 85.766  1.00 30.32  ? ? ? ? ? ? 135 LEU B CG    1 
+ATOM   5036 C CD1   . LEU D 3 141 ? 81.635  29.841 87.273  1.00 27.51  ? ? ? ? ? ? 135 LEU B CD1   1 
+ATOM   5037 C CD2   . LEU D 3 141 ? 81.526  28.289 85.319  1.00 32.37  ? ? ? ? ? ? 135 LEU B CD2   1 
+ATOM   5038 N N     . ALA D 3 142 ? 81.597  33.499 85.899  1.00 29.89  ? ? ? ? ? ? 136 ALA B N     1 
+ATOM   5039 C CA    . ALA D 3 142 ? 82.340  34.563 85.243  1.00 30.62  ? ? ? ? ? ? 136 ALA B CA    1 
+ATOM   5040 C C     . ALA D 3 142 ? 83.310  34.057 84.172  1.00 33.24  ? ? ? ? ? ? 136 ALA B C     1 
+ATOM   5041 O O     . ALA D 3 142 ? 83.823  32.945 84.261  1.00 31.52  ? ? ? ? ? ? 136 ALA B O     1 
+ATOM   5042 C CB    . ALA D 3 142 ? 83.073  35.413 86.277  1.00 31.13  ? ? ? ? ? ? 136 ALA B CB    1 
+ATOM   5043 N N     . PHE D 3 143 ? 83.547  34.886 83.163  1.00 27.45  ? ? ? ? ? ? 137 PHE B N     1 
+ATOM   5044 C CA    . PHE D 3 143 ? 84.495  34.574 82.103  1.00 24.46  ? ? ? ? ? ? 137 PHE B CA    1 
+ATOM   5045 C C     . PHE D 3 143 ? 85.345  35.823 82.110  1.00 28.47  ? ? ? ? ? ? 137 PHE B C     1 
+ATOM   5046 O O     . PHE D 3 143 ? 84.918  36.860 81.620  1.00 27.42  ? ? ? ? ? ? 137 PHE B O     1 
+ATOM   5047 C CB    . PHE D 3 143 ? 83.753  34.449 80.765  1.00 26.23  ? ? ? ? ? ? 137 PHE B CB    1 
+ATOM   5048 C CG    . PHE D 3 143 ? 84.643  34.221 79.565  1.00 26.57  ? ? ? ? ? ? 137 PHE B CG    1 
+ATOM   5049 C CD1   . PHE D 3 143 ? 85.072  32.946 79.238  1.00 27.79  ? ? ? ? ? ? 137 PHE B CD1   1 
+ATOM   5050 C CD2   . PHE D 3 143 ? 84.985  35.272 78.727  1.00 25.74  ? ? ? ? ? ? 137 PHE B CD2   1 
+ATOM   5051 C CE1   . PHE D 3 143 ? 85.883  32.736 78.145  1.00 27.50  ? ? ? ? ? ? 137 PHE B CE1   1 
+ATOM   5052 C CE2   . PHE D 3 143 ? 85.787  35.063 77.622  1.00 27.78  ? ? ? ? ? ? 137 PHE B CE2   1 
+ATOM   5053 C CZ    . PHE D 3 143 ? 86.241  33.793 77.332  1.00 25.55  ? ? ? ? ? ? 137 PHE B CZ    1 
+ATOM   5054 N N     . GLU D 3 144 ? 86.527  35.754 82.709  1.00 31.36  ? ? ? ? ? ? 138 GLU B N     1 
+ATOM   5055 C CA    . GLU D 3 144 ? 87.362  36.949 82.761  1.00 33.69  ? ? ? ? ? ? 138 GLU B CA    1 
+ATOM   5056 C C     . GLU D 3 144 ? 88.576  36.892 81.834  1.00 39.66  ? ? ? ? ? ? 138 GLU B C     1 
+ATOM   5057 O O     . GLU D 3 144 ? 88.711  35.960 81.046  1.00 39.99  ? ? ? ? ? ? 138 GLU B O     1 
+ATOM   5058 C CB    . GLU D 3 144 ? 87.737  37.272 84.200  1.00 36.08  ? ? ? ? ? ? 138 GLU B CB    1 
+ATOM   5059 C CG    . GLU D 3 144 ? 87.333  36.105 85.034  1.00 49.97  ? ? ? ? ? ? 138 GLU B CG    1 
+ATOM   5060 C CD    . GLU D 3 144 ? 86.998  36.428 86.474  1.00 74.64  ? ? ? ? ? ? 138 GLU B CD    1 
+ATOM   5061 O OE1   . GLU D 3 144 ? 86.358  37.479 86.639  1.00 68.31  ? ? ? ? ? ? 138 GLU B OE1   1 
+ATOM   5062 O OE2   . GLU D 3 144 ? 87.288  35.631 87.410  1.00 71.05  ? ? ? ? ? ? 138 GLU B OE2   1 
+ATOM   5063 N N     . ARG D 3 145 ? 89.418  37.921 81.893  1.00 37.42  ? ? ? ? ? ? 139 ARG B N     1 
+ATOM   5064 C CA    . ARG D 3 145 ? 90.587  38.044 81.029  1.00 36.42  ? ? ? ? ? ? 139 ARG B CA    1 
+ATOM   5065 C C     . ARG D 3 145 ? 91.436  36.780 81.029  1.00 39.07  ? ? ? ? ? ? 139 ARG B C     1 
+ATOM   5066 O O     . ARG D 3 145 ? 91.926  36.345 79.980  1.00 37.17  ? ? ? ? ? ? 139 ARG B O     1 
+ATOM   5067 C CB    . ARG D 3 145 ? 91.397  39.288 81.421  1.00 36.92  ? ? ? ? ? ? 139 ARG B CB    1 
+ATOM   5068 C CG    . ARG D 3 145 ? 92.791  39.393 80.804  1.00 40.16  ? ? ? ? ? ? 139 ARG B CG    1 
+ATOM   5069 C CD    . ARG D 3 145 ? 92.724  39.727 79.322  1.00 44.23  ? ? ? ? ? ? 139 ARG B CD    1 
+ATOM   5070 N NE    . ARG D 3 145 ? 93.990  40.231 78.803  1.00 55.06  ? ? ? ? ? ? 139 ARG B NE    1 
+ATOM   5071 C CZ    . ARG D 3 145 ? 94.370  41.500 78.874  1.00 67.89  ? ? ? ? ? ? 139 ARG B CZ    1 
+ATOM   5072 N NH1   . ARG D 3 145 ? 93.592  42.401 79.453  1.00 47.79  ? ? ? ? ? ? 139 ARG B NH1   1 
+ATOM   5073 N NH2   . ARG D 3 145 ? 95.534  41.869 78.363  1.00 65.91  ? ? ? ? ? ? 139 ARG B NH2   1 
+ATOM   5074 N N     . THR D 3 146 ? 91.563  36.162 82.198  1.00 35.15  ? ? ? ? ? ? 140 THR B N     1 
+ATOM   5075 C CA    . THR D 3 146 ? 92.338  34.938 82.282  1.00 34.37  ? ? ? ? ? ? 140 THR B CA    1 
+ATOM   5076 C C     . THR D 3 146 ? 91.772  33.826 81.399  1.00 37.37  ? ? ? ? ? ? 140 THR B C     1 
+ATOM   5077 O O     . THR D 3 146 ? 92.487  33.239 80.590  1.00 37.33  ? ? ? ? ? ? 140 THR B O     1 
+ATOM   5078 C CB    . THR D 3 146 ? 92.556  34.500 83.740  1.00 36.69  ? ? ? ? ? ? 140 THR B CB    1 
+ATOM   5079 O OG1   . THR D 3 146 ? 93.503  35.381 84.330  1.00 39.50  ? ? ? ? ? ? 140 THR B OG1   1 
+ATOM   5080 C CG2   . THR D 3 146 ? 93.145  33.107 83.793  1.00 33.97  ? ? ? ? ? ? 140 THR B CG2   1 
+ATOM   5081 N N     . ASP D 3 147 ? 90.480  33.552 81.532  1.00 33.61  ? ? ? ? ? ? 141 ASP B N     1 
+ATOM   5082 C CA    . ASP D 3 147 ? 89.816  32.533 80.719  1.00 32.17  ? ? ? ? ? ? 141 ASP B CA    1 
+ATOM   5083 C C     . ASP D 3 147 ? 89.889  32.935 79.255  1.00 31.78  ? ? ? ? ? ? 141 ASP B C     1 
+ATOM   5084 O O     . ASP D 3 147 ? 90.048  32.099 78.382  1.00 32.99  ? ? ? ? ? ? 141 ASP B O     1 
+ATOM   5085 C CB    . ASP D 3 147 ? 88.355  32.394 81.150  1.00 34.32  ? ? ? ? ? ? 141 ASP B CB    1 
+ATOM   5086 C CG    . ASP D 3 147 ? 88.223  32.215 82.641  1.00 34.28  ? ? ? ? ? ? 141 ASP B CG    1 
+ATOM   5087 O OD1   . ASP D 3 147 ? 88.764  31.210 83.143  1.00 33.17  ? ? ? ? ? ? 141 ASP B OD1   1 
+ATOM   5088 O OD2   . ASP D 3 147 ? 87.622  33.088 83.306  1.00 37.31  ? ? ? ? ? ? 141 ASP B OD2   1 
+ATOM   5089 N N     . PHE D 3 148 ? 89.764  34.224 78.973  1.00 29.23  ? ? ? ? ? ? 142 PHE B N     1 
+ATOM   5090 C CA    . PHE D 3 148 ? 89.847  34.660 77.587  1.00 30.40  ? ? ? ? ? ? 142 PHE B CA    1 
+ATOM   5091 C C     . PHE D 3 148 ? 91.236  34.372 77.023  1.00 40.09  ? ? ? ? ? ? 142 PHE B C     1 
+ATOM   5092 O O     . PHE D 3 148 ? 91.368  33.854 75.909  1.00 40.46  ? ? ? ? ? ? 142 PHE B O     1 
+ATOM   5093 C CB    . PHE D 3 148 ? 89.552  36.154 77.465  1.00 31.54  ? ? ? ? ? ? 142 PHE B CB    1 
+ATOM   5094 C CG    . PHE D 3 148 ? 89.650  36.664 76.052  1.00 32.05  ? ? ? ? ? ? 142 PHE B CG    1 
+ATOM   5095 C CD1   . PHE D 3 148 ? 89.125  35.924 74.995  1.00 32.34  ? ? ? ? ? ? 142 PHE B CD1   1 
+ATOM   5096 C CD2   . PHE D 3 148 ? 90.265  37.874 75.780  1.00 32.29  ? ? ? ? ? ? 142 PHE B CD2   1 
+ATOM   5097 C CE1   . PHE D 3 148 ? 89.239  36.371 73.685  1.00 32.11  ? ? ? ? ? ? 142 PHE B CE1   1 
+ATOM   5098 C CE2   . PHE D 3 148 ? 90.371  38.343 74.477  1.00 35.17  ? ? ? ? ? ? 142 PHE B CE2   1 
+ATOM   5099 C CZ    . PHE D 3 148 ? 89.859  37.582 73.425  1.00 32.90  ? ? ? ? ? ? 142 PHE B CZ    1 
+ATOM   5100 N N     . ASP D 3 149 ? 92.259  34.734 77.797  1.00 35.08  ? ? ? ? ? ? 143 ASP B N     1 
+ATOM   5101 C CA    . ASP D 3 149 ? 93.655  34.537 77.409  1.00 34.23  ? ? ? ? ? ? 143 ASP B CA    1 
+ATOM   5102 C C     . ASP D 3 149 ? 93.991  33.059 77.196  1.00 33.93  ? ? ? ? ? ? 143 ASP B C     1 
+ATOM   5103 O O     . ASP D 3 149 ? 94.683  32.692 76.244  1.00 37.38  ? ? ? ? ? ? 143 ASP B O     1 
+ATOM   5104 C CB    . ASP D 3 149 ? 94.584  35.130 78.474  1.00 37.26  ? ? ? ? ? ? 143 ASP B CB    1 
+ATOM   5105 C CG    . ASP D 3 149 ? 94.650  36.640 78.414  1.00 53.97  ? ? ? ? ? ? 143 ASP B CG    1 
+ATOM   5106 O OD1   . ASP D 3 149 ? 93.967  37.234 77.549  1.00 58.01  ? ? ? ? ? ? 143 ASP B OD1   1 
+ATOM   5107 O OD2   . ASP D 3 149 ? 95.389  37.223 79.233  1.00 63.60  ? ? ? ? ? ? 143 ASP B OD2   1 
+ATOM   5108 N N     . GLN D 3 150 ? 93.509  32.217 78.096  1.00 28.02  ? ? ? ? ? ? 144 GLN B N     1 
+ATOM   5109 C CA    . GLN D 3 150 ? 93.763  30.791 78.001  1.00 27.14  ? ? ? ? ? ? 144 GLN B CA    1 
+ATOM   5110 C C     . GLN D 3 150 ? 93.058  30.185 76.804  1.00 36.01  ? ? ? ? ? ? 144 GLN B C     1 
+ATOM   5111 O O     . GLN D 3 150 ? 93.677  29.523 75.976  1.00 39.86  ? ? ? ? ? ? 144 GLN B O     1 
+ATOM   5112 C CB    . GLN D 3 150 ? 93.375  30.115 79.307  1.00 27.44  ? ? ? ? ? ? 144 GLN B CB    1 
+ATOM   5113 C CG    . GLN D 3 150 ? 94.056  30.748 80.531  1.00 32.87  ? ? ? ? ? ? 144 GLN B CG    1 
+ATOM   5114 C CD    . GLN D 3 150 ? 93.662  30.078 81.814  1.00 28.47  ? ? ? ? ? ? 144 GLN B CD    1 
+ATOM   5115 O OE1   . GLN D 3 150 ? 92.694  29.311 81.830  1.00 33.92  ? ? ? ? ? ? 144 GLN B OE1   1 
+ATOM   5116 N NE2   . GLN D 3 150 ? 94.396  30.313 82.893  1.00 28.14  ? ? ? ? ? ? 144 GLN B NE2   1 
+ATOM   5117 N N     . VAL D 3 151 ? 91.767  30.456 76.698  1.00 33.54  ? ? ? ? ? ? 145 VAL B N     1 
+ATOM   5118 C CA    . VAL D 3 151 ? 90.956  29.986 75.576  1.00 34.50  ? ? ? ? ? ? 145 VAL B CA    1 
+ATOM   5119 C C     . VAL D 3 151 ? 91.555  30.419 74.209  1.00 37.15  ? ? ? ? ? ? 145 VAL B C     1 
+ATOM   5120 O O     . VAL D 3 151 ? 91.682  29.628 73.267  1.00 35.48  ? ? ? ? ? ? 145 VAL B O     1 
+ATOM   5121 C CB    . VAL D 3 151 ? 89.486  30.482 75.746  1.00 39.04  ? ? ? ? ? ? 145 VAL B CB    1 
+ATOM   5122 C CG1   . VAL D 3 151 ? 88.697  30.310 74.462  1.00 40.22  ? ? ? ? ? ? 145 VAL B CG1   1 
+ATOM   5123 C CG2   . VAL D 3 151 ? 88.792  29.757 76.896  1.00 37.27  ? ? ? ? ? ? 145 VAL B CG2   1 
+ATOM   5124 N N     . ARG D 3 152 ? 91.930  31.693 74.118  1.00 30.74  ? ? ? ? ? ? 146 ARG B N     1 
+ATOM   5125 C CA    . ARG D 3 152 ? 92.522  32.271 72.919  1.00 29.02  ? ? ? ? ? ? 146 ARG B CA    1 
+ATOM   5126 C C     . ARG D 3 152 ? 93.885  31.649 72.671  1.00 37.99  ? ? ? ? ? ? 146 ARG B C     1 
+ATOM   5127 O O     . ARG D 3 152 ? 94.259  31.382 71.536  1.00 39.69  ? ? ? ? ? ? 146 ARG B O     1 
+ATOM   5128 C CB    . ARG D 3 152 ? 92.666  33.779 73.109  1.00 27.29  ? ? ? ? ? ? 146 ARG B CB    1 
+ATOM   5129 C CG    . ARG D 3 152 ? 93.610  34.448 72.134  1.00 32.02  ? ? ? ? ? ? 146 ARG B CG    1 
+ATOM   5130 C CD    . ARG D 3 152 ? 93.228  35.897 71.888  1.00 43.71  ? ? ? ? ? ? 146 ARG B CD    1 
+ATOM   5131 N NE    . ARG D 3 152 ? 93.732  36.846 72.877  1.00 46.92  ? ? ? ? ? ? 146 ARG B NE    1 
+ATOM   5132 C CZ    . ARG D 3 152 ? 93.917  38.135 72.615  1.00 66.40  ? ? ? ? ? ? 146 ARG B CZ    1 
+ATOM   5133 N NH1   . ARG D 3 152 ? 93.661  38.610 71.402  1.00 63.27  ? ? ? ? ? ? 146 ARG B NH1   1 
+ATOM   5134 N NH2   . ARG D 3 152 ? 94.364  38.946 73.563  1.00 65.67  ? ? ? ? ? ? 146 ARG B NH2   1 
+ATOM   5135 N N     . SER D 3 153 ? 94.626  31.412 73.747  1.00 34.71  ? ? ? ? ? ? 147 SER B N     1 
+ATOM   5136 C CA    . SER D 3 153 ? 95.946  30.801 73.658  1.00 31.71  ? ? ? ? ? ? 147 SER B CA    1 
+ATOM   5137 C C     . SER D 3 153 ? 95.823  29.435 72.990  1.00 34.30  ? ? ? ? ? ? 147 SER B C     1 
+ATOM   5138 O O     . SER D 3 153 ? 96.737  28.969 72.303  1.00 34.95  ? ? ? ? ? ? 147 SER B O     1 
+ATOM   5139 C CB    . SER D 3 153 ? 96.551  30.659 75.062  1.00 28.15  ? ? ? ? ? ? 147 SER B CB    1 
+ATOM   5140 O OG    . SER D 3 153 ? 96.303  29.379 75.612  1.00 25.25  ? ? ? ? ? ? 147 SER B OG    1 
+ATOM   5141 N N     . LEU D 3 154 ? 94.683  28.787 73.185  1.00 29.55  ? ? ? ? ? ? 148 LEU B N     1 
+ATOM   5142 C CA    . LEU D 3 154 ? 94.488  27.469 72.602  1.00 28.73  ? ? ? ? ? ? 148 LEU B CA    1 
+ATOM   5143 C C     . LEU D 3 154 ? 93.782  27.475 71.263  1.00 42.11  ? ? ? ? ? ? 148 LEU B C     1 
+ATOM   5144 O O     . LEU D 3 154 ? 94.053  26.631 70.411  1.00 44.43  ? ? ? ? ? ? 148 LEU B O     1 
+ATOM   5145 C CB    . LEU D 3 154 ? 93.645  26.606 73.529  1.00 27.25  ? ? ? ? ? ? 148 LEU B CB    1 
+ATOM   5146 C CG    . LEU D 3 154 ? 94.298  26.120 74.813  1.00 30.94  ? ? ? ? ? ? 148 LEU B CG    1 
+ATOM   5147 C CD1   . LEU D 3 154 ? 93.209  26.019 75.854  1.00 29.83  ? ? ? ? ? ? 148 LEU B CD1   1 
+ATOM   5148 C CD2   . LEU D 3 154 ? 94.921  24.763 74.566  1.00 28.49  ? ? ? ? ? ? 148 LEU B CD2   1 
+ATOM   5149 N N     . MET D 3 155 ? 92.824  28.376 71.098  1.00 42.13  ? ? ? ? ? ? 149 MET B N     1 
+ATOM   5150 C CA    . MET D 3 155 ? 92.044  28.387 69.868  1.00 42.84  ? ? ? ? ? ? 149 MET B CA    1 
+ATOM   5151 C C     . MET D 3 155 ? 92.687  29.136 68.711  1.00 45.29  ? ? ? ? ? ? 149 MET B C     1 
+ATOM   5152 O O     . MET D 3 155 ? 92.497  28.783 67.549  1.00 46.72  ? ? ? ? ? ? 149 MET B O     1 
+ATOM   5153 C CB    . MET D 3 155 ? 90.604  28.817 70.140  1.00 45.35  ? ? ? ? ? ? 149 MET B CB    1 
+ATOM   5154 C CG    . MET D 3 155 ? 89.826  27.843 71.011  1.00 49.16  ? ? ? ? ? ? 149 MET B CG    1 
+ATOM   5155 S SD    . MET D 3 155 ? 88.401  28.675 71.751  1.00 54.80  ? ? ? ? ? ? 149 MET B SD    1 
+ATOM   5156 C CE    . MET D 3 155 ? 87.544  29.247 70.309  1.00 50.55  ? ? ? ? ? ? 149 MET B CE    1 
+ATOM   5157 N N     . GLU D 3 156 ? 93.453  30.157 69.068  1.00 40.04  ? ? ? ? ? ? 150 GLU B N     1 
+ATOM   5158 C CA    . GLU D 3 156 ? 94.233  30.988 68.157  1.00 40.18  ? ? ? ? ? ? 150 GLU B CA    1 
+ATOM   5159 C C     . GLU D 3 156 ? 94.806  30.181 67.000  1.00 48.50  ? ? ? ? ? ? 150 GLU B C     1 
+ATOM   5160 O O     . GLU D 3 156 ? 94.810  30.614 65.850  1.00 49.67  ? ? ? ? ? ? 150 GLU B O     1 
+ATOM   5161 C CB    . GLU D 3 156 ? 95.456  31.460 68.933  1.00 40.83  ? ? ? ? ? ? 150 GLU B CB    1 
+ATOM   5162 C CG    . GLU D 3 156 ? 95.833  32.889 68.752  1.00 39.82  ? ? ? ? ? ? 150 GLU B CG    1 
+ATOM   5163 C CD    . GLU D 3 156 ? 96.882  33.285 69.758  1.00 59.20  ? ? ? ? ? ? 150 GLU B CD    1 
+ATOM   5164 O OE1   . GLU D 3 156 ? 97.609  32.381 70.229  1.00 45.98  ? ? ? ? ? ? 150 GLU B OE1   1 
+ATOM   5165 O OE2   . GLU D 3 156 ? 96.978  34.491 70.085  1.00 63.54  ? ? ? ? ? ? 150 GLU B OE2   1 
+ATOM   5166 N N     . ASN D 3 157 ? 95.367  29.025 67.336  1.00 46.57  ? ? ? ? ? ? 151 ASN B N     1 
+ATOM   5167 C CA    . ASN D 3 157 ? 96.023  28.196 66.342  1.00 48.40  ? ? ? ? ? ? 151 ASN B CA    1 
+ATOM   5168 C C     . ASN D 3 157 ? 95.120  27.324 65.496  1.00 55.73  ? ? ? ? ? ? 151 ASN B C     1 
+ATOM   5169 O O     . ASN D 3 157 ? 95.601  26.477 64.746  1.00 59.87  ? ? ? ? ? ? 151 ASN B O     1 
+ATOM   5170 C CB    . ASN D 3 157 ? 97.131  27.365 66.977  1.00 48.11  ? ? ? ? ? ? 151 ASN B CB    1 
+ATOM   5171 C CG    . ASN D 3 157 ? 97.941  28.164 67.962  1.00 49.33  ? ? ? ? ? ? 151 ASN B CG    1 
+ATOM   5172 O OD1   . ASN D 3 157 ? 98.430  29.243 67.637  1.00 46.61  ? ? ? ? ? ? 151 ASN B OD1   1 
+ATOM   5173 N ND2   . ASN D 3 157 ? 98.041  27.662 69.188  1.00 28.16  ? ? ? ? ? ? 151 ASN B ND2   1 
+ATOM   5174 N N     . SER D 3 158 ? 93.815  27.521 65.588  1.00 48.80  ? ? ? ? ? ? 152 SER B N     1 
+ATOM   5175 C CA    . SER D 3 158 ? 92.956  26.693 64.767  1.00 45.38  ? ? ? ? ? ? 152 SER B CA    1 
+ATOM   5176 C C     . SER D 3 158 ? 92.642  27.402 63.483  1.00 44.37  ? ? ? ? ? ? 152 SER B C     1 
+ATOM   5177 O O     . SER D 3 158 ? 92.603  28.624 63.420  1.00 44.18  ? ? ? ? ? ? 152 SER B O     1 
+ATOM   5178 C CB    . SER D 3 158 ? 91.682  26.260 65.467  1.00 49.14  ? ? ? ? ? ? 152 SER B CB    1 
+ATOM   5179 O OG    . SER D 3 158 ? 90.892  25.518 64.550  1.00 49.21  ? ? ? ? ? ? 152 SER B OG    1 
+ATOM   5180 N N     . ASP D 3 159 ? 92.482  26.618 62.434  1.00 41.72  ? ? ? ? ? ? 153 ASP B N     1 
+ATOM   5181 C CA    . ASP D 3 159 ? 92.216  27.186 61.120  1.00 41.80  ? ? ? ? ? ? 153 ASP B CA    1 
+ATOM   5182 C C     . ASP D 3 159 ? 90.789  26.833 60.740  1.00 40.68  ? ? ? ? ? ? 153 ASP B C     1 
+ATOM   5183 O O     . ASP D 3 159 ? 90.322  27.201 59.672  1.00 39.31  ? ? ? ? ? ? 153 ASP B O     1 
+ATOM   5184 C CB    . ASP D 3 159 ? 93.232  26.662 60.099  1.00 44.78  ? ? ? ? ? ? 153 ASP B CB    1 
+ATOM   5185 C CG    . ASP D 3 159 ? 94.570  27.373 60.198  1.00 71.75  ? ? ? ? ? ? 153 ASP B CG    1 
+ATOM   5186 O OD1   . ASP D 3 159 ? 94.607  28.515 60.702  1.00 76.98  ? ? ? ? ? ? 153 ASP B OD1   1 
+ATOM   5187 O OD2   . ASP D 3 159 ? 95.587  26.780 59.774  1.00 85.49  ? ? ? ? ? ? 153 ASP B OD2   1 
+ATOM   5188 N N     . ARG D 3 160 ? 90.130  26.132 61.664  1.00 38.15  ? ? ? ? ? ? 154 ARG B N     1 
+ATOM   5189 C CA    . ARG D 3 160 ? 88.726  25.745 61.530  1.00 37.80  ? ? ? ? ? ? 154 ARG B CA    1 
+ATOM   5190 C C     . ARG D 3 160 ? 87.810  26.968 61.541  1.00 45.45  ? ? ? ? ? ? 154 ARG B C     1 
+ATOM   5191 O O     . ARG D 3 160 ? 88.031  27.910 62.303  1.00 46.52  ? ? ? ? ? ? 154 ARG B O     1 
+ATOM   5192 C CB    . ARG D 3 160 ? 88.315  24.902 62.727  1.00 32.23  ? ? ? ? ? ? 154 ARG B CB    1 
+ATOM   5193 C CG    . ARG D 3 160 ? 88.469  23.433 62.528  1.00 33.05  ? ? ? ? ? ? 154 ARG B CG    1 
+ATOM   5194 C CD    . ARG D 3 160 ? 87.931  22.728 63.741  1.00 49.12  ? ? ? ? ? ? 154 ARG B CD    1 
+ATOM   5195 N NE    . ARG D 3 160 ? 86.572  22.227 63.572  1.00 71.49  ? ? ? ? ? ? 154 ARG B NE    1 
+ATOM   5196 C CZ    . ARG D 3 160 ? 85.735  22.027 64.587  1.00 90.75  ? ? ? ? ? ? 154 ARG B CZ    1 
+ATOM   5197 N NH1   . ARG D 3 160 ? 86.106  22.322 65.830  1.00 64.50  ? ? ? ? ? ? 154 ARG B NH1   1 
+ATOM   5198 N NH2   . ARG D 3 160 ? 84.522  21.558 64.358  1.00 86.54  ? ? ? ? ? ? 154 ARG B NH2   1 
+ATOM   5199 N N     . CYS D 3 161 ? 86.780  26.949 60.703  1.00 43.77  ? ? ? ? ? ? 155 CYS B N     1 
+ATOM   5200 C CA    . CYS D 3 161 ? 85.860  28.070 60.626  1.00 44.62  ? ? ? ? ? ? 155 CYS B CA    1 
+ATOM   5201 C C     . CYS D 3 161 ? 85.136  28.240 61.946  1.00 40.04  ? ? ? ? ? ? 155 CYS B C     1 
+ATOM   5202 O O     . CYS D 3 161 ? 85.086  29.355 62.470  1.00 35.86  ? ? ? ? ? ? 155 CYS B O     1 
+ATOM   5203 C CB    . CYS D 3 161 ? 84.862  27.904 59.480  1.00 48.01  ? ? ? ? ? ? 155 CYS B CB    1 
+ATOM   5204 S SG    . CYS D 3 161 ? 84.173  29.485 58.867  1.00 53.29  ? ? ? ? ? ? 155 CYS B SG    1 
+ATOM   5205 N N     . GLN D 3 162 ? 84.610  27.146 62.486  1.00 35.83  ? ? ? ? ? ? 156 GLN B N     1 
+ATOM   5206 C CA    . GLN D 3 162 ? 83.918  27.160 63.777  1.00 34.39  ? ? ? ? ? ? 156 GLN B CA    1 
+ATOM   5207 C C     . GLN D 3 162 ? 84.730  27.865 64.856  1.00 39.22  ? ? ? ? ? ? 156 GLN B C     1 
+ATOM   5208 O O     . GLN D 3 162 ? 84.214  28.772 65.509  1.00 40.49  ? ? ? ? ? ? 156 GLN B O     1 
+ATOM   5209 C CB    . GLN D 3 162 ? 83.609  25.743 64.235  1.00 35.22  ? ? ? ? ? ? 156 GLN B CB    1 
+ATOM   5210 C CG    . GLN D 3 162 ? 82.271  25.624 64.899  1.00 51.80  ? ? ? ? ? ? 156 GLN B CG    1 
+ATOM   5211 C CD    . GLN D 3 162 ? 82.074  24.271 65.519  1.00 92.78  ? ? ? ? ? ? 156 GLN B CD    1 
+ATOM   5212 O OE1   . GLN D 3 162 ? 82.933  23.393 65.424  1.00 93.12  ? ? ? ? ? ? 156 GLN B OE1   1 
+ATOM   5213 N NE2   . GLN D 3 162 ? 80.929  24.082 66.164  1.00 100.00 ? ? ? ? ? ? 156 GLN B NE2   1 
+ATOM   5214 N N     . ASP D 3 163 ? 85.986  27.441 65.030  1.00 34.74  ? ? ? ? ? ? 157 ASP B N     1 
+ATOM   5215 C CA    . ASP D 3 163 ? 86.915  27.992 66.023  1.00 31.94  ? ? ? ? ? ? 157 ASP B CA    1 
+ATOM   5216 C C     . ASP D 3 163 ? 87.191  29.470 65.852  1.00 32.63  ? ? ? ? ? ? 157 ASP B C     1 
+ATOM   5217 O O     . ASP D 3 163 ? 87.142  30.227 66.815  1.00 33.40  ? ? ? ? ? ? 157 ASP B O     1 
+ATOM   5218 C CB    . ASP D 3 163 ? 88.238  27.222 66.036  1.00 32.82  ? ? ? ? ? ? 157 ASP B CB    1 
+ATOM   5219 C CG    . ASP D 3 163 ? 88.031  25.735 66.275  1.00 43.81  ? ? ? ? ? ? 157 ASP B CG    1 
+ATOM   5220 O OD1   . ASP D 3 163 ? 86.966  25.380 66.824  1.00 42.29  ? ? ? ? ? ? 157 ASP B OD1   1 
+ATOM   5221 O OD2   . ASP D 3 163 ? 88.899  24.912 65.917  1.00 56.77  ? ? ? ? ? ? 157 ASP B OD2   1 
+ATOM   5222 N N     . ILE D 3 164 ? 87.487  29.883 64.628  1.00 31.18  ? ? ? ? ? ? 158 ILE B N     1 
+ATOM   5223 C CA    . ILE D 3 164 ? 87.756  31.292 64.350  1.00 33.20  ? ? ? ? ? ? 158 ILE B CA    1 
+ATOM   5224 C C     . ILE D 3 164 ? 86.553  32.158 64.727  1.00 38.19  ? ? ? ? ? ? 158 ILE B C     1 
+ATOM   5225 O O     . ILE D 3 164 ? 86.716  33.250 65.275  1.00 36.43  ? ? ? ? ? ? 158 ILE B O     1 
+ATOM   5226 C CB    . ILE D 3 164 ? 88.108  31.508 62.850  1.00 35.72  ? ? ? ? ? ? 158 ILE B CB    1 
+ATOM   5227 C CG1   . ILE D 3 164 ? 89.337  30.665 62.469  1.00 34.58  ? ? ? ? ? ? 158 ILE B CG1   1 
+ATOM   5228 C CG2   . ILE D 3 164 ? 88.178  33.011 62.495  1.00 32.32  ? ? ? ? ? ? 158 ILE B CG2   1 
+ATOM   5229 C CD1   . ILE D 3 164 ? 89.899  30.940 61.099  1.00 33.76  ? ? ? ? ? ? 158 ILE B CD1   1 
+ATOM   5230 N N     . ARG D 3 165 ? 85.358  31.656 64.417  1.00 34.97  ? ? ? ? ? ? 159 ARG B N     1 
+ATOM   5231 C CA    . ARG D 3 165 ? 84.109  32.350 64.721  1.00 34.33  ? ? ? ? ? ? 159 ARG B CA    1 
+ATOM   5232 C C     . ARG D 3 165 ? 83.947  32.495 66.224  1.00 35.80  ? ? ? ? ? ? 159 ARG B C     1 
+ATOM   5233 O O     . ARG D 3 165 ? 83.744  33.599 66.735  1.00 36.93  ? ? ? ? ? ? 159 ARG B O     1 
+ATOM   5234 C CB    . ARG D 3 165 ? 82.880  31.592 64.186  1.00 30.56  ? ? ? ? ? ? 159 ARG B CB    1 
+ATOM   5235 C CG    . ARG D 3 165 ? 81.569  32.416 64.295  1.00 38.32  ? ? ? ? ? ? 159 ARG B CG    1 
+ATOM   5236 C CD    . ARG D 3 165 ? 80.260  31.602 64.258  1.00 28.78  ? ? ? ? ? ? 159 ARG B CD    1 
+ATOM   5237 N NE    . ARG D 3 165 ? 80.254  30.467 65.177  1.00 24.08  ? ? ? ? ? ? 159 ARG B NE    1 
+ATOM   5238 C CZ    . ARG D 3 165 ? 79.459  29.411 65.061  1.00 29.95  ? ? ? ? ? ? 159 ARG B CZ    1 
+ATOM   5239 N NH1   . ARG D 3 165 ? 78.582  29.325 64.065  1.00 28.09  ? ? ? ? ? ? 159 ARG B NH1   1 
+ATOM   5240 N NH2   . ARG D 3 165 ? 79.541  28.445 65.957  1.00 26.86  ? ? ? ? ? ? 159 ARG B NH2   1 
+ATOM   5241 N N     . ASN D 3 166 ? 84.014  31.349 66.895  1.00 27.81  ? ? ? ? ? ? 160 ASN B N     1 
+ATOM   5242 C CA    . ASN D 3 166 ? 83.865  31.224 68.332  1.00 26.99  ? ? ? ? ? ? 160 ASN B CA    1 
+ATOM   5243 C C     . ASN D 3 166 ? 84.842  32.018 69.161  1.00 36.74  ? ? ? ? ? ? 160 ASN B C     1 
+ATOM   5244 O O     . ASN D 3 166 ? 84.544  32.366 70.296  1.00 41.33  ? ? ? ? ? ? 160 ASN B O     1 
+ATOM   5245 C CB    . ASN D 3 166 ? 83.932  29.759 68.741  1.00 23.03  ? ? ? ? ? ? 160 ASN B CB    1 
+ATOM   5246 C CG    . ASN D 3 166 ? 82.794  28.972 68.162  1.00 38.67  ? ? ? ? ? ? 160 ASN B CG    1 
+ATOM   5247 O OD1   . ASN D 3 166 ? 82.010  29.513 67.379  1.00 31.32  ? ? ? ? ? ? 160 ASN B OD1   1 
+ATOM   5248 N ND2   . ASN D 3 166 ? 82.679  27.703 68.544  1.00 30.21  ? ? ? ? ? ? 160 ASN B ND2   1 
+ATOM   5249 N N     . LEU D 3 167 ? 86.012  32.301 68.614  1.00 33.04  ? ? ? ? ? ? 161 LEU B N     1 
+ATOM   5250 C CA    . LEU D 3 167 ? 87.012  33.046 69.361  1.00 30.31  ? ? ? ? ? ? 161 LEU B CA    1 
+ATOM   5251 C C     . LEU D 3 167 ? 86.739  34.529 69.167  1.00 32.34  ? ? ? ? ? ? 161 LEU B C     1 
+ATOM   5252 O O     . LEU D 3 167 ? 86.974  35.334 70.063  1.00 34.38  ? ? ? ? ? ? 161 LEU B O     1 
+ATOM   5253 C CB    . LEU D 3 167 ? 88.418  32.651 68.897  1.00 29.54  ? ? ? ? ? ? 161 LEU B CB    1 
+ATOM   5254 C CG    . LEU D 3 167 ? 89.631  33.244 69.607  1.00 32.76  ? ? ? ? ? ? 161 LEU B CG    1 
+ATOM   5255 C CD1   . LEU D 3 167 ? 89.513  32.955 71.103  1.00 33.17  ? ? ? ? ? ? 161 LEU B CD1   1 
+ATOM   5256 C CD2   . LEU D 3 167 ? 90.894  32.619 69.039  1.00 27.45  ? ? ? ? ? ? 161 LEU B CD2   1 
+ATOM   5257 N N     . ALA D 3 168 ? 86.231  34.881 67.987  1.00 27.99  ? ? ? ? ? ? 162 ALA B N     1 
+ATOM   5258 C CA    . ALA D 3 168 ? 85.862  36.254 67.653  1.00 28.44  ? ? ? ? ? ? 162 ALA B CA    1 
+ATOM   5259 C C     . ALA D 3 168 ? 84.659  36.622 68.516  1.00 31.24  ? ? ? ? ? ? 162 ALA B C     1 
+ATOM   5260 O O     . ALA D 3 168 ? 84.594  37.710 69.092  1.00 31.38  ? ? ? ? ? ? 162 ALA B O     1 
+ATOM   5261 C CB    . ALA D 3 168 ? 85.497  36.356 66.181  1.00 29.34  ? ? ? ? ? ? 162 ALA B CB    1 
+ATOM   5262 N N     . PHE D 3 169 ? 83.703  35.697 68.602  1.00 28.44  ? ? ? ? ? ? 163 PHE B N     1 
+ATOM   5263 C CA    . PHE D 3 169 ? 82.528  35.894 69.449  1.00 30.74  ? ? ? ? ? ? 163 PHE B CA    1 
+ATOM   5264 C C     . PHE D 3 169 ? 82.908  36.145 70.907  1.00 33.41  ? ? ? ? ? ? 163 PHE B C     1 
+ATOM   5265 O O     . PHE D 3 169 ? 82.578  37.198 71.461  1.00 33.08  ? ? ? ? ? ? 163 PHE B O     1 
+ATOM   5266 C CB    . PHE D 3 169 ? 81.564  34.710 69.433  1.00 32.74  ? ? ? ? ? ? 163 PHE B CB    1 
+ATOM   5267 C CG    . PHE D 3 169 ? 80.544  34.761 70.552  1.00 33.33  ? ? ? ? ? ? 163 PHE B CG    1 
+ATOM   5268 C CD1   . PHE D 3 169 ? 79.582  35.765 70.594  1.00 33.41  ? ? ? ? ? ? 163 PHE B CD1   1 
+ATOM   5269 C CD2   . PHE D 3 169 ? 80.570  33.829 71.580  1.00 33.71  ? ? ? ? ? ? 163 PHE B CD2   1 
+ATOM   5270 C CE1   . PHE D 3 169 ? 78.646  35.814 71.621  1.00 32.55  ? ? ? ? ? ? 163 PHE B CE1   1 
+ATOM   5271 C CE2   . PHE D 3 169 ? 79.644  33.877 72.611  1.00 35.49  ? ? ? ? ? ? 163 PHE B CE2   1 
+ATOM   5272 C CZ    . PHE D 3 169 ? 78.677  34.869 72.631  1.00 32.33  ? ? ? ? ? ? 163 PHE B CZ    1 
+ATOM   5273 N N     . LEU D 3 170 ? 83.580  35.176 71.527  1.00 28.17  ? ? ? ? ? ? 164 LEU B N     1 
+ATOM   5274 C CA    . LEU D 3 170 ? 84.021  35.338 72.909  1.00 27.30  ? ? ? ? ? ? 164 LEU B CA    1 
+ATOM   5275 C C     . LEU D 3 170 ? 84.760  36.665 73.114  1.00 35.46  ? ? ? ? ? ? 164 LEU B C     1 
+ATOM   5276 O O     . LEU D 3 170 ? 84.538  37.353 74.112  1.00 37.79  ? ? ? ? ? ? 164 LEU B O     1 
+ATOM   5277 C CB    . LEU D 3 170 ? 84.936  34.192 73.314  1.00 25.55  ? ? ? ? ? ? 164 LEU B CB    1 
+ATOM   5278 C CG    . LEU D 3 170 ? 84.256  32.828 73.310  1.00 29.65  ? ? ? ? ? ? 164 LEU B CG    1 
+ATOM   5279 C CD1   . LEU D 3 170 ? 85.307  31.732 73.289  1.00 30.09  ? ? ? ? ? ? 164 LEU B CD1   1 
+ATOM   5280 C CD2   . LEU D 3 170 ? 83.319  32.668 74.502  1.00 30.15  ? ? ? ? ? ? 164 LEU B CD2   1 
+ATOM   5281 N N     . GLY D 3 171 ? 85.613  37.026 72.157  1.00 30.60  ? ? ? ? ? ? 165 GLY B N     1 
+ATOM   5282 C CA    . GLY D 3 171 ? 86.387  38.261 72.223  1.00 29.77  ? ? ? ? ? ? 165 GLY B CA    1 
+ATOM   5283 C C     . GLY D 3 171 ? 85.476  39.478 72.237  1.00 40.54  ? ? ? ? ? ? 165 GLY B C     1 
+ATOM   5284 O O     . GLY D 3 171 ? 85.703  40.421 72.990  1.00 42.33  ? ? ? ? ? ? 165 GLY B O     1 
+ATOM   5285 N N     . ILE D 3 172 ? 84.457  39.466 71.382  1.00 39.94  ? ? ? ? ? ? 166 ILE B N     1 
+ATOM   5286 C CA    . ILE D 3 172 ? 83.510  40.575 71.318  1.00 39.88  ? ? ? ? ? ? 166 ILE B CA    1 
+ATOM   5287 C C     . ILE D 3 172 ? 82.665  40.620 72.599  1.00 45.38  ? ? ? ? ? ? 166 ILE B C     1 
+ATOM   5288 O O     . ILE D 3 172 ? 82.426  41.689 73.166  1.00 46.80  ? ? ? ? ? ? 166 ILE B O     1 
+ATOM   5289 C CB    . ILE D 3 172 ? 82.592  40.469 70.078  1.00 42.77  ? ? ? ? ? ? 166 ILE B CB    1 
+ATOM   5290 C CG1   . ILE D 3 172 ? 83.294  41.056 68.856  1.00 42.56  ? ? ? ? ? ? 166 ILE B CG1   1 
+ATOM   5291 C CG2   . ILE D 3 172 ? 81.292  41.224 70.316  1.00 46.50  ? ? ? ? ? ? 166 ILE B CG2   1 
+ATOM   5292 C CD1   . ILE D 3 172 ? 82.504  40.960 67.563  1.00 39.44  ? ? ? ? ? ? 166 ILE B CD1   1 
+ATOM   5293 N N     . ALA D 3 173 ? 82.243  39.448 73.066  1.00 36.98  ? ? ? ? ? ? 167 ALA B N     1 
+ATOM   5294 C CA    . ALA D 3 173 ? 81.453  39.340 74.285  1.00 34.30  ? ? ? ? ? ? 167 ALA B CA    1 
+ATOM   5295 C C     . ALA D 3 173 ? 82.199  39.919 75.483  1.00 38.96  ? ? ? ? ? ? 167 ALA B C     1 
+ATOM   5296 O O     . ALA D 3 173 ? 81.605  40.634 76.294  1.00 40.17  ? ? ? ? ? ? 167 ALA B O     1 
+ATOM   5297 C CB    . ALA D 3 173 ? 81.081  37.888 74.550  1.00 33.37  ? ? ? ? ? ? 167 ALA B CB    1 
+ATOM   5298 N N     . TYR D 3 174 ? 83.489  39.595 75.609  1.00 31.13  ? ? ? ? ? ? 168 TYR B N     1 
+ATOM   5299 C CA    . TYR D 3 174 ? 84.295  40.084 76.736  1.00 28.70  ? ? ? ? ? ? 168 TYR B CA    1 
+ATOM   5300 C C     . TYR D 3 174 ? 84.608  41.566 76.582  1.00 33.83  ? ? ? ? ? ? 168 TYR B C     1 
+ATOM   5301 O O     . TYR D 3 174 ? 84.439  42.355 77.504  1.00 35.48  ? ? ? ? ? ? 168 TYR B O     1 
+ATOM   5302 C CB    . TYR D 3 174 ? 85.608  39.289 76.913  1.00 30.51  ? ? ? ? ? ? 168 TYR B CB    1 
+ATOM   5303 C CG    . TYR D 3 174 ? 86.452  39.757 78.093  1.00 31.13  ? ? ? ? ? ? 168 TYR B CG    1 
+ATOM   5304 C CD1   . TYR D 3 174 ? 86.094  39.458 79.407  1.00 33.77  ? ? ? ? ? ? 168 TYR B CD1   1 
+ATOM   5305 C CD2   . TYR D 3 174 ? 87.577  40.555 77.897  1.00 31.16  ? ? ? ? ? ? 168 TYR B CD2   1 
+ATOM   5306 C CE1   . TYR D 3 174 ? 86.845  39.923 80.490  1.00 37.02  ? ? ? ? ? ? 168 TYR B CE1   1 
+ATOM   5307 C CE2   . TYR D 3 174 ? 88.330  41.021 78.976  1.00 30.61  ? ? ? ? ? ? 168 TYR B CE2   1 
+ATOM   5308 C CZ    . TYR D 3 174 ? 87.960  40.708 80.267  1.00 33.25  ? ? ? ? ? ? 168 TYR B CZ    1 
+ATOM   5309 O OH    . TYR D 3 174 ? 88.698  41.176 81.329  1.00 28.77  ? ? ? ? ? ? 168 TYR B OH    1 
+ATOM   5310 N N     . ASN D 3 175 ? 85.081  41.939 75.402  1.00 30.11  ? ? ? ? ? ? 169 ASN B N     1 
+ATOM   5311 C CA    . ASN D 3 175 ? 85.439  43.319 75.138  1.00 29.35  ? ? ? ? ? ? 169 ASN B CA    1 
+ATOM   5312 C C     . ASN D 3 175 ? 84.254  44.278 75.248  1.00 38.13  ? ? ? ? ? ? 169 ASN B C     1 
+ATOM   5313 O O     . ASN D 3 175 ? 84.344  45.296 75.928  1.00 38.87  ? ? ? ? ? ? 169 ASN B O     1 
+ATOM   5314 C CB    . ASN D 3 175 ? 86.079  43.424 73.741  1.00 25.58  ? ? ? ? ? ? 169 ASN B CB    1 
+ATOM   5315 C CG    . ASN D 3 175 ? 86.937  44.682 73.559  1.00 52.13  ? ? ? ? ? ? 169 ASN B CG    1 
+ATOM   5316 O OD1   . ASN D 3 175 ? 87.887  44.693 72.768  1.00 43.59  ? ? ? ? ? ? 169 ASN B OD1   1 
+ATOM   5317 N ND2   . ASN D 3 175 ? 86.582  45.754 74.262  1.00 49.14  ? ? ? ? ? ? 169 ASN B ND2   1 
+ATOM   5318 N N     . THR D 3 176 ? 83.153  43.977 74.561  1.00 38.24  ? ? ? ? ? ? 170 THR B N     1 
+ATOM   5319 C CA    . THR D 3 176 ? 81.999  44.874 74.538  1.00 38.00  ? ? ? ? ? ? 170 THR B CA    1 
+ATOM   5320 C C     . THR D 3 176 ? 80.974  44.720 75.658  1.00 43.83  ? ? ? ? ? ? 170 THR B C     1 
+ATOM   5321 O O     . THR D 3 176 ? 80.163  45.618 75.875  1.00 43.78  ? ? ? ? ? ? 170 THR B O     1 
+ATOM   5322 C CB    . THR D 3 176 ? 81.206  44.674 73.244  1.00 33.68  ? ? ? ? ? ? 170 THR B CB    1 
+ATOM   5323 O OG1   . THR D 3 176 ? 80.564  43.399 73.313  1.00 35.39  ? ? ? ? ? ? 170 THR B OG1   1 
+ATOM   5324 C CG2   . THR D 3 176 ? 82.117  44.691 72.019  1.00 30.00  ? ? ? ? ? ? 170 THR B CG2   1 
+ATOM   5325 N N     . LEU D 3 177 ? 80.982  43.576 76.333  1.00 42.92  ? ? ? ? ? ? 171 LEU B N     1 
+ATOM   5326 C CA    . LEU D 3 177 ? 80.018  43.260 77.389  1.00 43.26  ? ? ? ? ? ? 171 LEU B CA    1 
+ATOM   5327 C C     . LEU D 3 177 ? 78.573  43.223 76.902  1.00 43.63  ? ? ? ? ? ? 171 LEU B C     1 
+ATOM   5328 O O     . LEU D 3 177 ? 77.654  43.273 77.723  1.00 41.18  ? ? ? ? ? ? 171 LEU B O     1 
+ATOM   5329 C CB    . LEU D 3 177 ? 80.109  44.233 78.567  1.00 43.23  ? ? ? ? ? ? 171 LEU B CB    1 
+ATOM   5330 C CG    . LEU D 3 177 ? 81.301  44.101 79.510  1.00 44.74  ? ? ? ? ? ? 171 LEU B CG    1 
+ATOM   5331 C CD1   . LEU D 3 177 ? 82.457  44.896 78.922  1.00 43.92  ? ? ? ? ? ? 171 LEU B CD1   1 
+ATOM   5332 C CD2   . LEU D 3 177 ? 80.928  44.629 80.881  1.00 41.78  ? ? ? ? ? ? 171 LEU B CD2   1 
+ATOM   5333 N N     . LEU D 3 178 ? 78.366  43.175 75.586  1.00 38.70  ? ? ? ? ? ? 172 LEU B N     1 
+ATOM   5334 C CA    . LEU D 3 178 ? 77.012  43.148 75.038  1.00 37.72  ? ? ? ? ? ? 172 LEU B CA    1 
+ATOM   5335 C C     . LEU D 3 178 ? 76.299  41.851 75.394  1.00 47.83  ? ? ? ? ? ? 172 LEU B C     1 
+ATOM   5336 O O     . LEU D 3 178 ? 76.924  40.804 75.589  1.00 50.53  ? ? ? ? ? ? 172 LEU B O     1 
+ATOM   5337 C CB    . LEU D 3 178 ? 77.029  43.274 73.514  1.00 36.25  ? ? ? ? ? ? 172 LEU B CB    1 
+ATOM   5338 C CG    . LEU D 3 178 ? 77.476  44.575 72.847  1.00 39.25  ? ? ? ? ? ? 172 LEU B CG    1 
+ATOM   5339 C CD1   . LEU D 3 178 ? 77.484  44.380 71.338  1.00 36.51  ? ? ? ? ? ? 172 LEU B CD1   1 
+ATOM   5340 C CD2   . LEU D 3 178 ? 76.602  45.758 73.235  1.00 40.83  ? ? ? ? ? ? 172 LEU B CD2   1 
+ATOM   5341 N N     . ARG D 3 179 ? 74.977  41.914 75.483  1.00 43.39  ? ? ? ? ? ? 173 ARG B N     1 
+ATOM   5342 C CA    . ARG D 3 179 ? 74.194  40.721 75.758  1.00 40.88  ? ? ? ? ? ? 173 ARG B CA    1 
+ATOM   5343 C C     . ARG D 3 179 ? 74.216  39.897 74.475  1.00 40.45  ? ? ? ? ? ? 173 ARG B C     1 
+ATOM   5344 O O     . ARG D 3 179 ? 74.375  40.422 73.377  1.00 37.03  ? ? ? ? ? ? 173 ARG B O     1 
+ATOM   5345 C CB    . ARG D 3 179 ? 72.760  41.075 76.167  1.00 37.31  ? ? ? ? ? ? 173 ARG B CB    1 
+ATOM   5346 C CG    . ARG D 3 179 ? 72.613  41.311 77.656  1.00 39.19  ? ? ? ? ? ? 173 ARG B CG    1 
+ATOM   5347 C CD    . ARG D 3 179 ? 71.433  42.212 77.944  1.00 50.33  ? ? ? ? ? ? 173 ARG B CD    1 
+ATOM   5348 N NE    . ARG D 3 179 ? 71.709  43.128 79.040  1.00 65.69  ? ? ? ? ? ? 173 ARG B NE    1 
+ATOM   5349 C CZ    . ARG D 3 179 ? 71.703  44.447 78.917  1.00 85.10  ? ? ? ? ? ? 173 ARG B CZ    1 
+ATOM   5350 N NH1   . ARG D 3 179 ? 71.413  45.001 77.735  1.00 71.63  ? ? ? ? ? ? 173 ARG B NH1   1 
+ATOM   5351 N NH2   . ARG D 3 179 ? 71.939  45.206 79.966  1.00 81.67  ? ? ? ? ? ? 173 ARG B NH2   1 
+ATOM   5352 N N     . ILE D 3 180 ? 74.052  38.592 74.610  1.00 37.41  ? ? ? ? ? ? 174 ILE B N     1 
+ATOM   5353 C CA    . ILE D 3 180 ? 74.097  37.748 73.434  1.00 35.79  ? ? ? ? ? ? 174 ILE B CA    1 
+ATOM   5354 C C     . ILE D 3 180 ? 73.160  38.199 72.312  1.00 41.08  ? ? ? ? ? ? 174 ILE B C     1 
+ATOM   5355 O O     . ILE D 3 180 ? 73.561  38.193 71.153  1.00 40.57  ? ? ? ? ? ? 174 ILE B O     1 
+ATOM   5356 C CB    . ILE D 3 180 ? 73.984  36.233 73.791  1.00 37.84  ? ? ? ? ? ? 174 ILE B CB    1 
+ATOM   5357 C CG1   . ILE D 3 180 ? 72.734  35.975 74.645  1.00 37.33  ? ? ? ? ? ? 174 ILE B CG1   1 
+ATOM   5358 C CG2   . ILE D 3 180 ? 75.204  35.786 74.589  1.00 38.10  ? ? ? ? ? ? 174 ILE B CG2   1 
+ATOM   5359 C CD1   . ILE D 3 180 ? 72.456  34.521 75.024  1.00 25.79  ? ? ? ? ? ? 174 ILE B CD1   1 
+ATOM   5360 N N     . ALA D 3 181 ? 71.928  38.586 72.637  1.00 38.66  ? ? ? ? ? ? 175 ALA B N     1 
+ATOM   5361 C CA    . ALA D 3 181 ? 70.964  39.012 71.615  1.00 36.96  ? ? ? ? ? ? 175 ALA B CA    1 
+ATOM   5362 C C     . ALA D 3 181 ? 71.384  40.273 70.870  1.00 36.77  ? ? ? ? ? ? 175 ALA B C     1 
+ATOM   5363 O O     . ALA D 3 181 ? 71.063  40.450 69.698  1.00 33.85  ? ? ? ? ? ? 175 ALA B O     1 
+ATOM   5364 C CB    . ALA D 3 181 ? 69.603  39.201 72.226  1.00 38.41  ? ? ? ? ? ? 175 ALA B CB    1 
+ATOM   5365 N N     . GLU D 3 182 ? 72.150  41.123 71.542  1.00 34.60  ? ? ? ? ? ? 176 GLU B N     1 
+ATOM   5366 C CA    . GLU D 3 182 ? 72.653  42.319 70.891  1.00 34.24  ? ? ? ? ? ? 176 GLU B CA    1 
+ATOM   5367 C C     . GLU D 3 182 ? 73.775  41.887 69.950  1.00 44.03  ? ? ? ? ? ? 176 GLU B C     1 
+ATOM   5368 O O     . GLU D 3 182 ? 73.897  42.404 68.844  1.00 47.80  ? ? ? ? ? ? 176 GLU B O     1 
+ATOM   5369 C CB    . GLU D 3 182 ? 73.165  43.320 71.922  1.00 35.53  ? ? ? ? ? ? 176 GLU B CB    1 
+ATOM   5370 C CG    . GLU D 3 182 ? 72.053  43.898 72.763  1.00 46.54  ? ? ? ? ? ? 176 GLU B CG    1 
+ATOM   5371 C CD    . GLU D 3 182 ? 72.444  44.078 74.207  1.00 59.35  ? ? ? ? ? ? 176 GLU B CD    1 
+ATOM   5372 O OE1   . GLU D 3 182 ? 73.538  44.620 74.457  1.00 36.99  ? ? ? ? ? ? 176 GLU B OE1   1 
+ATOM   5373 O OE2   . GLU D 3 182 ? 71.633  43.702 75.084  1.00 61.67  ? ? ? ? ? ? 176 GLU B OE2   1 
+ATOM   5374 N N     . ILE D 3 183 ? 74.571  40.905 70.369  1.00 40.60  ? ? ? ? ? ? 177 ILE B N     1 
+ATOM   5375 C CA    . ILE D 3 183 ? 75.663  40.407 69.533  1.00 37.71  ? ? ? ? ? ? 177 ILE B CA    1 
+ATOM   5376 C C     . ILE D 3 183 ? 75.135  39.725 68.274  1.00 38.86  ? ? ? ? ? ? 177 ILE B C     1 
+ATOM   5377 O O     . ILE D 3 183 ? 75.662  39.937 67.181  1.00 36.48  ? ? ? ? ? ? 177 ILE B O     1 
+ATOM   5378 C CB    . ILE D 3 183 ? 76.622  39.466 70.294  1.00 38.74  ? ? ? ? ? ? 177 ILE B CB    1 
+ATOM   5379 C CG1   . ILE D 3 183 ? 77.514  40.261 71.253  1.00 39.21  ? ? ? ? ? ? 177 ILE B CG1   1 
+ATOM   5380 C CG2   . ILE D 3 183 ? 77.442  38.641 69.317  1.00 33.30  ? ? ? ? ? ? 177 ILE B CG2   1 
+ATOM   5381 C CD1   . ILE D 3 183 ? 78.097  39.432 72.406  1.00 39.22  ? ? ? ? ? ? 177 ILE B CD1   1 
+ATOM   5382 N N     . ALA D 3 184 ? 74.084  38.925 68.424  1.00 38.21  ? ? ? ? ? ? 178 ALA B N     1 
+ATOM   5383 C CA    . ALA D 3 184 ? 73.471  38.258 67.277  1.00 39.35  ? ? ? ? ? ? 178 ALA B CA    1 
+ATOM   5384 C C     . ALA D 3 184 ? 72.858  39.271 66.292  1.00 45.32  ? ? ? ? ? ? 178 ALA B C     1 
+ATOM   5385 O O     . ALA D 3 184 ? 72.705  38.992 65.100  1.00 45.33  ? ? ? ? ? ? 178 ALA B O     1 
+ATOM   5386 C CB    . ALA D 3 184 ? 72.430  37.238 67.733  1.00 39.06  ? ? ? ? ? ? 178 ALA B CB    1 
+ATOM   5387 N N     . ARG D 3 185 ? 72.507  40.451 66.793  1.00 43.42  ? ? ? ? ? ? 179 ARG B N     1 
+ATOM   5388 C CA    . ARG D 3 185 ? 71.909  41.484 65.949  1.00 44.52  ? ? ? ? ? ? 179 ARG B CA    1 
+ATOM   5389 C C     . ARG D 3 185 ? 72.917  42.333 65.185  1.00 50.75  ? ? ? ? ? ? 179 ARG B C     1 
+ATOM   5390 O O     . ARG D 3 185 ? 72.542  43.129 64.332  1.00 53.48  ? ? ? ? ? ? 179 ARG B O     1 
+ATOM   5391 C CB    . ARG D 3 185 ? 71.030  42.409 66.787  1.00 45.04  ? ? ? ? ? ? 179 ARG B CB    1 
+ATOM   5392 C CG    . ARG D 3 185 ? 69.600  41.940 66.929  1.00 54.10  ? ? ? ? ? ? 179 ARG B CG    1 
+ATOM   5393 C CD    . ARG D 3 185 ? 68.708  43.105 67.277  1.00 49.21  ? ? ? ? ? ? 179 ARG B CD    1 
+ATOM   5394 N NE    . ARG D 3 185 ? 69.143  43.792 68.485  1.00 38.55  ? ? ? ? ? ? 179 ARG B NE    1 
+ATOM   5395 C CZ    . ARG D 3 185 ? 68.774  43.439 69.711  1.00 38.66  ? ? ? ? ? ? 179 ARG B CZ    1 
+ATOM   5396 N NH1   . ARG D 3 185 ? 67.979  42.394 69.883  1.00 34.27  ? ? ? ? ? ? 179 ARG B NH1   1 
+ATOM   5397 N NH2   . ARG D 3 185 ? 69.184  44.110 70.778  1.00 30.88  ? ? ? ? ? ? 179 ARG B NH2   1 
+ATOM   5398 N N     . ILE D 3 186 ? 74.195  42.202 65.510  1.00 47.63  ? ? ? ? ? ? 180 ILE B N     1 
+ATOM   5399 C CA    . ILE D 3 186 ? 75.200  43.004 64.822  1.00 47.30  ? ? ? ? ? ? 180 ILE B CA    1 
+ATOM   5400 C C     . ILE D 3 186 ? 75.150  42.675 63.335  1.00 49.25  ? ? ? ? ? ? 180 ILE B C     1 
+ATOM   5401 O O     . ILE D 3 186 ? 75.174  41.503 62.958  1.00 48.44  ? ? ? ? ? ? 180 ILE B O     1 
+ATOM   5402 C CB    . ILE D 3 186 ? 76.627  42.767 65.386  1.00 48.56  ? ? ? ? ? ? 180 ILE B CB    1 
+ATOM   5403 C CG1   . ILE D 3 186 ? 76.720  43.248 66.834  1.00 47.04  ? ? ? ? ? ? 180 ILE B CG1   1 
+ATOM   5404 C CG2   . ILE D 3 186 ? 77.685  43.447 64.521  1.00 44.55  ? ? ? ? ? ? 180 ILE B CG2   1 
+ATOM   5405 C CD1   . ILE D 3 186 ? 78.012  42.849 67.518  1.00 38.87  ? ? ? ? ? ? 180 ILE B CD1   1 
+ATOM   5406 N N     . ARG D 3 187 ? 75.149  43.696 62.490  1.00 44.79  ? ? ? ? ? ? 181 ARG B N     1 
+ATOM   5407 C CA    . ARG D 3 187 ? 75.162  43.426 61.061  1.00 45.48  ? ? ? ? ? ? 181 ARG B CA    1 
+ATOM   5408 C C     . ARG D 3 187 ? 76.481  44.001 60.556  1.00 44.77  ? ? ? ? ? ? 181 ARG B C     1 
+ATOM   5409 O O     . ARG D 3 187 ? 77.029  44.924 61.163  1.00 44.20  ? ? ? ? ? ? 181 ARG B O     1 
+ATOM   5410 C CB    . ARG D 3 187 ? 73.973  44.075 60.352  1.00 47.16  ? ? ? ? ? ? 181 ARG B CB    1 
+ATOM   5411 C CG    . ARG D 3 187 ? 72.792  43.154 60.037  1.00 51.21  ? ? ? ? ? ? 181 ARG B CG    1 
+ATOM   5412 C CD    . ARG D 3 187 ? 71.713  43.986 59.326  1.00 56.98  ? ? ? ? ? ? 181 ARG B CD    1 
+ATOM   5413 N NE    . ARG D 3 187 ? 70.325  43.624 59.611  1.00 38.89  ? ? ? ? ? ? 181 ARG B NE    1 
+ATOM   5414 C CZ    . ARG D 3 187 ? 69.676  42.656 58.981  1.00 55.21  ? ? ? ? ? ? 181 ARG B CZ    1 
+ATOM   5415 N NH1   . ARG D 3 187 ? 70.296  41.935 58.055  1.00 55.38  ? ? ? ? ? ? 181 ARG B NH1   1 
+ATOM   5416 N NH2   . ARG D 3 187 ? 68.412  42.395 59.279  1.00 50.49  ? ? ? ? ? ? 181 ARG B NH2   1 
+ATOM   5417 N N     . VAL D 3 188 ? 77.011  43.441 59.475  1.00 39.00  ? ? ? ? ? ? 182 VAL B N     1 
+ATOM   5418 C CA    . VAL D 3 188 ? 78.271  43.931 58.932  1.00 37.30  ? ? ? ? ? ? 182 VAL B CA    1 
+ATOM   5419 C C     . VAL D 3 188 ? 78.272  45.450 58.750  1.00 47.56  ? ? ? ? ? ? 182 VAL B C     1 
+ATOM   5420 O O     . VAL D 3 188 ? 79.213  46.128 59.162  1.00 48.89  ? ? ? ? ? ? 182 VAL B O     1 
+ATOM   5421 C CB    . VAL D 3 188 ? 78.634  43.246 57.621  1.00 37.88  ? ? ? ? ? ? 182 VAL B CB    1 
+ATOM   5422 C CG1   . VAL D 3 188 ? 79.989  43.730 57.139  1.00 38.05  ? ? ? ? ? ? 182 VAL B CG1   1 
+ATOM   5423 C CG2   . VAL D 3 188 ? 78.640  41.735 57.806  1.00 36.69  ? ? ? ? ? ? 182 VAL B CG2   1 
+ATOM   5424 N N     . LYS D 3 189 ? 77.205  46.002 58.176  1.00 48.13  ? ? ? ? ? ? 183 LYS B N     1 
+ATOM   5425 C CA    . LYS D 3 189 ? 77.143  47.453 58.008  1.00 49.44  ? ? ? ? ? ? 183 LYS B CA    1 
+ATOM   5426 C C     . LYS D 3 189 ? 77.291  48.239 59.311  1.00 56.37  ? ? ? ? ? ? 183 LYS B C     1 
+ATOM   5427 O O     . LYS D 3 189 ? 77.404  49.459 59.290  1.00 60.04  ? ? ? ? ? ? 183 LYS B O     1 
+ATOM   5428 C CB    . LYS D 3 189 ? 75.951  47.962 57.169  1.00 53.44  ? ? ? ? ? ? 183 LYS B CB    1 
+ATOM   5429 C CG    . LYS D 3 189 ? 74.635  47.189 57.190  1.00 74.25  ? ? ? ? ? ? 183 LYS B CG    1 
+ATOM   5430 C CD    . LYS D 3 189 ? 73.627  47.782 58.151  1.00 90.71  ? ? ? ? ? ? 183 LYS B CD    1 
+ATOM   5431 C CE    . LYS D 3 189 ? 72.768  48.841 57.496  1.00 100.00 ? ? ? ? ? ? 183 LYS B CE    1 
+ATOM   5432 N NZ    . LYS D 3 189 ? 71.552  48.251 56.882  1.00 100.00 ? ? ? ? ? ? 183 LYS B NZ    1 
+ATOM   5433 N N     . ASP D 3 190 ? 77.237  47.543 60.442  1.00 50.84  ? ? ? ? ? ? 184 ASP B N     1 
+ATOM   5434 C CA    . ASP D 3 190 ? 77.333  48.211 61.736  1.00 50.17  ? ? ? ? ? ? 184 ASP B CA    1 
+ATOM   5435 C C     . ASP D 3 190 ? 78.759  48.437 62.187  1.00 53.23  ? ? ? ? ? ? 184 ASP B C     1 
+ATOM   5436 O O     . ASP D 3 190 ? 79.007  49.139 63.171  1.00 50.09  ? ? ? ? ? ? 184 ASP B O     1 
+ATOM   5437 C CB    . ASP D 3 190 ? 76.627  47.389 62.807  1.00 52.64  ? ? ? ? ? ? 184 ASP B CB    1 
+ATOM   5438 C CG    . ASP D 3 190 ? 75.133  47.344 62.617  1.00 59.63  ? ? ? ? ? ? 184 ASP B CG    1 
+ATOM   5439 O OD1   . ASP D 3 190 ? 74.573  48.299 62.030  1.00 60.59  ? ? ? ? ? ? 184 ASP B OD1   1 
+ATOM   5440 O OD2   . ASP D 3 190 ? 74.519  46.354 63.058  1.00 59.48  ? ? ? ? ? ? 184 ASP B OD2   1 
+ATOM   5441 N N     . ILE D 3 191 ? 79.697  47.810 61.486  1.00 51.60  ? ? ? ? ? ? 185 ILE B N     1 
+ATOM   5442 C CA    . ILE D 3 191 ? 81.091  47.943 61.876  1.00 53.36  ? ? ? ? ? ? 185 ILE B CA    1 
+ATOM   5443 C C     . ILE D 3 191 ? 81.823  49.068 61.177  1.00 58.71  ? ? ? ? ? ? 185 ILE B C     1 
+ATOM   5444 O O     . ILE D 3 191 ? 81.712  49.237 59.962  1.00 58.92  ? ? ? ? ? ? 185 ILE B O     1 
+ATOM   5445 C CB    . ILE D 3 191 ? 81.916  46.649 61.689  1.00 56.67  ? ? ? ? ? ? 185 ILE B CB    1 
+ATOM   5446 C CG1   . ILE D 3 191 ? 81.262  45.471 62.411  1.00 56.66  ? ? ? ? ? ? 185 ILE B CG1   1 
+ATOM   5447 C CG2   . ILE D 3 191 ? 83.337  46.854 62.199  1.00 57.23  ? ? ? ? ? ? 185 ILE B CG2   1 
+ATOM   5448 C CD1   . ILE D 3 191 ? 81.786  44.128 61.949  1.00 59.68  ? ? ? ? ? ? 185 ILE B CD1   1 
+ATOM   5449 N N     . SER D 3 192 ? 82.617  49.795 61.955  1.00 56.78  ? ? ? ? ? ? 186 SER B N     1 
+ATOM   5450 C CA    . SER D 3 192 ? 83.425  50.881 61.420  1.00 56.89  ? ? ? ? ? ? 186 SER B CA    1 
+ATOM   5451 C C     . SER D 3 192 ? 84.838  50.829 61.972  1.00 61.47  ? ? ? ? ? ? 186 SER B C     1 
+ATOM   5452 O O     . SER D 3 192 ? 85.251  49.802 62.504  1.00 61.68  ? ? ? ? ? ? 186 SER B O     1 
+ATOM   5453 C CB    . SER D 3 192 ? 82.774  52.245 61.665  1.00 60.94  ? ? ? ? ? ? 186 SER B CB    1 
+ATOM   5454 O OG    . SER D 3 192 ? 82.557  52.490 63.042  1.00 70.06  ? ? ? ? ? ? 186 SER B OG    1 
+ATOM   5455 N N     . ARG D 3 193 ? 85.567  51.934 61.831  1.00 58.49  ? ? ? ? ? ? 187 ARG B N     1 
+ATOM   5456 C CA    . ARG D 3 193 ? 86.948  51.989 62.288  1.00 59.22  ? ? ? ? ? ? 187 ARG B CA    1 
+ATOM   5457 C C     . ARG D 3 193 ? 87.270  53.252 63.074  1.00 68.53  ? ? ? ? ? ? 187 ARG B C     1 
+ATOM   5458 O O     . ARG D 3 193 ? 86.716  54.301 62.770  1.00 67.76  ? ? ? ? ? ? 187 ARG B O     1 
+ATOM   5459 C CB    . ARG D 3 193 ? 87.864  51.879 61.074  1.00 60.01  ? ? ? ? ? ? 187 ARG B CB    1 
+ATOM   5460 C CG    . ARG D 3 193 ? 87.579  50.647 60.239  1.00 75.77  ? ? ? ? ? ? 187 ARG B CG    1 
+ATOM   5461 C CD    . ARG D 3 193 ? 88.397  49.485 60.755  1.00 89.12  ? ? ? ? ? ? 187 ARG B CD    1 
+ATOM   5462 N NE    . ARG D 3 193 ? 88.036  48.215 60.140  1.00 96.03  ? ? ? ? ? ? 187 ARG B NE    1 
+ATOM   5463 C CZ    . ARG D 3 193 ? 88.809  47.138 60.193  1.00 100.00 ? ? ? ? ? ? 187 ARG B CZ    1 
+ATOM   5464 N NH1   . ARG D 3 193 ? 89.975  47.199 60.829  1.00 72.41  ? ? ? ? ? ? 187 ARG B NH1   1 
+ATOM   5465 N NH2   . ARG D 3 193 ? 88.428  46.006 59.619  1.00 97.82  ? ? ? ? ? ? 187 ARG B NH2   1 
+ATOM   5466 N N     . THR D 3 194 ? 88.158  53.184 64.063  1.00 70.95  ? ? ? ? ? ? 188 THR B N     1 
+ATOM   5467 C CA    . THR D 3 194 ? 88.473  54.390 64.828  1.00 73.62  ? ? ? ? ? ? 188 THR B CA    1 
+ATOM   5468 C C     . THR D 3 194 ? 89.454  55.379 64.237  1.00 80.23  ? ? ? ? ? ? 188 THR B C     1 
+ATOM   5469 O O     . THR D 3 194 ? 89.341  56.553 64.595  1.00 83.26  ? ? ? ? ? ? 188 THR B O     1 
+ATOM   5470 C CB    . THR D 3 194 ? 89.074  54.095 66.218  1.00 83.67  ? ? ? ? ? ? 188 THR B CB    1 
+ATOM   5471 O OG1   . THR D 3 194 ? 90.043  53.048 66.103  1.00 79.25  ? ? ? ? ? ? 188 THR B OG1   1 
+ATOM   5472 C CG2   . THR D 3 194 ? 87.996  53.702 67.219  1.00 83.31  ? ? ? ? ? ? 188 THR B CG2   1 
+ATOM   5473 N N     . ASP D 3 195 ? 90.388  54.898 63.413  1.00 73.31  ? ? ? ? ? ? 189 ASP B N     1 
+ATOM   5474 C CA    . ASP D 3 195 ? 91.531  55.632 62.825  1.00 72.19  ? ? ? ? ? ? 189 ASP B CA    1 
+ATOM   5475 C C     . ASP D 3 195 ? 92.791  54.890 63.266  1.00 73.43  ? ? ? ? ? ? 189 ASP B C     1 
+ATOM   5476 O O     . ASP D 3 195 ? 93.702  54.668 62.470  1.00 74.88  ? ? ? ? ? ? 189 ASP B O     1 
+ATOM   5477 C CB    . ASP D 3 195 ? 91.704  57.082 63.308  1.00 74.17  ? ? ? ? ? ? 189 ASP B CB    1 
+ATOM   5478 C CG    . ASP D 3 195 ? 91.233  58.100 62.285  1.00 90.45  ? ? ? ? ? ? 189 ASP B CG    1 
+ATOM   5479 O OD1   . ASP D 3 195 ? 91.106  57.736 61.093  1.00 91.39  ? ? ? ? ? ? 189 ASP B OD1   1 
+ATOM   5480 O OD2   . ASP D 3 195 ? 90.967  59.262 62.659  1.00 99.46  ? ? ? ? ? ? 189 ASP B OD2   1 
+ATOM   5481 N N     . GLY D 3 196 ? 92.827  54.507 64.541  1.00 64.43  ? ? ? ? ? ? 190 GLY B N     1 
+ATOM   5482 C CA    . GLY D 3 196 ? 93.945  53.759 65.102  1.00 61.06  ? ? ? ? ? ? 190 GLY B CA    1 
+ATOM   5483 C C     . GLY D 3 196 ? 93.858  52.364 64.504  1.00 58.70  ? ? ? ? ? ? 190 GLY B C     1 
+ATOM   5484 O O     . GLY D 3 196 ? 94.744  51.531 64.693  1.00 55.00  ? ? ? ? ? ? 190 GLY B O     1 
+ATOM   5485 N N     . GLY D 3 197 ? 92.773  52.143 63.767  1.00 55.45  ? ? ? ? ? ? 191 GLY B N     1 
+ATOM   5486 C CA    . GLY D 3 197 ? 92.507  50.873 63.106  1.00 55.63  ? ? ? ? ? ? 191 GLY B CA    1 
+ATOM   5487 C C     . GLY D 3 197 ? 91.533  49.998 63.895  1.00 59.88  ? ? ? ? ? ? 191 GLY B C     1 
+ATOM   5488 O O     . GLY D 3 197 ? 91.091  48.962 63.396  1.00 60.86  ? ? ? ? ? ? 191 GLY B O     1 
+ATOM   5489 N N     . ARG D 3 198 ? 91.202  50.416 65.118  1.00 54.22  ? ? ? ? ? ? 192 ARG B N     1 
+ATOM   5490 C CA    . ARG D 3 198 ? 90.283  49.673 65.987  1.00 51.57  ? ? ? ? ? ? 192 ARG B CA    1 
+ATOM   5491 C C     . ARG D 3 198 ? 88.854  49.586 65.464  1.00 53.92  ? ? ? ? ? ? 192 ARG B C     1 
+ATOM   5492 O O     . ARG D 3 198 ? 88.250  50.587 65.084  1.00 53.15  ? ? ? ? ? ? 192 ARG B O     1 
+ATOM   5493 C CB    . ARG D 3 198 ? 90.241  50.275 67.392  1.00 46.37  ? ? ? ? ? ? 192 ARG B CB    1 
+ATOM   5494 C CG    . ARG D 3 198 ? 91.525  50.140 68.173  1.00 46.39  ? ? ? ? ? ? 192 ARG B CG    1 
+ATOM   5495 C CD    . ARG D 3 198 ? 91.582  51.170 69.285  1.00 43.42  ? ? ? ? ? ? 192 ARG B CD    1 
+ATOM   5496 N NE    . ARG D 3 198 ? 92.906  51.775 69.360  1.00 48.84  ? ? ? ? ? ? 192 ARG B NE    1 
+ATOM   5497 C CZ    . ARG D 3 198 ? 93.929  51.227 69.994  1.00 51.13  ? ? ? ? ? ? 192 ARG B CZ    1 
+ATOM   5498 N NH1   . ARG D 3 198 ? 93.776  50.087 70.631  1.00 39.25  ? ? ? ? ? ? 192 ARG B NH1   1 
+ATOM   5499 N NH2   . ARG D 3 198 ? 95.103  51.830 70.016  1.00 45.20  ? ? ? ? ? ? 192 ARG B NH2   1 
+ATOM   5500 N N     . MET D 3 199 ? 88.295  48.384 65.474  1.00 51.17  ? ? ? ? ? ? 193 MET B N     1 
+ATOM   5501 C CA    . MET D 3 199 ? 86.921  48.232 65.012  1.00 50.92  ? ? ? ? ? ? 193 MET B CA    1 
+ATOM   5502 C C     . MET D 3 199 ? 85.914  48.920 65.963  1.00 56.99  ? ? ? ? ? ? 193 MET B C     1 
+ATOM   5503 O O     . MET D 3 199 ? 86.119  48.951 67.183  1.00 53.01  ? ? ? ? ? ? 193 MET B O     1 
+ATOM   5504 C CB    . MET D 3 199 ? 86.570  46.752 64.786  1.00 53.21  ? ? ? ? ? ? 193 MET B CB    1 
+ATOM   5505 C CG    . MET D 3 199 ? 86.862  46.222 63.376  1.00 58.61  ? ? ? ? ? ? 193 MET B CG    1 
+ATOM   5506 S SD    . MET D 3 199 ? 86.513  44.452 63.117  1.00 65.50  ? ? ? ? ? ? 193 MET B SD    1 
+ATOM   5507 C CE    . MET D 3 199 ? 85.121  44.182 64.223  1.00 61.88  ? ? ? ? ? ? 193 MET B CE    1 
+ATOM   5508 N N     . LEU D 3 200 ? 84.848  49.489 65.391  1.00 56.89  ? ? ? ? ? ? 194 LEU B N     1 
+ATOM   5509 C CA    . LEU D 3 200 ? 83.767  50.160 66.135  1.00 55.57  ? ? ? ? ? ? 194 LEU B CA    1 
+ATOM   5510 C C     . LEU D 3 200 ? 82.446  49.460 65.820  1.00 56.08  ? ? ? ? ? ? 194 LEU B C     1 
+ATOM   5511 O O     . LEU D 3 200 ? 82.019  49.422 64.661  1.00 54.95  ? ? ? ? ? ? 194 LEU B O     1 
+ATOM   5512 C CB    . LEU D 3 200 ? 83.637  51.645 65.754  1.00 55.71  ? ? ? ? ? ? 194 LEU B CB    1 
+ATOM   5513 C CG    . LEU D 3 200 ? 84.507  52.636 66.535  1.00 62.83  ? ? ? ? ? ? 194 LEU B CG    1 
+ATOM   5514 C CD1   . LEU D 3 200 ? 84.555  54.043 65.940  1.00 65.89  ? ? ? ? ? ? 194 LEU B CD1   1 
+ATOM   5515 C CD2   . LEU D 3 200 ? 84.130  52.664 68.009  1.00 65.59  ? ? ? ? ? ? 194 LEU B CD2   1 
+ATOM   5516 N N     . ILE D 3 201 ? 81.787  48.934 66.849  1.00 50.80  ? ? ? ? ? ? 195 ILE B N     1 
+ATOM   5517 C CA    . ILE D 3 201 ? 80.506  48.269 66.642  1.00 49.67  ? ? ? ? ? ? 195 ILE B CA    1 
+ATOM   5518 C C     . ILE D 3 201 ? 79.328  49.122 67.076  1.00 49.29  ? ? ? ? ? ? 195 ILE B C     1 
+ATOM   5519 O O     . ILE D 3 201 ? 79.192  49.519 68.235  1.00 42.78  ? ? ? ? ? ? 195 ILE B O     1 
+ATOM   5520 C CB    . ILE D 3 201 ? 80.401  46.877 67.267  1.00 52.28  ? ? ? ? ? ? 195 ILE B CB    1 
+ATOM   5521 C CG1   . ILE D 3 201 ? 81.567  46.005 66.806  1.00 52.89  ? ? ? ? ? ? 195 ILE B CG1   1 
+ATOM   5522 C CG2   . ILE D 3 201 ? 79.076  46.238 66.876  1.00 51.36  ? ? ? ? ? ? 195 ILE B CG2   1 
+ATOM   5523 C CD1   . ILE D 3 201 ? 81.599  44.651 67.473  1.00 57.23  ? ? ? ? ? ? 195 ILE B CD1   1 
+ATOM   5524 N N     . HIS D 3 202 ? 78.490  49.413 66.096  1.00 49.50  ? ? ? ? ? ? 196 HIS B N     1 
+ATOM   5525 C CA    . HIS D 3 202 ? 77.339  50.230 66.360  1.00 49.41  ? ? ? ? ? ? 196 HIS B CA    1 
+ATOM   5526 C C     . HIS D 3 202 ? 76.189  49.425 66.925  1.00 49.15  ? ? ? ? ? ? 196 HIS B C     1 
+ATOM   5527 O O     . HIS D 3 202 ? 75.727  48.474 66.300  1.00 46.44  ? ? ? ? ? ? 196 HIS B O     1 
+ATOM   5528 C CB    . HIS D 3 202 ? 76.854  50.899 65.105  1.00 50.97  ? ? ? ? ? ? 196 HIS B CB    1 
+ATOM   5529 C CG    . HIS D 3 202 ? 75.640  51.710 65.368  1.00 55.77  ? ? ? ? ? ? 196 HIS B CG    1 
+ATOM   5530 N ND1   . HIS D 3 202 ? 75.704  52.905 66.047  1.00 58.39  ? ? ? ? ? ? 196 HIS B ND1   1 
+ATOM   5531 C CD2   . HIS D 3 202 ? 74.327  51.418 65.234  1.00 58.57  ? ? ? ? ? ? 196 HIS B CD2   1 
+ATOM   5532 C CE1   . HIS D 3 202 ? 74.479  53.359 66.241  1.00 58.04  ? ? ? ? ? ? 196 HIS B CE1   1 
+ATOM   5533 N NE2   . HIS D 3 202 ? 73.625  52.475 65.761  1.00 58.35  ? ? ? ? ? ? 196 HIS B NE2   1 
+ATOM   5534 N N     . ILE D 3 203 ? 75.702  49.823 68.094  1.00 47.19  ? ? ? ? ? ? 197 ILE B N     1 
+ATOM   5535 C CA    . ILE D 3 203 ? 74.601  49.092 68.708  1.00 49.57  ? ? ? ? ? ? 197 ILE B CA    1 
+ATOM   5536 C C     . ILE D 3 203 ? 73.271  49.846 68.683  1.00 62.01  ? ? ? ? ? ? 197 ILE B C     1 
+ATOM   5537 O O     . ILE D 3 203 ? 73.169  50.947 69.225  1.00 62.61  ? ? ? ? ? ? 197 ILE B O     1 
+ATOM   5538 C CB    . ILE D 3 203 ? 74.912  48.642 70.164  1.00 52.00  ? ? ? ? ? ? 197 ILE B CB    1 
+ATOM   5539 C CG1   . ILE D 3 203 ? 76.226  47.854 70.237  1.00 50.40  ? ? ? ? ? ? 197 ILE B CG1   1 
+ATOM   5540 C CG2   . ILE D 3 203 ? 73.763  47.804 70.699  1.00 52.75  ? ? ? ? ? ? 197 ILE B CG2   1 
+ATOM   5541 C CD1   . ILE D 3 203 ? 76.234  46.586 69.407  1.00 36.29  ? ? ? ? ? ? 197 ILE B CD1   1 
+ATOM   5542 N N     . GLY D 3 204 ? 72.257  49.251 68.055  1.00 63.38  ? ? ? ? ? ? 198 GLY B N     1 
+ATOM   5543 C CA    . GLY D 3 204 ? 70.924  49.844 68.003  1.00 65.30  ? ? ? ? ? ? 198 GLY B CA    1 
+ATOM   5544 C C     . GLY D 3 204 ? 70.184  49.609 69.330  1.00 73.53  ? ? ? ? ? ? 198 GLY B C     1 
+ATOM   5545 O O     . GLY D 3 204 ? 70.396  50.343 70.298  1.00 75.44  ? ? ? ? ? ? 198 GLY B O     1 
+ATOM   5546 N N     . ARG D 3 205 ? 69.346  48.572 69.395  1.00 69.55  ? ? ? ? ? ? 199 ARG B N     1 
+ATOM   5547 C CA    . ARG D 3 205 ? 68.576  48.263 70.610  1.00 66.49  ? ? ? ? ? ? 199 ARG B CA    1 
+ATOM   5548 C C     . ARG D 3 205 ? 69.209  47.305 71.639  1.00 63.78  ? ? ? ? ? ? 199 ARG B C     1 
+ATOM   5549 O O     . ARG D 3 205 ? 69.898  46.355 71.271  1.00 58.13  ? ? ? ? ? ? 199 ARG B O     1 
+ATOM   5550 C CB    . ARG D 3 205 ? 67.147  47.834 70.242  1.00 64.79  ? ? ? ? ? ? 199 ARG B CB    1 
+ATOM   5551 C CG    . ARG D 3 205 ? 66.776  46.399 70.573  1.00 72.89  ? ? ? ? ? ? 199 ARG B CG    1 
+ATOM   5552 C CD    . ARG D 3 205 ? 65.353  46.093 70.132  1.00 65.44  ? ? ? ? ? ? 199 ARG B CD    1 
+ATOM   5553 N NE    . ARG D 3 205 ? 65.277  45.048 69.113  1.00 56.71  ? ? ? ? ? ? 199 ARG B NE    1 
+ATOM   5554 C CZ    . ARG D 3 205 ? 64.680  43.875 69.315  1.00 68.83  ? ? ? ? ? ? 199 ARG B CZ    1 
+ATOM   5555 N NH1   . ARG D 3 205 ? 64.153  43.605 70.502  1.00 46.80  ? ? ? ? ? ? 199 ARG B NH1   1 
+ATOM   5556 N NH2   . ARG D 3 205 ? 64.631  42.974 68.342  1.00 66.68  ? ? ? ? ? ? 199 ARG B NH2   1 
+ATOM   5557 N N     . THR D 3 206 ? 68.958  47.549 72.926  1.00 63.43  ? ? ? ? ? ? 200 THR B N     1 
+ATOM   5558 C CA    . THR D 3 206 ? 69.461  46.698 74.018  1.00 63.82  ? ? ? ? ? ? 200 THR B CA    1 
+ATOM   5559 C C     . THR D 3 206 ? 68.303  46.343 74.963  1.00 67.78  ? ? ? ? ? ? 200 THR B C     1 
+ATOM   5560 O O     . THR D 3 206 ? 67.154  46.694 74.683  1.00 66.63  ? ? ? ? ? ? 200 THR B O     1 
+ATOM   5561 C CB    . THR D 3 206 ? 70.578  47.411 74.803  1.00 70.97  ? ? ? ? ? ? 200 THR B CB    1 
+ATOM   5562 O OG1   . THR D 3 206 ? 70.004  48.361 75.707  1.00 69.54  ? ? ? ? ? ? 200 THR B OG1   1 
+ATOM   5563 C CG2   . THR D 3 206 ? 71.504  48.132 73.829  1.00 69.07  ? ? ? ? ? ? 200 THR B CG2   1 
+ATOM   5564 N N     . LYS D 3 207 ? 68.554  45.670 76.072  1.00 64.63  ? ? ? ? ? ? 201 LYS B N     1 
+ATOM   5565 C CA    . LYS D 3 207 ? 67.429  45.386 76.933  1.00 64.13  ? ? ? ? ? ? 201 LYS B CA    1 
+ATOM   5566 C C     . LYS D 3 207 ? 67.046  46.660 77.640  1.00 70.24  ? ? ? ? ? ? 201 LYS B C     1 
+ATOM   5567 O O     . LYS D 3 207 ? 65.877  46.940 77.885  1.00 71.80  ? ? ? ? ? ? 201 LYS B O     1 
+ATOM   5568 C CB    . LYS D 3 207 ? 67.873  44.329 77.980  1.00 64.66  ? ? ? ? ? ? 201 LYS B CB    1 
+ATOM   5569 C CG    . LYS D 3 207 ? 66.715  43.830 78.749  1.00 54.63  ? ? ? ? ? ? 201 LYS B CG    1 
+ATOM   5570 C CD    . LYS D 3 207 ? 67.049  44.058 80.181  1.00 52.88  ? ? ? ? ? ? 201 LYS B CD    1 
+ATOM   5571 C CE    . LYS D 3 207 ? 66.948  42.763 80.934  1.00 44.67  ? ? ? ? ? ? 201 LYS B CE    1 
+ATOM   5572 N NZ    . LYS D 3 207 ? 66.990  43.117 82.362  1.00 62.76  ? ? ? ? ? ? 201 LYS B NZ    1 
+ATOM   5573 N N     . THR D 3 208 ? 68.055  47.454 77.924  1.00 66.36  ? ? ? ? ? ? 202 THR B N     1 
+ATOM   5574 C CA    . THR D 3 208 ? 67.833  48.703 78.588  1.00 64.78  ? ? ? ? ? ? 202 THR B CA    1 
+ATOM   5575 C C     . THR D 3 208 ? 67.490  49.889 77.618  1.00 70.25  ? ? ? ? ? ? 202 THR B C     1 
+ATOM   5576 O O     . THR D 3 208 ? 66.919  50.862 78.099  1.00 74.02  ? ? ? ? ? ? 202 THR B O     1 
+ATOM   5577 C CB    . THR D 3 208 ? 68.979  48.892 79.624  1.00 74.89  ? ? ? ? ? ? 202 THR B CB    1 
+ATOM   5578 O OG1   . THR D 3 208 ? 70.217  49.079 78.925  1.00 84.61  ? ? ? ? ? ? 202 THR B OG1   1 
+ATOM   5579 C CG2   . THR D 3 208 ? 69.097  47.625 80.491  1.00 72.23  ? ? ? ? ? ? 202 THR B CG2   1 
+ATOM   5580 N N     . LEU D 3 209 ? 67.735  49.844 76.293  1.00 64.98  ? ? ? ? ? ? 203 LEU B N     1 
+ATOM   5581 C CA    . LEU D 3 209 ? 67.410  50.976 75.366  1.00 65.55  ? ? ? ? ? ? 203 LEU B CA    1 
+ATOM   5582 C C     . LEU D 3 209 ? 67.055  50.721 73.871  1.00 70.61  ? ? ? ? ? ? 203 LEU B C     1 
+ATOM   5583 O O     . LEU D 3 209 ? 67.622  49.839 73.231  1.00 69.60  ? ? ? ? ? ? 203 LEU B O     1 
+ATOM   5584 C CB    . LEU D 3 209 ? 68.483  52.073 75.474  1.00 66.77  ? ? ? ? ? ? 203 LEU B CB    1 
+ATOM   5585 C CG    . LEU D 3 209 ? 69.564  52.284 74.402  1.00 73.28  ? ? ? ? ? ? 203 LEU B CG    1 
+ATOM   5586 C CD1   . LEU D 3 209 ? 69.261  53.533 73.589  1.00 73.32  ? ? ? ? ? ? 203 LEU B CD1   1 
+ATOM   5587 C CD2   . LEU D 3 209 ? 70.970  52.363 75.003  1.00 77.00  ? ? ? ? ? ? 203 LEU B CD2   1 
+ATOM   5588 N N     . VAL D 3 210 ? 66.112  51.501 73.337  1.00 69.50  ? ? ? ? ? ? 204 VAL B N     1 
+ATOM   5589 C CA    . VAL D 3 210 ? 65.622  51.408 71.955  1.00 70.02  ? ? ? ? ? ? 204 VAL B CA    1 
+ATOM   5590 C C     . VAL D 3 210 ? 65.604  52.819 71.334  1.00 81.07  ? ? ? ? ? ? 204 VAL B C     1 
+ATOM   5591 O O     . VAL D 3 210 ? 64.560  53.467 71.208  1.00 82.26  ? ? ? ? ? ? 204 VAL B O     1 
+ATOM   5592 C CB    . VAL D 3 210 ? 64.203  50.789 71.923  1.00 71.10  ? ? ? ? ? ? 204 VAL B CB    1 
+ATOM   5593 C CG1   . VAL D 3 210 ? 64.280  49.294 71.637  1.00 69.08  ? ? ? ? ? ? 204 VAL B CG1   1 
+ATOM   5594 C CG2   . VAL D 3 210 ? 63.491  51.030 73.248  1.00 71.64  ? ? ? ? ? ? 204 VAL B CG2   1 
+ATOM   5595 N N     . SER D 3 211 ? 66.800  53.279 70.972  1.00 79.34  ? ? ? ? ? ? 205 SER B N     1 
+ATOM   5596 C CA    . SER D 3 211 ? 67.027  54.611 70.403  1.00 79.76  ? ? ? ? ? ? 205 SER B CA    1 
+ATOM   5597 C C     . SER D 3 211 ? 67.765  54.649 69.059  1.00 82.98  ? ? ? ? ? ? 205 SER B C     1 
+ATOM   5598 O O     . SER D 3 211 ? 68.482  53.709 68.708  1.00 82.58  ? ? ? ? ? ? 205 SER B O     1 
+ATOM   5599 C CB    . SER D 3 211 ? 67.849  55.443 71.384  1.00 85.14  ? ? ? ? ? ? 205 SER B CB    1 
+ATOM   5600 O OG    . SER D 3 211 ? 68.905  56.108 70.701  1.00 97.00  ? ? ? ? ? ? 205 SER B OG    1 
+ATOM   5601 N N     . THR D 3 212 ? 67.627  55.769 68.344  1.00 77.92  ? ? ? ? ? ? 206 THR B N     1 
+ATOM   5602 C CA    . THR D 3 212 ? 68.273  55.981 67.043  1.00 75.73  ? ? ? ? ? ? 206 THR B CA    1 
+ATOM   5603 C C     . THR D 3 212 ? 69.695  56.485 67.195  1.00 71.91  ? ? ? ? ? ? 206 THR B C     1 
+ATOM   5604 O O     . THR D 3 212 ? 70.465  56.478 66.236  1.00 68.74  ? ? ? ? ? ? 206 THR B O     1 
+ATOM   5605 C CB    . THR D 3 212 ? 67.542  57.033 66.176  1.00 97.06  ? ? ? ? ? ? 206 THR B CB    1 
+ATOM   5606 O OG1   . THR D 3 212 ? 67.673  58.333 66.771  1.00 100.00 ? ? ? ? ? ? 206 THR B OG1   1 
+ATOM   5607 C CG2   . THR D 3 212 ? 66.073  56.681 66.020  1.00 99.54  ? ? ? ? ? ? 206 THR B CG2   1 
+ATOM   5608 N N     . ALA D 3 213 ? 70.009  56.980 68.386  1.00 67.70  ? ? ? ? ? ? 207 ALA B N     1 
+ATOM   5609 C CA    . ALA D 3 213 ? 71.344  57.469 68.680  1.00 68.67  ? ? ? ? ? ? 207 ALA B CA    1 
+ATOM   5610 C C     . ALA D 3 213 ? 72.067  56.155 68.898  1.00 77.34  ? ? ? ? ? ? 207 ALA B C     1 
+ATOM   5611 O O     . ALA D 3 213 ? 72.582  55.556 67.958  1.00 79.64  ? ? ? ? ? ? 207 ALA B O     1 
+ATOM   5612 C CB    . ALA D 3 213 ? 71.337  58.291 69.960  1.00 69.45  ? ? ? ? ? ? 207 ALA B CB    1 
+ATOM   5613 N N     . GLY D 3 214 ? 72.051  55.639 70.114  1.00 73.72  ? ? ? ? ? ? 208 GLY B N     1 
+ATOM   5614 C CA    . GLY D 3 214 ? 72.682  54.346 70.276  1.00 74.42  ? ? ? ? ? ? 208 GLY B CA    1 
+ATOM   5615 C C     . GLY D 3 214 ? 74.168  54.426 70.599  1.00 83.33  ? ? ? ? ? ? 208 GLY B C     1 
+ATOM   5616 O O     . GLY D 3 214 ? 74.761  55.506 70.558  1.00 84.77  ? ? ? ? ? ? 208 GLY B O     1 
+ATOM   5617 N N     . VAL D 3 215 ? 74.744  53.257 70.802  1.00 79.29  ? ? ? ? ? ? 209 VAL B N     1 
+ATOM   5618 C CA    . VAL D 3 215 ? 76.139  53.124 71.192  1.00 76.78  ? ? ? ? ? ? 209 VAL B CA    1 
+ATOM   5619 C C     . VAL D 3 215 ? 77.153  52.750 70.130  1.00 74.01  ? ? ? ? ? ? 209 VAL B C     1 
+ATOM   5620 O O     . VAL D 3 215 ? 76.821  52.227 69.063  1.00 73.32  ? ? ? ? ? ? 209 VAL B O     1 
+ATOM   5621 C CB    . VAL D 3 215 ? 76.252  52.032 72.243  1.00 81.25  ? ? ? ? ? ? 209 VAL B CB    1 
+ATOM   5622 C CG1   . VAL D 3 215 ? 77.532  52.199 73.039  1.00 81.82  ? ? ? ? ? ? 209 VAL B CG1   1 
+ATOM   5623 C CG2   . VAL D 3 215 ? 75.027  52.031 73.141  1.00 81.46  ? ? ? ? ? ? 209 VAL B CG2   1 
+ATOM   5624 N N     . GLU D 3 216 ? 78.414  52.971 70.472  1.00 65.99  ? ? ? ? ? ? 210 GLU B N     1 
+ATOM   5625 C CA    . GLU D 3 216 ? 79.509  52.610 69.593  1.00 63.46  ? ? ? ? ? ? 210 GLU B CA    1 
+ATOM   5626 C C     . GLU D 3 216 ? 80.491  51.790 70.403  1.00 63.92  ? ? ? ? ? ? 210 GLU B C     1 
+ATOM   5627 O O     . GLU D 3 216 ? 81.341  52.327 71.104  1.00 65.31  ? ? ? ? ? ? 210 GLU B O     1 
+ATOM   5628 C CB    . GLU D 3 216 ? 80.168  53.836 68.972  1.00 63.85  ? ? ? ? ? ? 210 GLU B CB    1 
+ATOM   5629 C CG    . GLU D 3 216 ? 79.380  54.381 67.800  1.00 67.22  ? ? ? ? ? ? 210 GLU B CG    1 
+ATOM   5630 C CD    . GLU D 3 216 ? 79.433  53.474 66.590  1.00 76.64  ? ? ? ? ? ? 210 GLU B CD    1 
+ATOM   5631 O OE1   . GLU D 3 216 ? 80.454  52.778 66.410  1.00 71.55  ? ? ? ? ? ? 210 GLU B OE1   1 
+ATOM   5632 O OE2   . GLU D 3 216 ? 78.469  53.480 65.799  1.00 56.64  ? ? ? ? ? ? 210 GLU B OE2   1 
+ATOM   5633 N N     . LYS D 3 217 ? 80.321  50.479 70.343  1.00 57.60  ? ? ? ? ? ? 211 LYS B N     1 
+ATOM   5634 C CA    . LYS D 3 217 ? 81.180  49.590 71.092  1.00 56.53  ? ? ? ? ? ? 211 LYS B CA    1 
+ATOM   5635 C C     . LYS D 3 217 ? 82.491  49.401 70.334  1.00 58.92  ? ? ? ? ? ? 211 LYS B C     1 
+ATOM   5636 O O     . LYS D 3 217 ? 82.512  48.991 69.168  1.00 57.97  ? ? ? ? ? ? 211 LYS B O     1 
+ATOM   5637 C CB    . LYS D 3 217 ? 80.448  48.277 71.345  1.00 58.25  ? ? ? ? ? ? 211 LYS B CB    1 
+ATOM   5638 C CG    . LYS D 3 217 ? 78.964  48.477 71.610  1.00 63.26  ? ? ? ? ? ? 211 LYS B CG    1 
+ATOM   5639 C CD    . LYS D 3 217 ? 78.758  49.008 73.012  1.00 63.98  ? ? ? ? ? ? 211 LYS B CD    1 
+ATOM   5640 C CE    . LYS D 3 217 ? 79.851  48.495 73.933  1.00 55.00  ? ? ? ? ? ? 211 LYS B CE    1 
+ATOM   5641 N NZ    . LYS D 3 217 ? 79.633  48.769 75.371  1.00 68.85  ? ? ? ? ? ? 211 LYS B NZ    1 
+ATOM   5642 N N     . ALA D 3 218 ? 83.586  49.758 70.992  1.00 54.60  ? ? ? ? ? ? 212 ALA B N     1 
+ATOM   5643 C CA    . ALA D 3 218 ? 84.905  49.645 70.386  1.00 54.48  ? ? ? ? ? ? 212 ALA B CA    1 
+ATOM   5644 C C     . ALA D 3 218 ? 85.612  48.347 70.784  1.00 57.06  ? ? ? ? ? ? 212 ALA B C     1 
+ATOM   5645 O O     . ALA D 3 218 ? 85.376  47.803 71.868  1.00 56.45  ? ? ? ? ? ? 212 ALA B O     1 
+ATOM   5646 C CB    . ALA D 3 218 ? 85.767  50.849 70.763  1.00 55.29  ? ? ? ? ? ? 212 ALA B CB    1 
+ATOM   5647 N N     . LEU D 3 219 ? 86.495  47.875 69.906  1.00 50.40  ? ? ? ? ? ? 213 LEU B N     1 
+ATOM   5648 C CA    . LEU D 3 219 ? 87.271  46.663 70.148  1.00 47.44  ? ? ? ? ? ? 213 LEU B CA    1 
+ATOM   5649 C C     . LEU D 3 219 ? 88.766  46.959 70.221  1.00 48.03  ? ? ? ? ? ? 213 LEU B C     1 
+ATOM   5650 O O     . LEU D 3 219 ? 89.268  47.848 69.531  1.00 47.35  ? ? ? ? ? ? 213 LEU B O     1 
+ATOM   5651 C CB    . LEU D 3 219 ? 87.047  45.673 69.008  1.00 47.25  ? ? ? ? ? ? 213 LEU B CB    1 
+ATOM   5652 C CG    . LEU D 3 219 ? 85.600  45.386 68.614  1.00 49.06  ? ? ? ? ? ? 213 LEU B CG    1 
+ATOM   5653 C CD1   . LEU D 3 219 ? 85.532  44.234 67.617  1.00 46.37  ? ? ? ? ? ? 213 LEU B CD1   1 
+ATOM   5654 C CD2   . LEU D 3 219 ? 84.812  45.053 69.864  1.00 51.24  ? ? ? ? ? ? 213 LEU B CD2   1 
+ATOM   5655 N N     . SER D 3 220 ? 89.475  46.182 71.031  1.00 42.47  ? ? ? ? ? ? 214 SER B N     1 
+ATOM   5656 C CA    . SER D 3 220 ? 90.924  46.333 71.156  1.00 40.58  ? ? ? ? ? ? 214 SER B CA    1 
+ATOM   5657 C C     . SER D 3 220 ? 91.578  45.866 69.852  1.00 45.63  ? ? ? ? ? ? 214 SER B C     1 
+ATOM   5658 O O     . SER D 3 220 ? 90.998  45.052 69.128  1.00 46.71  ? ? ? ? ? ? 214 SER B O     1 
+ATOM   5659 C CB    . SER D 3 220 ? 91.437  45.443 72.288  1.00 36.38  ? ? ? ? ? ? 214 SER B CB    1 
+ATOM   5660 O OG    . SER D 3 220 ? 91.484  44.096 71.853  1.00 40.59  ? ? ? ? ? ? 214 SER B OG    1 
+ATOM   5661 N N     . LEU D 3 221 ? 92.783  46.347 69.564  1.00 38.13  ? ? ? ? ? ? 215 LEU B N     1 
+ATOM   5662 C CA    . LEU D 3 221 ? 93.481  45.924 68.355  1.00 37.18  ? ? ? ? ? ? 215 LEU B CA    1 
+ATOM   5663 C C     . LEU D 3 221 ? 93.502  44.394 68.203  1.00 38.07  ? ? ? ? ? ? 215 LEU B C     1 
+ATOM   5664 O O     . LEU D 3 221 ? 93.282  43.855 67.124  1.00 38.75  ? ? ? ? ? ? 215 LEU B O     1 
+ATOM   5665 C CB    . LEU D 3 221 ? 94.904  46.463 68.368  1.00 38.34  ? ? ? ? ? ? 215 LEU B CB    1 
+ATOM   5666 C CG    . LEU D 3 221 ? 95.018  47.981 68.387  1.00 43.02  ? ? ? ? ? ? 215 LEU B CG    1 
+ATOM   5667 C CD1   . LEU D 3 221 ? 96.298  48.376 69.110  1.00 43.62  ? ? ? ? ? ? 215 LEU B CD1   1 
+ATOM   5668 C CD2   . LEU D 3 221 ? 95.015  48.488 66.951  1.00 37.93  ? ? ? ? ? ? 215 LEU B CD2   1 
+ATOM   5669 N N     . GLY D 3 222 ? 93.766  43.683 69.290  1.00 35.20  ? ? ? ? ? ? 216 GLY B N     1 
+ATOM   5670 C CA    . GLY D 3 222 ? 93.798  42.229 69.248  1.00 35.65  ? ? ? ? ? ? 216 GLY B CA    1 
+ATOM   5671 C C     . GLY D 3 222 ? 92.444  41.588 68.922  1.00 39.89  ? ? ? ? ? ? 216 GLY B C     1 
+ATOM   5672 O O     . GLY D 3 222 ? 92.394  40.592 68.193  1.00 40.01  ? ? ? ? ? ? 216 GLY B O     1 
+ATOM   5673 N N     . VAL D 3 223 ? 91.361  42.116 69.501  1.00 36.42  ? ? ? ? ? ? 217 VAL B N     1 
+ATOM   5674 C CA    . VAL D 3 223 ? 89.998  41.602 69.269  1.00 33.18  ? ? ? ? ? ? 217 VAL B CA    1 
+ATOM   5675 C C     . VAL D 3 223 ? 89.534  41.883 67.824  1.00 38.20  ? ? ? ? ? ? 217 VAL B C     1 
+ATOM   5676 O O     . VAL D 3 223 ? 88.860  41.059 67.207  1.00 35.86  ? ? ? ? ? ? 217 VAL B O     1 
+ATOM   5677 C CB    . VAL D 3 223 ? 88.977  42.078 70.362  1.00 32.93  ? ? ? ? ? ? 217 VAL B CB    1 
+ATOM   5678 C CG1   . VAL D 3 223 ? 87.540  41.764 69.962  1.00 31.96  ? ? ? ? ? ? 217 VAL B CG1   1 
+ATOM   5679 C CG2   . VAL D 3 223 ? 89.270  41.388 71.673  1.00 32.00  ? ? ? ? ? ? 217 VAL B CG2   1 
+ATOM   5680 N N     . THR D 3 224 ? 89.941  43.037 67.283  1.00 37.13  ? ? ? ? ? ? 218 THR B N     1 
+ATOM   5681 C CA    . THR D 3 224 ? 89.629  43.437 65.908  1.00 35.71  ? ? ? ? ? ? 218 THR B CA    1 
+ATOM   5682 C C     . THR D 3 224 ? 90.252  42.403 65.002  1.00 41.61  ? ? ? ? ? ? 218 THR B C     1 
+ATOM   5683 O O     . THR D 3 224 ? 89.596  41.867 64.107  1.00 41.63  ? ? ? ? ? ? 218 THR B O     1 
+ATOM   5684 C CB    . THR D 3 224 ? 90.260  44.794 65.535  1.00 40.84  ? ? ? ? ? ? 218 THR B CB    1 
+ATOM   5685 O OG1   . THR D 3 224 ? 89.817  45.784 66.467  1.00 39.44  ? ? ? ? ? ? 218 THR B OG1   1 
+ATOM   5686 C CG2   . THR D 3 224 ? 89.851  45.205 64.128  1.00 50.36  ? ? ? ? ? ? 218 THR B CG2   1 
+ATOM   5687 N N     . LYS D 3 225 ? 91.526  42.121 65.261  1.00 37.61  ? ? ? ? ? ? 219 LYS B N     1 
+ATOM   5688 C CA    . LYS D 3 225 ? 92.239  41.139 64.466  1.00 35.97  ? ? ? ? ? ? 219 LYS B CA    1 
+ATOM   5689 C C     . LYS D 3 225 ? 91.346  39.919 64.393  1.00 35.55  ? ? ? ? ? ? 219 LYS B C     1 
+ATOM   5690 O O     . LYS D 3 225 ? 90.982  39.443 63.314  1.00 36.25  ? ? ? ? ? ? 219 LYS B O     1 
+ATOM   5691 C CB    . LYS D 3 225 ? 93.559  40.750 65.138  1.00 40.46  ? ? ? ? ? ? 219 LYS B CB    1 
+ATOM   5692 C CG    . LYS D 3 225 ? 94.806  41.272 64.431  1.00 64.49  ? ? ? ? ? ? 219 LYS B CG    1 
+ATOM   5693 C CD    . LYS D 3 225 ? 95.129  42.699 64.867  1.00 80.10  ? ? ? ? ? ? 219 LYS B CD    1 
+ATOM   5694 C CE    . LYS D 3 225 ? 94.655  43.732 63.851  1.00 71.42  ? ? ? ? ? ? 219 LYS B CE    1 
+ATOM   5695 N NZ    . LYS D 3 225 ? 94.615  45.096 64.457  1.00 69.60  ? ? ? ? ? ? 219 LYS B NZ    1 
+ATOM   5696 N N     . LEU D 3 226 ? 91.010  39.423 65.579  1.00 31.25  ? ? ? ? ? ? 220 LEU B N     1 
+ATOM   5697 C CA    . LEU D 3 226 ? 90.194  38.226 65.762  1.00 28.16  ? ? ? ? ? ? 220 LEU B CA    1 
+ATOM   5698 C C     . LEU D 3 226 ? 88.945  38.283 64.906  1.00 34.53  ? ? ? ? ? ? 220 LEU B C     1 
+ATOM   5699 O O     . LEU D 3 226 ? 88.576  37.317 64.246  1.00 34.17  ? ? ? ? ? ? 220 LEU B O     1 
+ATOM   5700 C CB    . LEU D 3 226 ? 89.759  38.131 67.225  1.00 27.39  ? ? ? ? ? ? 220 LEU B CB    1 
+ATOM   5701 C CG    . LEU D 3 226 ? 90.731  37.574 68.257  1.00 33.25  ? ? ? ? ? ? 220 LEU B CG    1 
+ATOM   5702 C CD1   . LEU D 3 226 ? 90.063  37.556 69.621  1.00 31.81  ? ? ? ? ? ? 220 LEU B CD1   1 
+ATOM   5703 C CD2   . LEU D 3 226 ? 91.179  36.181 67.843  1.00 37.64  ? ? ? ? ? ? 220 LEU B CD2   1 
+ATOM   5704 N N     . VAL D 3 227 ? 88.265  39.419 64.975  1.00 34.96  ? ? ? ? ? ? 221 VAL B N     1 
+ATOM   5705 C CA    . VAL D 3 227 ? 87.026  39.629 64.244  1.00 37.16  ? ? ? ? ? ? 221 VAL B CA    1 
+ATOM   5706 C C     . VAL D 3 227 ? 87.355  39.586 62.759  1.00 41.15  ? ? ? ? ? ? 221 VAL B C     1 
+ATOM   5707 O O     . VAL D 3 227 ? 86.705  38.886 61.978  1.00 37.51  ? ? ? ? ? ? 221 VAL B O     1 
+ATOM   5708 C CB    . VAL D 3 227 ? 86.412  41.002 64.609  1.00 42.16  ? ? ? ? ? ? 221 VAL B CB    1 
+ATOM   5709 C CG1   . VAL D 3 227 ? 85.065  41.188 63.930  1.00 43.35  ? ? ? ? ? ? 221 VAL B CG1   1 
+ATOM   5710 C CG2   . VAL D 3 227 ? 86.280  41.151 66.113  1.00 40.53  ? ? ? ? ? ? 221 VAL B CG2   1 
+ATOM   5711 N N     . GLU D 3 228 ? 88.359  40.383 62.395  1.00 41.93  ? ? ? ? ? ? 222 GLU B N     1 
+ATOM   5712 C CA    . GLU D 3 228 ? 88.865  40.493 61.027  1.00 39.85  ? ? ? ? ? ? 222 GLU B CA    1 
+ATOM   5713 C C     . GLU D 3 228 ? 89.099  39.086 60.482  1.00 40.34  ? ? ? ? ? ? 222 GLU B C     1 
+ATOM   5714 O O     . GLU D 3 228 ? 88.652  38.749 59.384  1.00 40.75  ? ? ? ? ? ? 222 GLU B O     1 
+ATOM   5715 C CB    . GLU D 3 228 ? 90.171  41.311 60.995  1.00 40.43  ? ? ? ? ? ? 222 GLU B CB    1 
+ATOM   5716 C CG    . GLU D 3 228 ? 89.983  42.829 60.925  1.00 35.29  ? ? ? ? ? ? 222 GLU B CG    1 
+ATOM   5717 C CD    . GLU D 3 228 ? 91.277  43.644 61.077  1.00 51.43  ? ? ? ? ? ? 222 GLU B CD    1 
+ATOM   5718 O OE1   . GLU D 3 228 ? 92.359  43.086 61.384  1.00 55.52  ? ? ? ? ? ? 222 GLU B OE1   1 
+ATOM   5719 O OE2   . GLU D 3 228 ? 91.202  44.877 60.904  1.00 49.62  ? ? ? ? ? ? 222 GLU B OE2   1 
+ATOM   5720 N N     . ARG D 3 229 ? 89.745  38.239 61.270  1.00 35.28  ? ? ? ? ? ? 223 ARG B N     1 
+ATOM   5721 C CA    . ARG D 3 229 ? 89.948  36.904 60.752  1.00 34.84  ? ? ? ? ? ? 223 ARG B CA    1 
+ATOM   5722 C C     . ARG D 3 229 ? 88.648  36.169 60.445  1.00 45.38  ? ? ? ? ? ? 223 ARG B C     1 
+ATOM   5723 O O     . ARG D 3 229 ? 88.580  35.440 59.452  1.00 48.15  ? ? ? ? ? ? 223 ARG B O     1 
+ATOM   5724 C CB    . ARG D 3 229 ? 90.911  36.066 61.592  1.00 30.16  ? ? ? ? ? ? 223 ARG B CB    1 
+ATOM   5725 C CG    . ARG D 3 229 ? 91.078  34.641 61.063  1.00 29.05  ? ? ? ? ? ? 223 ARG B CG    1 
+ATOM   5726 C CD    . ARG D 3 229 ? 92.010  33.815 61.933  1.00 36.35  ? ? ? ? ? ? 223 ARG B CD    1 
+ATOM   5727 N NE    . ARG D 3 229 ? 92.843  32.925 61.133  1.00 54.77  ? ? ? ? ? ? 223 ARG B NE    1 
+ATOM   5728 C CZ    . ARG D 3 229 ? 93.105  31.660 61.443  1.00 64.66  ? ? ? ? ? ? 223 ARG B CZ    1 
+ATOM   5729 N NH1   . ARG D 3 229 ? 92.596  31.123 62.542  1.00 52.58  ? ? ? ? ? ? 223 ARG B NH1   1 
+ATOM   5730 N NH2   . ARG D 3 229 ? 93.883  30.933 60.657  1.00 71.51  ? ? ? ? ? ? 223 ARG B NH2   1 
+ATOM   5731 N N     . TRP D 3 230 ? 87.623  36.366 61.273  1.00 42.18  ? ? ? ? ? ? 224 TRP B N     1 
+ATOM   5732 C CA    . TRP D 3 230 ? 86.334  35.709 61.077  1.00 39.76  ? ? ? ? ? ? 224 TRP B CA    1 
+ATOM   5733 C C     . TRP D 3 230 ? 85.593  36.244 59.835  1.00 37.73  ? ? ? ? ? ? 224 TRP B C     1 
+ATOM   5734 O O     . TRP D 3 230 ? 85.057  35.485 59.031  1.00 33.56  ? ? ? ? ? ? 224 TRP B O     1 
+ATOM   5735 C CB    . TRP D 3 230 ? 85.461  35.861 62.336  1.00 37.36  ? ? ? ? ? ? 224 TRP B CB    1 
+ATOM   5736 C CG    . TRP D 3 230 ? 83.984  35.841 62.043  1.00 36.81  ? ? ? ? ? ? 224 TRP B CG    1 
+ATOM   5737 C CD1   . TRP D 3 230 ? 83.135  36.902 62.029  1.00 39.55  ? ? ? ? ? ? 224 TRP B CD1   1 
+ATOM   5738 C CD2   . TRP D 3 230 ? 83.219  34.710 61.631  1.00 35.16  ? ? ? ? ? ? 224 TRP B CD2   1 
+ATOM   5739 N NE1   . TRP D 3 230 ? 81.882  36.501 61.652  1.00 37.74  ? ? ? ? ? ? 224 TRP B NE1   1 
+ATOM   5740 C CE2   . TRP D 3 230 ? 81.907  35.156 61.403  1.00 37.49  ? ? ? ? ? ? 224 TRP B CE2   1 
+ATOM   5741 C CE3   . TRP D 3 230 ? 83.516  33.355 61.445  1.00 36.29  ? ? ? ? ? ? 224 TRP B CE3   1 
+ATOM   5742 C CZ2   . TRP D 3 230 ? 80.892  34.301 61.002  1.00 37.08  ? ? ? ? ? ? 224 TRP B CZ2   1 
+ATOM   5743 C CZ3   . TRP D 3 230 ? 82.505  32.504 61.062  1.00 36.93  ? ? ? ? ? ? 224 TRP B CZ3   1 
+ATOM   5744 C CH2   . TRP D 3 230 ? 81.204  32.979 60.821  1.00 37.12  ? ? ? ? ? ? 224 TRP B CH2   1 
+ATOM   5745 N N     . ILE D 3 231 ? 85.554  37.561 59.677  1.00 35.64  ? ? ? ? ? ? 225 ILE B N     1 
+ATOM   5746 C CA    . ILE D 3 231 ? 84.860  38.126 58.525  1.00 37.97  ? ? ? ? ? ? 225 ILE B CA    1 
+ATOM   5747 C C     . ILE D 3 231 ? 85.481  37.547 57.261  1.00 49.41  ? ? ? ? ? ? 225 ILE B C     1 
+ATOM   5748 O O     . ILE D 3 231 ? 84.772  37.149 56.342  1.00 50.75  ? ? ? ? ? ? 225 ILE B O     1 
+ATOM   5749 C CB    . ILE D 3 231 ? 84.942  39.676 58.494  1.00 39.69  ? ? ? ? ? ? 225 ILE B CB    1 
+ATOM   5750 C CG1   . ILE D 3 231 ? 84.276  40.274 59.741  1.00 39.80  ? ? ? ? ? ? 225 ILE B CG1   1 
+ATOM   5751 C CG2   . ILE D 3 231 ? 84.352  40.234 57.198  1.00 35.51  ? ? ? ? ? ? 225 ILE B CG2   1 
+ATOM   5752 C CD1   . ILE D 3 231 ? 84.620  41.728 59.999  1.00 38.09  ? ? ? ? ? ? 225 ILE B CD1   1 
+ATOM   5753 N N     . SER D 3 232 ? 86.808  37.482 57.243  1.00 47.33  ? ? ? ? ? ? 226 SER B N     1 
+ATOM   5754 C CA    . SER D 3 232 ? 87.561  36.957 56.114  1.00 46.15  ? ? ? ? ? ? 226 SER B CA    1 
+ATOM   5755 C C     . SER D 3 232 ? 87.259  35.496 55.697  1.00 47.28  ? ? ? ? ? ? 226 SER B C     1 
+ATOM   5756 O O     . SER D 3 232 ? 86.845  35.255 54.559  1.00 49.98  ? ? ? ? ? ? 226 SER B O     1 
+ATOM   5757 C CB    . SER D 3 232 ? 89.057  37.261 56.299  1.00 48.89  ? ? ? ? ? ? 226 SER B CB    1 
+ATOM   5758 O OG    . SER D 3 232 ? 89.881  36.219 55.807  1.00 64.55  ? ? ? ? ? ? 226 SER B OG    1 
+ATOM   5759 N N     . VAL D 3 233 ? 87.437  34.532 56.604  1.00 39.75  ? ? ? ? ? ? 227 VAL B N     1 
+ATOM   5760 C CA    . VAL D 3 233 ? 87.208  33.106 56.319  1.00 36.64  ? ? ? ? ? ? 227 VAL B CA    1 
+ATOM   5761 C C     . VAL D 3 233 ? 85.737  32.799 56.065  1.00 40.18  ? ? ? ? ? ? 227 VAL B C     1 
+ATOM   5762 O O     . VAL D 3 233 ? 85.384  31.767 55.495  1.00 37.89  ? ? ? ? ? ? 227 VAL B O     1 
+ATOM   5763 C CB    . VAL D 3 233 ? 87.719  32.225 57.495  1.00 37.74  ? ? ? ? ? ? 227 VAL B CB    1 
+ATOM   5764 C CG1   . VAL D 3 233 ? 86.802  32.369 58.697  1.00 38.17  ? ? ? ? ? ? 227 VAL B CG1   1 
+ATOM   5765 C CG2   . VAL D 3 233 ? 87.850  30.749 57.098  1.00 36.43  ? ? ? ? ? ? 227 VAL B CG2   1 
+ATOM   5766 N N     . SER D 3 234 ? 84.869  33.694 56.520  1.00 42.85  ? ? ? ? ? ? 228 SER B N     1 
+ATOM   5767 C CA    . SER D 3 234 ? 83.425  33.495 56.389  1.00 42.82  ? ? ? ? ? ? 228 SER B CA    1 
+ATOM   5768 C C     . SER D 3 234 ? 82.768  34.156 55.164  1.00 55.36  ? ? ? ? ? ? 228 SER B C     1 
+ATOM   5769 O O     . SER D 3 234 ? 81.740  33.692 54.664  1.00 55.20  ? ? ? ? ? ? 228 SER B O     1 
+ATOM   5770 C CB    . SER D 3 234 ? 82.734  34.002 57.657  1.00 35.44  ? ? ? ? ? ? 228 SER B CB    1 
+ATOM   5771 O OG    . SER D 3 234 ? 82.786  35.419 57.711  1.00 30.12  ? ? ? ? ? ? 228 SER B OG    1 
+ATOM   5772 N N     . GLY D 3 235 ? 83.316  35.281 54.716  1.00 55.24  ? ? ? ? ? ? 229 GLY B N     1 
+ATOM   5773 C CA    . GLY D 3 235 ? 82.724  35.993 53.591  1.00 55.90  ? ? ? ? ? ? 229 GLY B CA    1 
+ATOM   5774 C C     . GLY D 3 235 ? 81.370  36.559 53.999  1.00 62.80  ? ? ? ? ? ? 229 GLY B C     1 
+ATOM   5775 O O     . GLY D 3 235 ? 80.402  36.488 53.248  1.00 66.06  ? ? ? ? ? ? 229 GLY B O     1 
+ATOM   5776 N N     . VAL D 3 236 ? 81.287  37.109 55.202  1.00 57.80  ? ? ? ? ? ? 230 VAL B N     1 
+ATOM   5777 C CA    . VAL D 3 236 ? 80.021  37.669 55.625  1.00 56.92  ? ? ? ? ? ? 230 VAL B CA    1 
+ATOM   5778 C C     . VAL D 3 236 ? 79.999  39.078 55.091  1.00 58.22  ? ? ? ? ? ? 230 VAL B C     1 
+ATOM   5779 O O     . VAL D 3 236 ? 78.963  39.575 54.653  1.00 56.30  ? ? ? ? ? ? 230 VAL B O     1 
+ATOM   5780 C CB    . VAL D 3 236 ? 79.890  37.720 57.161  1.00 60.22  ? ? ? ? ? ? 230 VAL B CB    1 
+ATOM   5781 C CG1   . VAL D 3 236 ? 79.396  36.389 57.705  1.00 59.55  ? ? ? ? ? ? 230 VAL B CG1   1 
+ATOM   5782 C CG2   . VAL D 3 236 ? 81.204  38.135 57.813  1.00 59.56  ? ? ? ? ? ? 230 VAL B CG2   1 
+ATOM   5783 N N     . ALA D 3 237 ? 81.181  39.686 55.047  1.00 55.14  ? ? ? ? ? ? 231 ALA B N     1 
+ATOM   5784 C CA    . ALA D 3 237 ? 81.333  41.052 54.558  1.00 55.48  ? ? ? ? ? ? 231 ALA B CA    1 
+ATOM   5785 C C     . ALA D 3 237 ? 80.832  41.171 53.120  1.00 61.64  ? ? ? ? ? ? 231 ALA B C     1 
+ATOM   5786 O O     . ALA D 3 237 ? 80.847  42.250 52.540  1.00 62.63  ? ? ? ? ? ? 231 ALA B O     1 
+ATOM   5787 C CB    . ALA D 3 237 ? 82.783  41.496 54.682  1.00 56.21  ? ? ? ? ? ? 231 ALA B CB    1 
+ATOM   5788 N N     . ASP D 3 238 ? 80.377  40.060 52.550  1.00 58.51  ? ? ? ? ? ? 232 ASP B N     1 
+ATOM   5789 C CA    . ASP D 3 238 ? 79.860  39.992 51.196  1.00 59.56  ? ? ? ? ? ? 232 ASP B CA    1 
+ATOM   5790 C C     . ASP D 3 238 ? 78.750  40.977 50.945  1.00 72.15  ? ? ? ? ? ? 232 ASP B C     1 
+ATOM   5791 O O     . ASP D 3 238 ? 78.782  41.757 49.993  1.00 75.40  ? ? ? ? ? ? 232 ASP B O     1 
+ATOM   5792 C CB    . ASP D 3 238 ? 79.509  38.570 50.803  1.00 60.60  ? ? ? ? ? ? 232 ASP B CB    1 
+ATOM   5793 C CG    . ASP D 3 238 ? 80.638  37.953 50.062  1.00 72.78  ? ? ? ? ? ? 232 ASP B CG    1 
+ATOM   5794 O OD1   . ASP D 3 238 ? 81.660  38.657 49.955  1.00 72.82  ? ? ? ? ? ? 232 ASP B OD1   1 
+ATOM   5795 O OD2   . ASP D 3 238 ? 80.521  36.813 49.577  1.00 83.89  ? ? ? ? ? ? 232 ASP B OD2   1 
+ATOM   5796 N N     . ASP D 3 239 ? 77.819  40.974 51.892  1.00 70.34  ? ? ? ? ? ? 233 ASP B N     1 
+ATOM   5797 C CA    . ASP D 3 239 ? 76.665  41.881 51.985  1.00 69.49  ? ? ? ? ? ? 233 ASP B CA    1 
+ATOM   5798 C C     . ASP D 3 239 ? 76.769  42.691 53.319  1.00 69.29  ? ? ? ? ? ? 233 ASP B C     1 
+ATOM   5799 O O     . ASP D 3 239 ? 76.825  42.066 54.387  1.00 67.55  ? ? ? ? ? ? 233 ASP B O     1 
+ATOM   5800 C CB    . ASP D 3 239 ? 75.402  40.999 52.002  1.00 72.10  ? ? ? ? ? ? 233 ASP B CB    1 
+ATOM   5801 C CG    . ASP D 3 239 ? 74.123  41.757 51.646  1.00 91.51  ? ? ? ? ? ? 233 ASP B CG    1 
+ATOM   5802 O OD1   . ASP D 3 239 ? 74.201  42.948 51.326  1.00 94.52  ? ? ? ? ? ? 233 ASP B OD1   1 
+ATOM   5803 O OD2   . ASP D 3 239 ? 73.040  41.127 51.729  1.00 100.00 ? ? ? ? ? ? 233 ASP B OD2   1 
+ATOM   5804 N N     . PRO D 3 240 ? 76.761  44.046 53.279  1.00 64.66  ? ? ? ? ? ? 234 PRO B N     1 
+ATOM   5805 C CA    . PRO D 3 240 ? 76.886  44.881 54.500  1.00 63.25  ? ? ? ? ? ? 234 PRO B CA    1 
+ATOM   5806 C C     . PRO D 3 240 ? 75.773  44.685 55.494  1.00 63.39  ? ? ? ? ? ? 234 PRO B C     1 
+ATOM   5807 O O     . PRO D 3 240 ? 75.924  44.769 56.718  1.00 58.47  ? ? ? ? ? ? 234 PRO B O     1 
+ATOM   5808 C CB    . PRO D 3 240 ? 76.803  46.349 53.969  1.00 64.70  ? ? ? ? ? ? 234 PRO B CB    1 
+ATOM   5809 C CG    . PRO D 3 240 ? 77.046  46.237 52.527  1.00 69.56  ? ? ? ? ? ? 234 PRO B CG    1 
+ATOM   5810 C CD    . PRO D 3 240 ? 77.439  44.804 52.222  1.00 65.03  ? ? ? ? ? ? 234 PRO B CD    1 
+ATOM   5811 N N     . ASN D 3 241 ? 74.695  44.287 54.863  1.00 63.42  ? ? ? ? ? ? 235 ASN B N     1 
+ATOM   5812 C CA    . ASN D 3 241 ? 73.445  44.041 55.530  1.00 64.67  ? ? ? ? ? ? 235 ASN B CA    1 
+ATOM   5813 C C     . ASN D 3 241 ? 73.354  42.633 56.118  1.00 69.40  ? ? ? ? ? ? 235 ASN B C     1 
+ATOM   5814 O O     . ASN D 3 241 ? 72.362  42.232 56.726  1.00 69.48  ? ? ? ? ? ? 235 ASN B O     1 
+ATOM   5815 C CB    . ASN D 3 241 ? 72.253  44.500 54.674  1.00 66.47  ? ? ? ? ? ? 235 ASN B CB    1 
+ATOM   5816 C CG    . ASN D 3 241 ? 72.283  46.001 54.378  1.00 100.00 ? ? ? ? ? ? 235 ASN B CG    1 
+ATOM   5817 O OD1   . ASN D 3 241 ? 71.712  46.789 55.125  1.00 91.89  ? ? ? ? ? ? 235 ASN B OD1   1 
+ATOM   5818 N ND2   . ASN D 3 241 ? 72.934  46.391 53.289  1.00 100.00 ? ? ? ? ? ? 235 ASN B ND2   1 
+ATOM   5819 N N     . ASN D 3 242 ? 74.467  41.925 56.010  1.00 64.09  ? ? ? ? ? ? 236 ASN B N     1 
+ATOM   5820 C CA    . ASN D 3 242 ? 74.604  40.583 56.553  1.00 61.68  ? ? ? ? ? ? 236 ASN B CA    1 
+ATOM   5821 C C     . ASN D 3 242 ? 74.907  40.600 58.064  1.00 59.47  ? ? ? ? ? ? 236 ASN B C     1 
+ATOM   5822 O O     . ASN D 3 242 ? 75.610  41.488 58.563  1.00 53.99  ? ? ? ? ? ? 236 ASN B O     1 
+ATOM   5823 C CB    . ASN D 3 242 ? 75.770  39.893 55.851  1.00 59.95  ? ? ? ? ? ? 236 ASN B CB    1 
+ATOM   5824 C CG    . ASN D 3 242 ? 75.328  38.738 55.007  1.00 72.76  ? ? ? ? ? ? 236 ASN B CG    1 
+ATOM   5825 O OD1   . ASN D 3 242 ? 74.154  38.387 54.998  1.00 81.62  ? ? ? ? ? ? 236 ASN B OD1   1 
+ATOM   5826 N ND2   . ASN D 3 242 ? 76.268  38.132 54.303  1.00 65.02  ? ? ? ? ? ? 236 ASN B ND2   1 
+ATOM   5827 N N     . TYR D 3 243 ? 74.412  39.601 58.790  1.00 54.89  ? ? ? ? ? ? 237 TYR B N     1 
+ATOM   5828 C CA    . TYR D 3 243 ? 74.674  39.499 60.231  1.00 51.73  ? ? ? ? ? ? 237 TYR B CA    1 
+ATOM   5829 C C     . TYR D 3 243 ? 76.134  39.101 60.422  1.00 46.19  ? ? ? ? ? ? 237 TYR B C     1 
+ATOM   5830 O O     . TYR D 3 243 ? 76.609  38.193 59.739  1.00 41.97  ? ? ? ? ? ? 237 TYR B O     1 
+ATOM   5831 C CB    . TYR D 3 243 ? 73.765  38.449 60.892  1.00 52.61  ? ? ? ? ? ? 237 TYR B CB    1 
+ATOM   5832 C CG    . TYR D 3 243 ? 72.350  38.945 61.140  1.00 52.94  ? ? ? ? ? ? 237 TYR B CG    1 
+ATOM   5833 C CD1   . TYR D 3 243 ? 71.254  38.320 60.545  1.00 51.86  ? ? ? ? ? ? 237 TYR B CD1   1 
+ATOM   5834 C CD2   . TYR D 3 243 ? 72.120  40.086 61.900  1.00 54.08  ? ? ? ? ? ? 237 TYR B CD2   1 
+ATOM   5835 C CE1   . TYR D 3 243 ? 69.968  38.798 60.738  1.00 50.85  ? ? ? ? ? ? 237 TYR B CE1   1 
+ATOM   5836 C CE2   . TYR D 3 243 ? 70.838  40.568 62.097  1.00 52.89  ? ? ? ? ? ? 237 TYR B CE2   1 
+ATOM   5837 C CZ    . TYR D 3 243 ? 69.769  39.921 61.509  1.00 57.47  ? ? ? ? ? ? 237 TYR B CZ    1 
+ATOM   5838 O OH    . TYR D 3 243 ? 68.494  40.397 61.714  1.00 61.52  ? ? ? ? ? ? 237 TYR B OH    1 
+ATOM   5839 N N     . LEU D 3 244 ? 76.832  39.763 61.345  1.00 40.61  ? ? ? ? ? ? 238 LEU B N     1 
+ATOM   5840 C CA    . LEU D 3 244 ? 78.231  39.450 61.621  1.00 39.22  ? ? ? ? ? ? 238 LEU B CA    1 
+ATOM   5841 C C     . LEU D 3 244 ? 78.478  37.981 61.914  1.00 39.78  ? ? ? ? ? ? 238 LEU B C     1 
+ATOM   5842 O O     . LEU D 3 244 ? 79.484  37.431 61.474  1.00 37.37  ? ? ? ? ? ? 238 LEU B O     1 
+ATOM   5843 C CB    . LEU D 3 244 ? 78.758  40.254 62.804  1.00 39.49  ? ? ? ? ? ? 238 LEU B CB    1 
+ATOM   5844 C CG    . LEU D 3 244 ? 80.208  39.901 63.142  1.00 41.61  ? ? ? ? ? ? 238 LEU B CG    1 
+ATOM   5845 C CD1   . LEU D 3 244 ? 81.023  39.749 61.872  1.00 40.60  ? ? ? ? ? ? 238 LEU B CD1   1 
+ATOM   5846 C CD2   . LEU D 3 244 ? 80.781  40.984 64.029  1.00 39.80  ? ? ? ? ? ? 238 LEU B CD2   1 
+ATOM   5847 N N     . PHE D 3 245 ? 77.554  37.347 62.637  1.00 35.66  ? ? ? ? ? ? 239 PHE B N     1 
+ATOM   5848 C CA    . PHE D 3 245 ? 77.688  35.938 63.011  1.00 35.94  ? ? ? ? ? ? 239 PHE B CA    1 
+ATOM   5849 C C     . PHE D 3 245 ? 76.612  35.056 62.408  1.00 40.85  ? ? ? ? ? ? 239 PHE B C     1 
+ATOM   5850 O O     . PHE D 3 245 ? 75.448  35.432 62.435  1.00 44.54  ? ? ? ? ? ? 239 PHE B O     1 
+ATOM   5851 C CB    . PHE D 3 245 ? 77.640  35.807 64.535  1.00 38.49  ? ? ? ? ? ? 239 PHE B CB    1 
+ATOM   5852 C CG    . PHE D 3 245 ? 78.920  36.214 65.213  1.00 39.92  ? ? ? ? ? ? 239 PHE B CG    1 
+ATOM   5853 C CD1   . PHE D 3 245 ? 79.053  37.473 65.793  1.00 38.04  ? ? ? ? ? ? 239 PHE B CD1   1 
+ATOM   5854 C CD2   . PHE D 3 245 ? 80.001  35.346 65.230  1.00 42.96  ? ? ? ? ? ? 239 PHE B CD2   1 
+ATOM   5855 C CE1   . PHE D 3 245 ? 80.232  37.854 66.395  1.00 39.43  ? ? ? ? ? ? 239 PHE B CE1   1 
+ATOM   5856 C CE2   . PHE D 3 245 ? 81.190  35.729 65.813  1.00 42.77  ? ? ? ? ? ? 239 PHE B CE2   1 
+ATOM   5857 C CZ    . PHE D 3 245 ? 81.303  36.983 66.396  1.00 39.04  ? ? ? ? ? ? 239 PHE B CZ    1 
+ATOM   5858 N N     . CYS D 3 246 ? 76.989  33.877 61.912  1.00 35.86  ? ? ? ? ? ? 240 CYS B N     1 
+ATOM   5859 C CA    . CYS D 3 246 ? 76.044  32.967 61.262  1.00 36.19  ? ? ? ? ? ? 240 CYS B CA    1 
+ATOM   5860 C C     . CYS D 3 246 ? 76.436  31.547 61.522  1.00 38.40  ? ? ? ? ? ? 240 CYS B C     1 
+ATOM   5861 O O     . CYS D 3 246 ? 77.503  31.307 62.081  1.00 41.59  ? ? ? ? ? ? 240 CYS B O     1 
+ATOM   5862 C CB    . CYS D 3 246 ? 76.132  33.153 59.747  1.00 38.97  ? ? ? ? ? ? 240 CYS B CB    1 
+ATOM   5863 S SG    . CYS D 3 246 ? 77.826  32.978 59.073  1.00 43.95  ? ? ? ? ? ? 240 CYS B SG    1 
+ATOM   5864 N N     . ARG D 3 247 ? 75.602  30.602 61.085  1.00 35.92  ? ? ? ? ? ? 241 ARG B N     1 
+ATOM   5865 C CA    . ARG D 3 247 ? 75.932  29.185 61.253  1.00 37.94  ? ? ? ? ? ? 241 ARG B CA    1 
+ATOM   5866 C C     . ARG D 3 247 ? 77.204  28.811 60.485  1.00 39.39  ? ? ? ? ? ? 241 ARG B C     1 
+ATOM   5867 O O     . ARG D 3 247 ? 77.626  29.498 59.553  1.00 37.28  ? ? ? ? ? ? 241 ARG B O     1 
+ATOM   5868 C CB    . ARG D 3 247 ? 74.822  28.225 60.796  1.00 41.82  ? ? ? ? ? ? 241 ARG B CB    1 
+ATOM   5869 C CG    . ARG D 3 247 ? 73.396  28.603 61.107  1.00 52.83  ? ? ? ? ? ? 241 ARG B CG    1 
+ATOM   5870 C CD    . ARG D 3 247 ? 72.474  27.865 60.156  1.00 50.24  ? ? ? ? ? ? 241 ARG B CD    1 
+ATOM   5871 N NE    . ARG D 3 247 ? 72.504  26.417 60.318  1.00 31.00  ? ? ? ? ? ? 241 ARG B NE    1 
+ATOM   5872 C CZ    . ARG D 3 247 ? 71.411  25.665 60.357  1.00 52.50  ? ? ? ? ? ? 241 ARG B CZ    1 
+ATOM   5873 N NH1   . ARG D 3 247 ? 70.216  26.234 60.211  1.00 39.37  ? ? ? ? ? ? 241 ARG B NH1   1 
+ATOM   5874 N NH2   . ARG D 3 247 ? 71.530  24.352 60.522  1.00 41.81  ? ? ? ? ? ? 241 ARG B NH2   1 
+ATOM   5875 N N     . VAL D 3 248 ? 77.784  27.681 60.863  1.00 34.61  ? ? ? ? ? ? 242 VAL B N     1 
+ATOM   5876 C CA    . VAL D 3 248 ? 78.975  27.192 60.198  1.00 34.07  ? ? ? ? ? ? 242 VAL B CA    1 
+ATOM   5877 C C     . VAL D 3 248 ? 78.790  25.700 60.257  1.00 40.49  ? ? ? ? ? ? 242 VAL B C     1 
+ATOM   5878 O O     . VAL D 3 248 ? 78.780  25.088 61.321  1.00 41.36  ? ? ? ? ? ? 242 VAL B O     1 
+ATOM   5879 C CB    . VAL D 3 248 ? 80.258  27.618 60.899  1.00 38.52  ? ? ? ? ? ? 242 VAL B CB    1 
+ATOM   5880 C CG1   . VAL D 3 248 ? 81.439  26.946 60.239  1.00 39.67  ? ? ? ? ? ? 242 VAL B CG1   1 
+ATOM   5881 C CG2   . VAL D 3 248 ? 80.415  29.129 60.826  1.00 37.63  ? ? ? ? ? ? 242 VAL B CG2   1 
+ATOM   5882 N N     . ARG D 3 249 ? 78.524  25.128 59.094  1.00 38.09  ? ? ? ? ? ? 243 ARG B N     1 
+ATOM   5883 C CA    . ARG D 3 249 ? 78.232  23.720 59.023  1.00 36.37  ? ? ? ? ? ? 243 ARG B CA    1 
+ATOM   5884 C C     . ARG D 3 249 ? 79.388  22.759 59.201  1.00 38.41  ? ? ? ? ? ? 243 ARG B C     1 
+ATOM   5885 O O     . ARG D 3 249 ? 80.549  23.157 59.161  1.00 39.12  ? ? ? ? ? ? 243 ARG B O     1 
+ATOM   5886 C CB    . ARG D 3 249 ? 77.402  23.421 57.788  1.00 38.01  ? ? ? ? ? ? 243 ARG B CB    1 
+ATOM   5887 C CG    . ARG D 3 249 ? 76.154  24.282 57.685  1.00 42.27  ? ? ? ? ? ? 243 ARG B CG    1 
+ATOM   5888 C CD    . ARG D 3 249 ? 75.259  23.710 56.613  1.00 45.41  ? ? ? ? ? ? 243 ARG B CD    1 
+ATOM   5889 N NE    . ARG D 3 249 ? 73.833  23.775 56.927  1.00 36.68  ? ? ? ? ? ? 243 ARG B NE    1 
+ATOM   5890 C CZ    . ARG D 3 249 ? 73.109  22.745 57.358  1.00 63.86  ? ? ? ? ? ? 243 ARG B CZ    1 
+ATOM   5891 N NH1   . ARG D 3 249 ? 73.679  21.565 57.574  1.00 58.43  ? ? ? ? ? ? 243 ARG B NH1   1 
+ATOM   5892 N NH2   . ARG D 3 249 ? 71.806  22.895 57.593  1.00 44.18  ? ? ? ? ? ? 243 ARG B NH2   1 
+ATOM   5893 N N     . LYS D 3 250 ? 79.061  21.494 59.470  1.00 35.66  ? ? ? ? ? ? 244 LYS B N     1 
+ATOM   5894 C CA    . LYS D 3 250 ? 80.082  20.482 59.712  1.00 37.84  ? ? ? ? ? ? 244 LYS B CA    1 
+ATOM   5895 C C     . LYS D 3 250 ? 81.226  20.538 58.708  1.00 49.67  ? ? ? ? ? ? 244 LYS B C     1 
+ATOM   5896 O O     . LYS D 3 250 ? 82.389  20.348 59.060  1.00 50.80  ? ? ? ? ? ? 244 LYS B O     1 
+ATOM   5897 C CB    . LYS D 3 250 ? 79.481  19.076 59.758  1.00 36.54  ? ? ? ? ? ? 244 LYS B CB    1 
+ATOM   5898 C CG    . LYS D 3 250 ? 79.041  18.582 58.395  1.00 37.79  ? ? ? ? ? ? 244 LYS B CG    1 
+ATOM   5899 C CD    . LYS D 3 250 ? 77.723  17.824 58.441  1.00 52.38  ? ? ? ? ? ? 244 LYS B CD    1 
+ATOM   5900 C CE    . LYS D 3 250 ? 77.914  16.388 58.884  1.00 69.37  ? ? ? ? ? ? 244 LYS B CE    1 
+ATOM   5901 N NZ    . LYS D 3 250 ? 77.271  15.435 57.961  1.00 70.39  ? ? ? ? ? ? 244 LYS B NZ    1 
+ATOM   5902 N N     . ASN D 3 251 ? 80.896  20.820 57.455  1.00 48.17  ? ? ? ? ? ? 245 ASN B N     1 
+ATOM   5903 C CA    . ASN D 3 251 ? 81.906  20.896 56.408  1.00 48.22  ? ? ? ? ? ? 245 ASN B CA    1 
+ATOM   5904 C C     . ASN D 3 251 ? 82.846  22.108 56.507  1.00 49.62  ? ? ? ? ? ? 245 ASN B C     1 
+ATOM   5905 O O     . ASN D 3 251 ? 83.781  22.264 55.719  1.00 48.56  ? ? ? ? ? ? 245 ASN B O     1 
+ATOM   5906 C CB    . ASN D 3 251 ? 81.273  20.667 55.021  1.00 53.22  ? ? ? ? ? ? 245 ASN B CB    1 
+ATOM   5907 C CG    . ASN D 3 251 ? 80.953  21.958 54.254  1.00 66.80  ? ? ? ? ? ? 245 ASN B CG    1 
+ATOM   5908 O OD1   . ASN D 3 251 ? 80.769  23.031 54.831  1.00 52.40  ? ? ? ? ? ? 245 ASN B OD1   1 
+ATOM   5909 N ND2   . ASN D 3 251 ? 80.858  21.834 52.931  1.00 56.48  ? ? ? ? ? ? 245 ASN B ND2   1 
+ATOM   5910 N N     . GLY D 3 252 ? 82.612  22.948 57.510  1.00 42.04  ? ? ? ? ? ? 246 GLY B N     1 
+ATOM   5911 C CA    . GLY D 3 252 ? 83.452  24.118 57.733  1.00 40.52  ? ? ? ? ? ? 246 GLY B CA    1 
+ATOM   5912 C C     . GLY D 3 252 ? 83.014  25.334 56.932  1.00 46.02  ? ? ? ? ? ? 246 GLY B C     1 
+ATOM   5913 O O     . GLY D 3 252 ? 83.604  26.409 57.039  1.00 46.58  ? ? ? ? ? ? 246 GLY B O     1 
+ATOM   5914 N N     . VAL D 3 253 ? 81.976  25.155 56.123  1.00 41.69  ? ? ? ? ? ? 247 VAL B N     1 
+ATOM   5915 C CA    . VAL D 3 253 ? 81.454  26.245 55.308  1.00 40.83  ? ? ? ? ? ? 247 VAL B CA    1 
+ATOM   5916 C C     . VAL D 3 253 ? 80.478  27.118 56.092  1.00 45.45  ? ? ? ? ? ? 247 VAL B C     1 
+ATOM   5917 O O     . VAL D 3 253 ? 79.457  26.638 56.596  1.00 47.12  ? ? ? ? ? ? 247 VAL B O     1 
+ATOM   5918 C CB    . VAL D 3 253 ? 80.767  25.709 54.031  1.00 44.25  ? ? ? ? ? ? 247 VAL B CB    1 
+ATOM   5919 C CG1   . VAL D 3 253 ? 80.033  26.812 53.278  1.00 42.91  ? ? ? ? ? ? 247 VAL B CG1   1 
+ATOM   5920 C CG2   . VAL D 3 253 ? 81.786  25.015 53.145  1.00 44.02  ? ? ? ? ? ? 247 VAL B CG2   1 
+ATOM   5921 N N     . ALA D 3 254 ? 80.795  28.404 56.197  1.00 40.58  ? ? ? ? ? ? 248 ALA B N     1 
+ATOM   5922 C CA    . ALA D 3 254 ? 79.915  29.340 56.890  1.00 42.23  ? ? ? ? ? ? 248 ALA B CA    1 
+ATOM   5923 C C     . ALA D 3 254 ? 78.614  29.429 56.079  1.00 49.37  ? ? ? ? ? ? 248 ALA B C     1 
+ATOM   5924 O O     . ALA D 3 254 ? 78.495  28.789 55.035  1.00 52.59  ? ? ? ? ? ? 248 ALA B O     1 
+ATOM   5925 C CB    . ALA D 3 254 ? 80.584  30.701 57.015  1.00 42.98  ? ? ? ? ? ? 248 ALA B CB    1 
+ATOM   5926 N N     . ALA D 3 255 ? 77.629  30.179 56.560  1.00 41.10  ? ? ? ? ? ? 249 ALA B N     1 
+ATOM   5927 C CA    . ALA D 3 255 ? 76.356  30.279 55.856  1.00 36.88  ? ? ? ? ? ? 249 ALA B CA    1 
+ATOM   5928 C C     . ALA D 3 255 ? 75.757  31.632 56.151  1.00 40.04  ? ? ? ? ? ? 249 ALA B C     1 
+ATOM   5929 O O     . ALA D 3 255 ? 74.761  31.758 56.856  1.00 44.42  ? ? ? ? ? ? 249 ALA B O     1 
+ATOM   5930 C CB    . ALA D 3 255 ? 75.412  29.171 56.300  1.00 35.56  ? ? ? ? ? ? 249 ALA B CB    1 
+ATOM   5931 N N     . PRO D 3 256 ? 76.372  32.677 55.606  1.00 36.07  ? ? ? ? ? ? 250 PRO B N     1 
+ATOM   5932 C CA    . PRO D 3 256 ? 75.932  34.044 55.849  1.00 37.19  ? ? ? ? ? ? 250 PRO B CA    1 
+ATOM   5933 C C     . PRO D 3 256 ? 74.466  34.273 55.566  1.00 47.07  ? ? ? ? ? ? 250 PRO B C     1 
+ATOM   5934 O O     . PRO D 3 256 ? 73.851  33.544 54.797  1.00 48.95  ? ? ? ? ? ? 250 PRO B O     1 
+ATOM   5935 C CB    . PRO D 3 256 ? 76.827  34.877 54.929  1.00 37.39  ? ? ? ? ? ? 250 PRO B CB    1 
+ATOM   5936 C CG    . PRO D 3 256 ? 78.095  34.103 54.883  1.00 41.65  ? ? ? ? ? ? 250 PRO B CG    1 
+ATOM   5937 C CD    . PRO D 3 256 ? 77.700  32.634 54.976  1.00 37.54  ? ? ? ? ? ? 250 PRO B CD    1 
+ATOM   5938 N N     . SER D 3 257 ? 73.912  35.289 56.215  1.00 45.58  ? ? ? ? ? ? 251 SER B N     1 
+ATOM   5939 C CA    . SER D 3 257 ? 72.509  35.604 56.045  1.00 45.80  ? ? ? ? ? ? 251 SER B CA    1 
+ATOM   5940 C C     . SER D 3 257 ? 72.213  37.013 56.496  1.00 49.17  ? ? ? ? ? ? 251 SER B C     1 
+ATOM   5941 O O     . SER D 3 257 ? 72.804  37.489 57.463  1.00 47.99  ? ? ? ? ? ? 251 SER B O     1 
+ATOM   5942 C CB    . SER D 3 257 ? 71.681  34.722 56.948  1.00 50.83  ? ? ? ? ? ? 251 SER B CB    1 
+ATOM   5943 O OG    . SER D 3 257 ? 70.352  35.225 56.961  1.00 57.38  ? ? ? ? ? ? 251 SER B OG    1 
+ATOM   5944 N N     . ALA D 3 258 ? 71.267  37.676 55.841  1.00 49.20  ? ? ? ? ? ? 252 ALA B N     1 
+ATOM   5945 C CA    . ALA D 3 258 ? 70.888  39.016 56.282  1.00 50.47  ? ? ? ? ? ? 252 ALA B CA    1 
+ATOM   5946 C C     . ALA D 3 258 ? 69.456  38.948 56.818  1.00 50.77  ? ? ? ? ? ? 252 ALA B C     1 
+ATOM   5947 O O     . ALA D 3 258 ? 68.872  39.954 57.210  1.00 50.21  ? ? ? ? ? ? 252 ALA B O     1 
+ATOM   5948 C CB    . ALA D 3 258 ? 71.013  40.043 55.162  1.00 50.96  ? ? ? ? ? ? 252 ALA B CB    1 
+ATOM   5949 N N     . THR D 3 259 ? 68.915  37.736 56.871  1.00 44.51  ? ? ? ? ? ? 253 THR B N     1 
+ATOM   5950 C CA    . THR D 3 259 ? 67.566  37.531 57.382  1.00 45.44  ? ? ? ? ? ? 253 THR B CA    1 
+ATOM   5951 C C     . THR D 3 259 ? 67.504  36.660 58.641  1.00 50.27  ? ? ? ? ? ? 253 THR B C     1 
+ATOM   5952 O O     . THR D 3 259 ? 66.652  36.873 59.497  1.00 50.56  ? ? ? ? ? ? 253 THR B O     1 
+ATOM   5953 C CB    . THR D 3 259 ? 66.609  37.031 56.291  1.00 51.04  ? ? ? ? ? ? 253 THR B CB    1 
+ATOM   5954 O OG1   . THR D 3 259 ? 66.657  35.598 56.219  1.00 55.83  ? ? ? ? ? ? 253 THR B OG1   1 
+ATOM   5955 C CG2   . THR D 3 259 ? 66.990  37.626 54.949  1.00 44.45  ? ? ? ? ? ? 253 THR B CG2   1 
+ATOM   5956 N N     . SER D 3 260 ? 68.403  35.687 58.759  1.00 44.27  ? ? ? ? ? ? 254 SER B N     1 
+ATOM   5957 C CA    . SER D 3 260 ? 68.454  34.852 59.956  1.00 41.62  ? ? ? ? ? ? 254 SER B CA    1 
+ATOM   5958 C C     . SER D 3 260 ? 69.724  35.099 60.783  1.00 46.18  ? ? ? ? ? ? 254 SER B C     1 
+ATOM   5959 O O     . SER D 3 260 ? 70.838  35.138 60.254  1.00 48.06  ? ? ? ? ? ? 254 SER B O     1 
+ATOM   5960 C CB    . SER D 3 260 ? 68.347  33.374 59.616  1.00 42.55  ? ? ? ? ? ? 254 SER B CB    1 
+ATOM   5961 O OG    . SER D 3 260 ? 68.950  32.631 60.673  1.00 58.19  ? ? ? ? ? ? 254 SER B OG    1 
+ATOM   5962 N N     . GLN D 3 261 ? 69.535  35.272 62.087  1.00 39.77  ? ? ? ? ? ? 255 GLN B N     1 
+ATOM   5963 C CA    . GLN D 3 261 ? 70.632  35.515 63.004  1.00 39.00  ? ? ? ? ? ? 255 GLN B CA    1 
+ATOM   5964 C C     . GLN D 3 261 ? 71.114  34.167 63.502  1.00 43.06  ? ? ? ? ? ? 255 GLN B C     1 
+ATOM   5965 O O     . GLN D 3 261 ? 70.413  33.159 63.381  1.00 43.83  ? ? ? ? ? ? 255 GLN B O     1 
+ATOM   5966 C CB    . GLN D 3 261 ? 70.127  36.301 64.220  1.00 40.41  ? ? ? ? ? ? 255 GLN B CB    1 
+ATOM   5967 C CG    . GLN D 3 261 ? 69.748  37.754 63.956  1.00 37.60  ? ? ? ? ? ? 255 GLN B CG    1 
+ATOM   5968 C CD    . GLN D 3 261 ? 69.101  38.391 65.170  1.00 44.71  ? ? ? ? ? ? 255 GLN B CD    1 
+ATOM   5969 O OE1   . GLN D 3 261 ? 68.918  37.738 66.214  1.00 31.92  ? ? ? ? ? ? 255 GLN B OE1   1 
+ATOM   5970 N NE2   . GLN D 3 261 ? 68.756  39.672 65.064  1.00 37.10  ? ? ? ? ? ? 255 GLN B NE2   1 
+ATOM   5971 N N     . LEU D 3 262 ? 72.305  34.145 64.084  1.00 37.29  ? ? ? ? ? ? 256 LEU B N     1 
+ATOM   5972 C CA    . LEU D 3 262 ? 72.767  32.901 64.680  1.00 34.92  ? ? ? ? ? ? 256 LEU B CA    1 
+ATOM   5973 C C     . LEU D 3 262 ? 72.011  32.972 66.016  1.00 35.94  ? ? ? ? ? ? 256 LEU B C     1 
+ATOM   5974 O O     . LEU D 3 262 ? 72.039  34.004 66.688  1.00 38.31  ? ? ? ? ? ? 256 LEU B O     1 
+ATOM   5975 C CB    . LEU D 3 262 ? 74.294  32.910 64.855  1.00 33.32  ? ? ? ? ? ? 256 LEU B CB    1 
+ATOM   5976 C CG    . LEU D 3 262 ? 75.004  31.814 65.660  1.00 32.51  ? ? ? ? ? ? 256 LEU B CG    1 
+ATOM   5977 C CD1   . LEU D 3 262 ? 74.857  30.452 65.022  1.00 29.03  ? ? ? ? ? ? 256 LEU B CD1   1 
+ATOM   5978 C CD2   . LEU D 3 262 ? 76.465  32.138 65.904  1.00 28.25  ? ? ? ? ? ? 256 LEU B CD2   1 
+ATOM   5979 N N     . SER D 3 263 ? 71.254  31.935 66.351  1.00 27.34  ? ? ? ? ? ? 257 SER B N     1 
+ATOM   5980 C CA    . SER D 3 263 ? 70.467  31.981 67.576  1.00 25.18  ? ? ? ? ? ? 257 SER B CA    1 
+ATOM   5981 C C     . SER D 3 263 ? 71.302  32.242 68.812  1.00 36.14  ? ? ? ? ? ? 257 SER B C     1 
+ATOM   5982 O O     . SER D 3 263 ? 72.460  31.838 68.887  1.00 35.75  ? ? ? ? ? ? 257 SER B O     1 
+ATOM   5983 C CB    . SER D 3 263 ? 69.658  30.703 67.758  1.00 23.25  ? ? ? ? ? ? 257 SER B CB    1 
+ATOM   5984 O OG    . SER D 3 263 ? 70.501  29.627 68.098  1.00 38.68  ? ? ? ? ? ? 257 SER B OG    1 
+ATOM   5985 N N     . THR D 3 264 ? 70.677  32.899 69.790  1.00 36.15  ? ? ? ? ? ? 258 THR B N     1 
+ATOM   5986 C CA    . THR D 3 264 ? 71.314  33.227 71.055  1.00 32.88  ? ? ? ? ? ? 258 THR B CA    1 
+ATOM   5987 C C     . THR D 3 264 ? 71.500  31.903 71.759  1.00 26.83  ? ? ? ? ? ? 258 THR B C     1 
+ATOM   5988 O O     . THR D 3 264 ? 72.350  31.757 72.635  1.00 29.08  ? ? ? ? ? ? 258 THR B O     1 
+ATOM   5989 C CB    . THR D 3 264 ? 70.387  34.056 71.922  1.00 33.15  ? ? ? ? ? ? 258 THR B CB    1 
+ATOM   5990 O OG1   . THR D 3 264 ? 69.112  33.408 71.959  1.00 35.11  ? ? ? ? ? ? 258 THR B OG1   1 
+ATOM   5991 C CG2   . THR D 3 264 ? 70.266  35.469 71.365  1.00 25.25  ? ? ? ? ? ? 258 THR B CG2   1 
+ATOM   5992 N N     . ARG D 3 265 ? 70.686  30.929 71.375  1.00 20.97  ? ? ? ? ? ? 259 ARG B N     1 
+ATOM   5993 C CA    . ARG D 3 265 ? 70.804  29.593 71.947  1.00 23.92  ? ? ? ? ? ? 259 ARG B CA    1 
+ATOM   5994 C C     . ARG D 3 265 ? 72.140  28.944 71.548  1.00 37.43  ? ? ? ? ? ? 259 ARG B C     1 
+ATOM   5995 O O     . ARG D 3 265 ? 72.737  28.198 72.322  1.00 40.62  ? ? ? ? ? ? 259 ARG B O     1 
+ATOM   5996 C CB    . ARG D 3 265 ? 69.653  28.702 71.484  1.00 21.41  ? ? ? ? ? ? 259 ARG B CB    1 
+ATOM   5997 C CG    . ARG D 3 265 ? 69.728  27.276 72.021  1.00 32.03  ? ? ? ? ? ? 259 ARG B CG    1 
+ATOM   5998 C CD    . ARG D 3 265 ? 69.303  27.290 73.473  1.00 36.00  ? ? ? ? ? ? 259 ARG B CD    1 
+ATOM   5999 N NE    . ARG D 3 265 ? 69.613  26.074 74.215  1.00 34.17  ? ? ? ? ? ? 259 ARG B NE    1 
+ATOM   6000 C CZ    . ARG D 3 265 ? 70.810  25.788 74.712  1.00 36.77  ? ? ? ? ? ? 259 ARG B CZ    1 
+ATOM   6001 N NH1   . ARG D 3 265 ? 71.843  26.588 74.492  1.00 27.80  ? ? ? ? ? ? 259 ARG B NH1   1 
+ATOM   6002 N NH2   . ARG D 3 265 ? 70.979  24.684 75.417  1.00 23.66  ? ? ? ? ? ? 259 ARG B NH2   1 
+ATOM   6003 N N     . ALA D 3 266 ? 72.577  29.205 70.318  1.00 34.92  ? ? ? ? ? ? 260 ALA B N     1 
+ATOM   6004 C CA    . ALA D 3 266 ? 73.830  28.684 69.789  1.00 33.77  ? ? ? ? ? ? 260 ALA B CA    1 
+ATOM   6005 C C     . ALA D 3 266 ? 74.958  29.471 70.450  1.00 33.00  ? ? ? ? ? ? 260 ALA B C     1 
+ATOM   6006 O O     . ALA D 3 266 ? 75.939  28.887 70.912  1.00 32.05  ? ? ? ? ? ? 260 ALA B O     1 
+ATOM   6007 C CB    . ALA D 3 266 ? 73.863  28.858 68.271  1.00 34.86  ? ? ? ? ? ? 260 ALA B CB    1 
+ATOM   6008 N N     . LEU D 3 267 ? 74.803  30.792 70.533  1.00 27.59  ? ? ? ? ? ? 261 LEU B N     1 
+ATOM   6009 C CA    . LEU D 3 267 ? 75.817  31.614 71.186  1.00 28.33  ? ? ? ? ? ? 261 LEU B CA    1 
+ATOM   6010 C C     . LEU D 3 267 ? 76.025  31.076 72.586  1.00 36.11  ? ? ? ? ? ? 261 LEU B C     1 
+ATOM   6011 O O     . LEU D 3 267 ? 77.135  31.068 73.112  1.00 36.72  ? ? ? ? ? ? 261 LEU B O     1 
+ATOM   6012 C CB    . LEU D 3 267 ? 75.385  33.076 71.302  1.00 27.60  ? ? ? ? ? ? 261 LEU B CB    1 
+ATOM   6013 C CG    . LEU D 3 267 ? 75.336  33.802 69.967  1.00 30.40  ? ? ? ? ? ? 261 LEU B CG    1 
+ATOM   6014 C CD1   . LEU D 3 267 ? 74.899  35.239 70.152  1.00 28.49  ? ? ? ? ? ? 261 LEU B CD1   1 
+ATOM   6015 C CD2   . LEU D 3 267 ? 76.654  33.693 69.206  1.00 31.58  ? ? ? ? ? ? 261 LEU B CD2   1 
+ATOM   6016 N N     . GLU D 3 268 ? 74.932  30.671 73.215  1.00 32.04  ? ? ? ? ? ? 262 GLU B N     1 
+ATOM   6017 C CA    . GLU D 3 268 ? 75.044  30.138 74.552  1.00 31.50  ? ? ? ? ? ? 262 GLU B CA    1 
+ATOM   6018 C C     . GLU D 3 268 ? 75.870  28.856 74.473  1.00 36.64  ? ? ? ? ? ? 262 GLU B C     1 
+ATOM   6019 O O     . GLU D 3 268 ? 76.664  28.574 75.375  1.00 34.02  ? ? ? ? ? ? 262 GLU B O     1 
+ATOM   6020 C CB    . GLU D 3 268 ? 73.667  29.822 75.112  1.00 33.49  ? ? ? ? ? ? 262 GLU B CB    1 
+ATOM   6021 C CG    . GLU D 3 268 ? 72.888  31.023 75.589  1.00 45.21  ? ? ? ? ? ? 262 GLU B CG    1 
+ATOM   6022 C CD    . GLU D 3 268 ? 71.550  30.594 76.136  1.00 46.36  ? ? ? ? ? ? 262 GLU B CD    1 
+ATOM   6023 O OE1   . GLU D 3 268 ? 70.958  29.674 75.542  1.00 35.71  ? ? ? ? ? ? 262 GLU B OE1   1 
+ATOM   6024 O OE2   . GLU D 3 268 ? 71.097  31.142 77.164  1.00 37.68  ? ? ? ? ? ? 262 GLU B OE2   1 
+ATOM   6025 N N     . GLY D 3 269 ? 75.675  28.079 73.405  1.00 34.26  ? ? ? ? ? ? 263 GLY B N     1 
+ATOM   6026 C CA    . GLY D 3 269 ? 76.410  26.826 73.177  1.00 32.80  ? ? ? ? ? ? 263 GLY B CA    1 
+ATOM   6027 C C     . GLY D 3 269 ? 77.920  27.054 72.998  1.00 32.61  ? ? ? ? ? ? 263 GLY B C     1 
+ATOM   6028 O O     . GLY D 3 269 ? 78.730  26.261 73.465  1.00 32.46  ? ? ? ? ? ? 263 GLY B O     1 
+ATOM   6029 N N     . ILE D 3 270 ? 78.310  28.145 72.337  1.00 27.95  ? ? ? ? ? ? 264 ILE B N     1 
+ATOM   6030 C CA    . ILE D 3 270 ? 79.728  28.448 72.179  1.00 27.96  ? ? ? ? ? ? 264 ILE B CA    1 
+ATOM   6031 C C     . ILE D 3 270 ? 80.344  28.493 73.572  1.00 32.57  ? ? ? ? ? ? 264 ILE B C     1 
+ATOM   6032 O O     . ILE D 3 270 ? 81.282  27.758 73.838  1.00 34.56  ? ? ? ? ? ? 264 ILE B O     1 
+ATOM   6033 C CB    . ILE D 3 270 ? 79.999  29.783 71.429  1.00 31.61  ? ? ? ? ? ? 264 ILE B CB    1 
+ATOM   6034 C CG1   . ILE D 3 270 ? 79.511  29.701 69.972  1.00 30.13  ? ? ? ? ? ? 264 ILE B CG1   1 
+ATOM   6035 C CG2   . ILE D 3 270 ? 81.491  30.120 71.460  1.00 28.51  ? ? ? ? ? ? 264 ILE B CG2   1 
+ATOM   6036 C CD1   . ILE D 3 270 ? 79.561  31.019 69.216  1.00 25.79  ? ? ? ? ? ? 264 ILE B CD1   1 
+ATOM   6037 N N     . PHE D 3 271 ? 79.794  29.321 74.466  1.00 31.79  ? ? ? ? ? ? 265 PHE B N     1 
+ATOM   6038 C CA    . PHE D 3 271 ? 80.250  29.479 75.861  1.00 29.58  ? ? ? ? ? ? 265 PHE B CA    1 
+ATOM   6039 C C     . PHE D 3 271 ? 80.368  28.134 76.598  1.00 34.03  ? ? ? ? ? ? 265 PHE B C     1 
+ATOM   6040 O O     . PHE D 3 271 ? 81.342  27.878 77.316  1.00 34.15  ? ? ? ? ? ? 265 PHE B O     1 
+ATOM   6041 C CB    . PHE D 3 271 ? 79.284  30.399 76.643  1.00 28.32  ? ? ? ? ? ? 265 PHE B CB    1 
+ATOM   6042 C CG    . PHE D 3 271 ? 79.629  31.872 76.594  1.00 25.59  ? ? ? ? ? ? 265 PHE B CG    1 
+ATOM   6043 C CD1   . PHE D 3 271 ? 78.763  32.783 76.016  1.00 22.02  ? ? ? ? ? ? 265 PHE B CD1   1 
+ATOM   6044 C CD2   . PHE D 3 271 ? 80.795  32.355 77.170  1.00 25.91  ? ? ? ? ? ? 265 PHE B CD2   1 
+ATOM   6045 C CE1   . PHE D 3 271 ? 79.053  34.136 75.982  1.00 22.70  ? ? ? ? ? ? 265 PHE B CE1   1 
+ATOM   6046 C CE2   . PHE D 3 271 ? 81.084  33.709 77.152  1.00 24.28  ? ? ? ? ? ? 265 PHE B CE2   1 
+ATOM   6047 C CZ    . PHE D 3 271 ? 80.211  34.599 76.555  1.00 23.19  ? ? ? ? ? ? 265 PHE B CZ    1 
+ATOM   6048 N N     . GLU D 3 272 ? 79.361  27.285 76.415  1.00 29.63  ? ? ? ? ? ? 266 GLU B N     1 
+ATOM   6049 C CA    . GLU D 3 272 ? 79.316  25.978 77.054  1.00 27.86  ? ? ? ? ? ? 266 GLU B CA    1 
+ATOM   6050 C C     . GLU D 3 272 ? 80.394  25.067 76.485  1.00 36.04  ? ? ? ? ? ? 266 GLU B C     1 
+ATOM   6051 O O     . GLU D 3 272 ? 81.097  24.397 77.235  1.00 37.75  ? ? ? ? ? ? 266 GLU B O     1 
+ATOM   6052 C CB    . GLU D 3 272 ? 77.938  25.323 76.912  1.00 27.59  ? ? ? ? ? ? 266 GLU B CB    1 
+ATOM   6053 C CG    . GLU D 3 272 ? 77.807  24.103 77.816  1.00 37.38  ? ? ? ? ? ? 266 GLU B CG    1 
+ATOM   6054 C CD    . GLU D 3 272 ? 76.514  23.333 77.631  1.00 57.20  ? ? ? ? ? ? 266 GLU B CD    1 
+ATOM   6055 O OE1   . GLU D 3 272 ? 75.523  23.951 77.191  1.00 62.90  ? ? ? ? ? ? 266 GLU B OE1   1 
+ATOM   6056 O OE2   . GLU D 3 272 ? 76.467  22.125 77.946  1.00 45.52  ? ? ? ? ? ? 266 GLU B OE2   1 
+ATOM   6057 N N     . ALA D 3 273 ? 80.508  25.035 75.161  1.00 32.30  ? ? ? ? ? ? 267 ALA B N     1 
+ATOM   6058 C CA    . ALA D 3 273 ? 81.505  24.211 74.483  1.00 31.11  ? ? ? ? ? ? 267 ALA B CA    1 
+ATOM   6059 C C     . ALA D 3 273 ? 82.939  24.634 74.847  1.00 37.90  ? ? ? ? ? ? 267 ALA B C     1 
+ATOM   6060 O O     . ALA D 3 273 ? 83.787  23.789 75.148  1.00 37.38  ? ? ? ? ? ? 267 ALA B O     1 
+ATOM   6061 C CB    . ALA D 3 273 ? 81.292  24.262 72.974  1.00 29.77  ? ? ? ? ? ? 267 ALA B CB    1 
+ATOM   6062 N N     . THR D 3 274 ? 83.202  25.941 74.830  1.00 34.11  ? ? ? ? ? ? 268 THR B N     1 
+ATOM   6063 C CA    . THR D 3 274 ? 84.507  26.478 75.192  1.00 32.15  ? ? ? ? ? ? 268 THR B CA    1 
+ATOM   6064 C C     . THR D 3 274 ? 84.881  26.072 76.617  1.00 36.63  ? ? ? ? ? ? 268 THR B C     1 
+ATOM   6065 O O     . THR D 3 274 ? 86.055  25.826 76.907  1.00 37.06  ? ? ? ? ? ? 268 THR B O     1 
+ATOM   6066 C CB    . THR D 3 274 ? 84.514  28.008 75.152  1.00 30.01  ? ? ? ? ? ? 268 THR B CB    1 
+ATOM   6067 O OG1   . THR D 3 274 ? 84.210  28.448 73.827  1.00 32.98  ? ? ? ? ? ? 268 THR B OG1   1 
+ATOM   6068 C CG2   . THR D 3 274 ? 85.890  28.533 75.525  1.00 38.32  ? ? ? ? ? ? 268 THR B CG2   1 
+ATOM   6069 N N     . HIS D 3 275 ? 83.887  26.034 77.506  1.00 29.00  ? ? ? ? ? ? 269 HIS B N     1 
+ATOM   6070 C CA    . HIS D 3 275 ? 84.081  25.661 78.910  1.00 25.97  ? ? ? ? ? ? 269 HIS B CA    1 
+ATOM   6071 C C     . HIS D 3 275 ? 84.292  24.157 78.999  1.00 31.87  ? ? ? ? ? ? 269 HIS B C     1 
+ATOM   6072 O O     . HIS D 3 275 ? 85.040  23.677 79.838  1.00 34.86  ? ? ? ? ? ? 269 HIS B O     1 
+ATOM   6073 C CB    . HIS D 3 275 ? 82.859  26.099 79.798  1.00 25.58  ? ? ? ? ? ? 269 HIS B CB    1 
+ATOM   6074 C CG    . HIS D 3 275 ? 83.067  25.920 81.282  1.00 28.69  ? ? ? ? ? ? 269 HIS B CG    1 
+ATOM   6075 N ND1   . HIS D 3 275 ? 82.891  24.707 81.922  1.00 30.77  ? ? ? ? ? ? 269 HIS B ND1   1 
+ATOM   6076 C CD2   . HIS D 3 275 ? 83.469  26.787 82.244  1.00 30.28  ? ? ? ? ? ? 269 HIS B CD2   1 
+ATOM   6077 C CE1   . HIS D 3 275 ? 83.153  24.841 83.211  1.00 30.29  ? ? ? ? ? ? 269 HIS B CE1   1 
+ATOM   6078 N NE2   . HIS D 3 275 ? 83.505  26.095 83.433  1.00 30.60  ? ? ? ? ? ? 269 HIS B NE2   1 
+ATOM   6079 N N     . ARG D 3 276 ? 83.627  23.404 78.130  1.00 29.09  ? ? ? ? ? ? 270 ARG B N     1 
+ATOM   6080 C CA    . ARG D 3 276 ? 83.741  21.951 78.158  1.00 29.95  ? ? ? ? ? ? 270 ARG B CA    1 
+ATOM   6081 C C     . ARG D 3 276 ? 85.127  21.574 77.647  1.00 38.40  ? ? ? ? ? ? 270 ARG B C     1 
+ATOM   6082 O O     . ARG D 3 276 ? 85.737  20.597 78.084  1.00 37.17  ? ? ? ? ? ? 270 ARG B O     1 
+ATOM   6083 C CB    . ARG D 3 276 ? 82.667  21.344 77.264  1.00 23.62  ? ? ? ? ? ? 270 ARG B CB    1 
+ATOM   6084 C CG    . ARG D 3 276 ? 82.507  19.854 77.434  1.00 24.83  ? ? ? ? ? ? 270 ARG B CG    1 
+ATOM   6085 C CD    . ARG D 3 276 ? 81.198  19.415 76.802  1.00 44.13  ? ? ? ? ? ? 270 ARG B CD    1 
+ATOM   6086 N NE    . ARG D 3 276 ? 81.179  19.701 75.369  1.00 45.39  ? ? ? ? ? ? 270 ARG B NE    1 
+ATOM   6087 C CZ    . ARG D 3 276 ? 80.321  20.508 74.753  1.00 64.32  ? ? ? ? ? ? 270 ARG B CZ    1 
+ATOM   6088 N NH1   . ARG D 3 276 ? 79.376  21.146 75.431  1.00 47.79  ? ? ? ? ? ? 270 ARG B NH1   1 
+ATOM   6089 N NH2   . ARG D 3 276 ? 80.419  20.692 73.444  1.00 61.17  ? ? ? ? ? ? 270 ARG B NH2   1 
+ATOM   6090 N N     . LEU D 3 277 ? 85.623  22.389 76.726  1.00 39.57  ? ? ? ? ? ? 271 LEU B N     1 
+ATOM   6091 C CA    . LEU D 3 277 ? 86.946  22.203 76.146  1.00 38.71  ? ? ? ? ? ? 271 LEU B CA    1 
+ATOM   6092 C C     . LEU D 3 277 ? 88.029  22.244 77.217  1.00 36.28  ? ? ? ? ? ? 271 LEU B C     1 
+ATOM   6093 O O     . LEU D 3 277 ? 88.838  21.330 77.334  1.00 33.74  ? ? ? ? ? ? 271 LEU B O     1 
+ATOM   6094 C CB    . LEU D 3 277 ? 87.184  23.313 75.124  1.00 38.16  ? ? ? ? ? ? 271 LEU B CB    1 
+ATOM   6095 C CG    . LEU D 3 277 ? 88.600  23.501 74.584  1.00 41.26  ? ? ? ? ? ? 271 LEU B CG    1 
+ATOM   6096 C CD1   . LEU D 3 277 ? 88.824  22.554 73.412  1.00 42.46  ? ? ? ? ? ? 271 LEU B CD1   1 
+ATOM   6097 C CD2   . LEU D 3 277 ? 88.775  24.950 74.137  1.00 35.28  ? ? ? ? ? ? 271 LEU B CD2   1 
+ATOM   6098 N N     . ILE D 3 278 ? 87.988  23.281 78.040  1.00 32.78  ? ? ? ? ? ? 272 ILE B N     1 
+ATOM   6099 C CA    . ILE D 3 278 ? 88.970  23.460 79.099  1.00 35.04  ? ? ? ? ? ? 272 ILE B CA    1 
+ATOM   6100 C C     . ILE D 3 278 ? 88.769  22.655 80.382  1.00 45.01  ? ? ? ? ? ? 272 ILE B C     1 
+ATOM   6101 O O     . ILE D 3 278 ? 89.705  22.083 80.908  1.00 47.27  ? ? ? ? ? ? 272 ILE B O     1 
+ATOM   6102 C CB    . ILE D 3 278 ? 89.112  24.957 79.444  1.00 37.41  ? ? ? ? ? ? 272 ILE B CB    1 
+ATOM   6103 C CG1   . ILE D 3 278 ? 89.502  25.744 78.188  1.00 37.41  ? ? ? ? ? ? 272 ILE B CG1   1 
+ATOM   6104 C CG2   . ILE D 3 278 ? 90.084  25.163 80.605  1.00 33.53  ? ? ? ? ? ? 272 ILE B CG2   1 
+ATOM   6105 C CD1   . ILE D 3 278 ? 90.120  27.083 78.481  1.00 53.61  ? ? ? ? ? ? 272 ILE B CD1   1 
+ATOM   6106 N N     . TYR D 3 279 ? 87.532  22.566 80.859  1.00 35.96  ? ? ? ? ? ? 273 TYR B N     1 
+ATOM   6107 C CA    . TYR D 3 279 ? 87.254  21.903 82.120  1.00 28.72  ? ? ? ? ? ? 273 TYR B CA    1 
+ATOM   6108 C C     . TYR D 3 279 ? 86.548  20.568 82.041  1.00 35.05  ? ? ? ? ? ? 273 TYR B C     1 
+ATOM   6109 O O     . TYR D 3 279 ? 86.355  19.907 83.053  1.00 38.10  ? ? ? ? ? ? 273 TYR B O     1 
+ATOM   6110 C CB    . TYR D 3 279 ? 86.516  22.859 83.054  1.00 25.12  ? ? ? ? ? ? 273 TYR B CB    1 
+ATOM   6111 C CG    . TYR D 3 279 ? 87.215  24.185 83.204  1.00 25.73  ? ? ? ? ? ? 273 TYR B CG    1 
+ATOM   6112 C CD1   . TYR D 3 279 ? 86.852  25.272 82.419  1.00 26.47  ? ? ? ? ? ? 273 TYR B CD1   1 
+ATOM   6113 C CD2   . TYR D 3 279 ? 88.250  24.355 84.124  1.00 26.45  ? ? ? ? ? ? 273 TYR B CD2   1 
+ATOM   6114 C CE1   . TYR D 3 279 ? 87.484  26.502 82.540  1.00 30.50  ? ? ? ? ? ? 273 TYR B CE1   1 
+ATOM   6115 C CE2   . TYR D 3 279 ? 88.886  25.587 84.256  1.00 27.66  ? ? ? ? ? ? 273 TYR B CE2   1 
+ATOM   6116 C CZ    . TYR D 3 279 ? 88.501  26.656 83.460  1.00 42.89  ? ? ? ? ? ? 273 TYR B CZ    1 
+ATOM   6117 O OH    . TYR D 3 279 ? 89.122  27.880 83.557  1.00 58.22  ? ? ? ? ? ? 273 TYR B OH    1 
+ATOM   6118 N N     . GLY D 3 280 ? 86.189  20.139 80.840  1.00 31.21  ? ? ? ? ? ? 274 GLY B N     1 
+ATOM   6119 C CA    . GLY D 3 280 ? 85.528  18.849 80.684  1.00 29.67  ? ? ? ? ? ? 274 GLY B CA    1 
+ATOM   6120 C C     . GLY D 3 280 ? 84.018  18.946 80.877  1.00 33.94  ? ? ? ? ? ? 274 GLY B C     1 
+ATOM   6121 O O     . GLY D 3 280 ? 83.469  20.033 81.026  1.00 30.41  ? ? ? ? ? ? 274 GLY B O     1 
+ATOM   6122 N N     . ALA D 3 281 ? 83.359  17.792 80.825  1.00 35.90  ? ? ? ? ? ? 275 ALA B N     1 
+ATOM   6123 C CA    . ALA D 3 281 ? 81.906  17.714 80.953  1.00 39.90  ? ? ? ? ? ? 275 ALA B CA    1 
+ATOM   6124 C C     . ALA D 3 281 ? 81.427  18.114 82.333  1.00 47.53  ? ? ? ? ? ? 275 ALA B C     1 
+ATOM   6125 O O     . ALA D 3 281 ? 82.131  17.936 83.319  1.00 49.20  ? ? ? ? ? ? 275 ALA B O     1 
+ATOM   6126 C CB    . ALA D 3 281 ? 81.398  16.326 80.580  1.00 41.11  ? ? ? ? ? ? 275 ALA B CB    1 
+ATOM   6127 N N     . LYS D 3 282 ? 80.219  18.656 82.398  1.00 46.50  ? ? ? ? ? ? 276 LYS B N     1 
+ATOM   6128 C CA    . LYS D 3 282 ? 79.690  19.121 83.666  1.00 47.76  ? ? ? ? ? ? 276 LYS B CA    1 
+ATOM   6129 C C     . LYS D 3 282 ? 78.973  18.142 84.578  1.00 58.08  ? ? ? ? ? ? 276 LYS B C     1 
+ATOM   6130 O O     . LYS D 3 282 ? 78.533  17.074 84.156  1.00 57.13  ? ? ? ? ? ? 276 LYS B O     1 
+ATOM   6131 C CB    . LYS D 3 282 ? 78.864  20.394 83.486  1.00 50.20  ? ? ? ? ? ? 276 LYS B CB    1 
+ATOM   6132 C CG    . LYS D 3 282 ? 77.577  20.226 82.696  1.00 50.74  ? ? ? ? ? ? 276 LYS B CG    1 
+ATOM   6133 C CD    . LYS D 3 282 ? 76.875  21.562 82.562  1.00 48.63  ? ? ? ? ? ? 276 LYS B CD    1 
+ATOM   6134 C CE    . LYS D 3 282 ? 75.519  21.403 81.911  1.00 42.99  ? ? ? ? ? ? 276 LYS B CE    1 
+ATOM   6135 N NZ    . LYS D 3 282 ? 75.048  22.728 81.456  1.00 46.52  ? ? ? ? ? ? 276 LYS B NZ    1 
+ATOM   6136 N N     . ASP D 3 283 ? 78.888  18.551 85.845  1.00 61.61  ? ? ? ? ? ? 277 ASP B N     1 
+ATOM   6137 C CA    . ASP D 3 283 ? 78.220  17.847 86.941  1.00 64.00  ? ? ? ? ? ? 277 ASP B CA    1 
+ATOM   6138 C C     . ASP D 3 283 ? 76.986  17.082 86.497  1.00 69.55  ? ? ? ? ? ? 277 ASP B C     1 
+ATOM   6139 O O     . ASP D 3 283 ? 76.565  17.151 85.344  1.00 67.91  ? ? ? ? ? ? 277 ASP B O     1 
+ATOM   6140 C CB    . ASP D 3 283 ? 77.698  18.898 87.925  1.00 67.04  ? ? ? ? ? ? 277 ASP B CB    1 
+ATOM   6141 C CG    . ASP D 3 283 ? 78.187  18.676 89.336  1.00 85.24  ? ? ? ? ? ? 277 ASP B CG    1 
+ATOM   6142 O OD1   . ASP D 3 283 ? 78.386  17.498 89.701  1.00 89.03  ? ? ? ? ? ? 277 ASP B OD1   1 
+ATOM   6143 O OD2   . ASP D 3 283 ? 78.380  19.680 90.065  1.00 87.69  ? ? ? ? ? ? 277 ASP B OD2   1 
+ATOM   6144 N N     . ASP D 3 284 ? 76.379  16.390 87.452  1.00 70.23  ? ? ? ? ? ? 278 ASP B N     1 
+ATOM   6145 C CA    . ASP D 3 284 ? 75.150  15.654 87.188  1.00 71.66  ? ? ? ? ? ? 278 ASP B CA    1 
+ATOM   6146 C C     . ASP D 3 284 ? 74.089  16.272 88.094  1.00 72.93  ? ? ? ? ? ? 278 ASP B C     1 
+ATOM   6147 O O     . ASP D 3 284 ? 72.909  15.921 88.051  1.00 74.81  ? ? ? ? ? ? 278 ASP B O     1 
+ATOM   6148 C CB    . ASP D 3 284 ? 75.318  14.142 87.410  1.00 73.80  ? ? ? ? ? ? 278 ASP B CB    1 
+ATOM   6149 C CG    . ASP D 3 284 ? 76.168  13.807 88.625  1.00 88.96  ? ? ? ? ? ? 278 ASP B CG    1 
+ATOM   6150 O OD1   . ASP D 3 284 ? 76.889  14.698 89.121  1.00 100.00 ? ? ? ? ? ? 278 ASP B OD1   1 
+ATOM   6151 O OD2   . ASP D 3 284 ? 76.121  12.645 89.081  1.00 87.66  ? ? ? ? ? ? 278 ASP B OD2   1 
+ATOM   6152 N N     . SER D 3 285 ? 74.529  17.249 88.877  1.00 63.91  ? ? ? ? ? ? 279 SER B N     1 
+ATOM   6153 C CA    . SER D 3 285 ? 73.647  17.949 89.793  1.00 63.18  ? ? ? ? ? ? 279 SER B CA    1 
+ATOM   6154 C C     . SER D 3 285 ? 72.365  18.481 89.152  1.00 66.86  ? ? ? ? ? ? 279 SER B C     1 
+ATOM   6155 O O     . SER D 3 285 ? 71.301  18.478 89.774  1.00 67.59  ? ? ? ? ? ? 279 SER B O     1 
+ATOM   6156 C CB    . SER D 3 285 ? 74.404  19.086 90.474  1.00 64.99  ? ? ? ? ? ? 279 SER B CB    1 
+ATOM   6157 O OG    . SER D 3 285 ? 75.341  19.688 89.606  1.00 66.04  ? ? ? ? ? ? 279 SER B OG    1 
+ATOM   6158 N N     . GLY D 3 286 ? 72.470  18.947 87.913  1.00 60.86  ? ? ? ? ? ? 280 GLY B N     1 
+ATOM   6159 C CA    . GLY D 3 286 ? 71.321  19.516 87.229  1.00 58.46  ? ? ? ? ? ? 280 GLY B CA    1 
+ATOM   6160 C C     . GLY D 3 286 ? 71.225  20.998 87.594  1.00 59.26  ? ? ? ? ? ? 280 GLY B C     1 
+ATOM   6161 O O     . GLY D 3 286 ? 70.244  21.658 87.260  1.00 61.10  ? ? ? ? ? ? 280 GLY B O     1 
+ATOM   6162 N N     . GLN D 3 287 ? 72.243  21.531 88.268  1.00 52.34  ? ? ? ? ? ? 281 GLN B N     1 
+ATOM   6163 C CA    . GLN D 3 287 ? 72.246  22.945 88.651  1.00 49.40  ? ? ? ? ? ? 281 GLN B CA    1 
+ATOM   6164 C C     . GLN D 3 287 ? 72.596  23.831 87.467  1.00 50.86  ? ? ? ? ? ? 281 GLN B C     1 
+ATOM   6165 O O     . GLN D 3 287 ? 73.129  23.364 86.466  1.00 52.31  ? ? ? ? ? ? 281 GLN B O     1 
+ATOM   6166 C CB    . GLN D 3 287 ? 73.267  23.206 89.753  1.00 49.93  ? ? ? ? ? ? 281 GLN B CB    1 
+ATOM   6167 C CG    . GLN D 3 287 ? 73.380  22.070 90.738  1.00 76.29  ? ? ? ? ? ? 281 GLN B CG    1 
+ATOM   6168 C CD    . GLN D 3 287 ? 74.662  22.139 91.533  1.00 100.00 ? ? ? ? ? ? 281 GLN B CD    1 
+ATOM   6169 O OE1   . GLN D 3 287 ? 74.726  22.795 92.571  1.00 95.72  ? ? ? ? ? ? 281 GLN B OE1   1 
+ATOM   6170 N NE2   . GLN D 3 287 ? 75.706  21.487 91.035  1.00 94.82  ? ? ? ? ? ? 281 GLN B NE2   1 
+ATOM   6171 N N     . ARG D 3 288 ? 72.297  25.117 87.582  1.00 43.75  ? ? ? ? ? ? 282 ARG B N     1 
+ATOM   6172 C CA    . ARG D 3 288 ? 72.603  26.054 86.514  1.00 42.01  ? ? ? ? ? ? 282 ARG B CA    1 
+ATOM   6173 C C     . ARG D 3 288 ? 73.967  26.673 86.764  1.00 47.05  ? ? ? ? ? ? 282 ARG B C     1 
+ATOM   6174 O O     . ARG D 3 288 ? 74.422  26.776 87.905  1.00 49.11  ? ? ? ? ? ? 282 ARG B O     1 
+ATOM   6175 C CB    . ARG D 3 288 ? 71.588  27.202 86.532  1.00 38.56  ? ? ? ? ? ? 282 ARG B CB    1 
+ATOM   6176 C CG    . ARG D 3 288 ? 70.350  26.968 85.698  1.00 50.09  ? ? ? ? ? ? 282 ARG B CG    1 
+ATOM   6177 C CD    . ARG D 3 288 ? 69.680  28.272 85.289  1.00 56.49  ? ? ? ? ? ? 282 ARG B CD    1 
+ATOM   6178 N NE    . ARG D 3 288 ? 68.329  27.963 84.826  1.00 56.65  ? ? ? ? ? ? 282 ARG B NE    1 
+ATOM   6179 C CZ    . ARG D 3 288 ? 67.359  28.826 84.519  1.00 57.22  ? ? ? ? ? ? 282 ARG B CZ    1 
+ATOM   6180 N NH1   . ARG D 3 288 ? 67.522  30.147 84.571  1.00 41.13  ? ? ? ? ? ? 282 ARG B NH1   1 
+ATOM   6181 N NH2   . ARG D 3 288 ? 66.192  28.332 84.124  1.00 33.06  ? ? ? ? ? ? 282 ARG B NH2   1 
+ATOM   6182 N N     . TYR D 3 289 ? 74.593  27.121 85.683  1.00 37.20  ? ? ? ? ? ? 283 TYR B N     1 
+ATOM   6183 C CA    . TYR D 3 289 ? 75.856  27.823 85.775  1.00 31.84  ? ? ? ? ? ? 283 TYR B CA    1 
+ATOM   6184 C C     . TYR D 3 289 ? 77.036  26.942 86.135  1.00 34.79  ? ? ? ? ? ? 283 TYR B C     1 
+ATOM   6185 O O     . TYR D 3 289 ? 77.990  27.391 86.772  1.00 35.89  ? ? ? ? ? ? 283 TYR B O     1 
+ATOM   6186 C CB    . TYR D 3 289 ? 75.705  28.982 86.752  1.00 30.48  ? ? ? ? ? ? 283 TYR B CB    1 
+ATOM   6187 C CG    . TYR D 3 289 ? 74.673  30.023 86.352  1.00 32.66  ? ? ? ? ? ? 283 TYR B CG    1 
+ATOM   6188 C CD1   . TYR D 3 289 ? 73.732  30.476 87.265  1.00 32.56  ? ? ? ? ? ? 283 TYR B CD1   1 
+ATOM   6189 C CD2   . TYR D 3 289 ? 74.654  30.587 85.079  1.00 34.68  ? ? ? ? ? ? 283 TYR B CD2   1 
+ATOM   6190 C CE1   . TYR D 3 289 ? 72.819  31.473 86.935  1.00 32.49  ? ? ? ? ? ? 283 TYR B CE1   1 
+ATOM   6191 C CE2   . TYR D 3 289 ? 73.729  31.579 84.732  1.00 32.09  ? ? ? ? ? ? 283 TYR B CE2   1 
+ATOM   6192 C CZ    . TYR D 3 289 ? 72.819  32.027 85.669  1.00 38.05  ? ? ? ? ? ? 283 TYR B CZ    1 
+ATOM   6193 O OH    . TYR D 3 289 ? 71.898  33.008 85.327  1.00 33.95  ? ? ? ? ? ? 283 TYR B OH    1 
+ATOM   6194 N N     . LEU D 3 290 ? 76.962  25.683 85.720  1.00 31.34  ? ? ? ? ? ? 284 LEU B N     1 
+ATOM   6195 C CA    . LEU D 3 290 ? 78.067  24.760 85.924  1.00 32.04  ? ? ? ? ? ? 284 LEU B CA    1 
+ATOM   6196 C C     . LEU D 3 290 ? 79.160  25.134 84.902  1.00 36.43  ? ? ? ? ? ? 284 LEU B C     1 
+ATOM   6197 O O     . LEU D 3 290 ? 80.350  24.895 85.129  1.00 36.27  ? ? ? ? ? ? 284 LEU B O     1 
+ATOM   6198 C CB    . LEU D 3 290 ? 77.607  23.312 85.705  1.00 32.65  ? ? ? ? ? ? 284 LEU B CB    1 
+ATOM   6199 C CG    . LEU D 3 290 ? 76.656  22.693 86.739  1.00 38.96  ? ? ? ? ? ? 284 LEU B CG    1 
+ATOM   6200 C CD1   . LEU D 3 290 ? 76.422  21.216 86.457  1.00 39.98  ? ? ? ? ? ? 284 LEU B CD1   1 
+ATOM   6201 C CD2   . LEU D 3 290 ? 77.100  22.920 88.186  1.00 38.05  ? ? ? ? ? ? 284 LEU B CD2   1 
+ATOM   6202 N N     . ALA D 3 291 ? 78.748  25.702 83.761  1.00 30.15  ? ? ? ? ? ? 285 ALA B N     1 
+ATOM   6203 C CA    . ALA D 3 291 ? 79.670  26.128 82.713  1.00 27.63  ? ? ? ? ? ? 285 ALA B CA    1 
+ATOM   6204 C C     . ALA D 3 291 ? 79.361  27.578 82.368  1.00 29.91  ? ? ? ? ? ? 285 ALA B C     1 
+ATOM   6205 O O     . ALA D 3 291 ? 78.366  28.119 82.856  1.00 31.69  ? ? ? ? ? ? 285 ALA B O     1 
+ATOM   6206 C CB    . ALA D 3 291 ? 79.479  25.250 81.482  1.00 26.85  ? ? ? ? ? ? 285 ALA B CB    1 
+ATOM   6207 N N     . TRP D 3 292 ? 80.182  28.190 81.518  1.00 26.54  ? ? ? ? ? ? 286 TRP B N     1 
+ATOM   6208 C CA    . TRP D 3 292 ? 79.932  29.557 81.077  1.00 30.11  ? ? ? ? ? ? 286 TRP B CA    1 
+ATOM   6209 C C     . TRP D 3 292 ? 78.633  29.600 80.252  1.00 35.60  ? ? ? ? ? ? 286 TRP B C     1 
+ATOM   6210 O O     . TRP D 3 292 ? 78.204  28.596 79.671  1.00 30.65  ? ? ? ? ? ? 286 TRP B O     1 
+ATOM   6211 C CB    . TRP D 3 292 ? 81.095  30.085 80.233  1.00 30.96  ? ? ? ? ? ? 286 TRP B CB    1 
+ATOM   6212 C CG    . TRP D 3 292 ? 82.390  30.224 80.990  1.00 33.87  ? ? ? ? ? ? 286 TRP B CG    1 
+ATOM   6213 C CD1   . TRP D 3 292 ? 82.584  30.828 82.202  1.00 36.82  ? ? ? ? ? ? 286 TRP B CD1   1 
+ATOM   6214 C CD2   . TRP D 3 292 ? 83.671  29.747 80.578  1.00 34.91  ? ? ? ? ? ? 286 TRP B CD2   1 
+ATOM   6215 N NE1   . TRP D 3 292 ? 83.905  30.747 82.570  1.00 35.66  ? ? ? ? ? ? 286 TRP B NE1   1 
+ATOM   6216 C CE2   . TRP D 3 292 ? 84.586  30.068 81.598  1.00 37.99  ? ? ? ? ? ? 286 TRP B CE2   1 
+ATOM   6217 C CE3   . TRP D 3 292 ? 84.131  29.067 79.445  1.00 36.75  ? ? ? ? ? ? 286 TRP B CE3   1 
+ATOM   6218 C CZ2   . TRP D 3 292 ? 85.931  29.748 81.504  1.00 37.87  ? ? ? ? ? ? 286 TRP B CZ2   1 
+ATOM   6219 C CZ3   . TRP D 3 292 ? 85.469  28.763 79.351  1.00 37.23  ? ? ? ? ? ? 286 TRP B CZ3   1 
+ATOM   6220 C CH2   . TRP D 3 292 ? 86.352  29.097 80.376  1.00 37.93  ? ? ? ? ? ? 286 TRP B CH2   1 
+ATOM   6221 N N     . SER D 3 293 ? 78.010  30.773 80.200  1.00 33.88  ? ? ? ? ? ? 287 SER B N     1 
+ATOM   6222 C CA    . SER D 3 293 ? 76.744  30.952 79.497  1.00 31.26  ? ? ? ? ? ? 287 SER B CA    1 
+ATOM   6223 C C     . SER D 3 293 ? 76.690  32.371 78.955  1.00 35.14  ? ? ? ? ? ? 287 SER B C     1 
+ATOM   6224 O O     . SER D 3 293 ? 77.605  33.153 79.174  1.00 36.26  ? ? ? ? ? ? 287 SER B O     1 
+ATOM   6225 C CB    . SER D 3 293 ? 75.567  30.694 80.456  1.00 32.92  ? ? ? ? ? ? 287 SER B CB    1 
+ATOM   6226 O OG    . SER D 3 293 ? 75.555  31.579 81.574  1.00 35.64  ? ? ? ? ? ? 287 SER B OG    1 
+ATOM   6227 N N     . GLY D 3 294 ? 75.619  32.697 78.242  1.00 32.67  ? ? ? ? ? ? 288 GLY B N     1 
+ATOM   6228 C CA    . GLY D 3 294 ? 75.442  34.011 77.638  1.00 30.43  ? ? ? ? ? ? 288 GLY B CA    1 
+ATOM   6229 C C     . GLY D 3 294 ? 75.902  35.224 78.439  1.00 36.27  ? ? ? ? ? ? 288 GLY B C     1 
+ATOM   6230 O O     . GLY D 3 294 ? 76.391  36.192 77.866  1.00 38.85  ? ? ? ? ? ? 288 GLY B O     1 
+ATOM   6231 N N     . HIS D 3 295 ? 75.712  35.229 79.747  1.00 36.49  ? ? ? ? ? ? 289 HIS B N     1 
+ATOM   6232 C CA    . HIS D 3 295 ? 76.102  36.410 80.505  1.00 40.47  ? ? ? ? ? ? 289 HIS B CA    1 
+ATOM   6233 C C     . HIS D 3 295 ? 77.450  36.356 81.218  1.00 40.30  ? ? ? ? ? ? 289 HIS B C     1 
+ATOM   6234 O O     . HIS D 3 295 ? 77.805  37.292 81.939  1.00 38.86  ? ? ? ? ? ? 289 HIS B O     1 
+ATOM   6235 C CB    . HIS D 3 295 ? 75.018  36.735 81.527  1.00 45.83  ? ? ? ? ? ? 289 HIS B CB    1 
+ATOM   6236 C CG    . HIS D 3 295 ? 74.082  37.813 81.084  1.00 52.97  ? ? ? ? ? ? 289 HIS B CG    1 
+ATOM   6237 N ND1   . HIS D 3 295 ? 73.874  38.126 79.764  1.00 56.71  ? ? ? ? ? ? 289 HIS B ND1   1 
+ATOM   6238 C CD2   . HIS D 3 295 ? 73.306  38.668 81.787  1.00 56.71  ? ? ? ? ? ? 289 HIS B CD2   1 
+ATOM   6239 C CE1   . HIS D 3 295 ? 73.001  39.120 79.670  1.00 56.42  ? ? ? ? ? ? 289 HIS B CE1   1 
+ATOM   6240 N NE2   . HIS D 3 295 ? 72.644  39.466 80.884  1.00 57.11  ? ? ? ? ? ? 289 HIS B NE2   1 
+ATOM   6241 N N     . SER D 3 296 ? 78.177  35.261 81.014  1.00 34.15  ? ? ? ? ? ? 290 SER B N     1 
+ATOM   6242 C CA    . SER D 3 296 ? 79.466  35.005 81.644  1.00 29.29  ? ? ? ? ? ? 290 SER B CA    1 
+ATOM   6243 C C     . SER D 3 296 ? 80.566  36.053 81.472  1.00 32.04  ? ? ? ? ? ? 290 SER B C     1 
+ATOM   6244 O O     . SER D 3 296 ? 81.301  36.353 82.413  1.00 32.07  ? ? ? ? ? ? 290 SER B O     1 
+ATOM   6245 C CB    . SER D 3 296 ? 79.948  33.608 81.261  1.00 24.77  ? ? ? ? ? ? 290 SER B CB    1 
+ATOM   6246 O OG    . SER D 3 296 ? 79.200  32.623 81.950  1.00 26.60  ? ? ? ? ? ? 290 SER B OG    1 
+ATOM   6247 N N     . ALA D 3 297 ? 80.666  36.623 80.277  1.00 29.23  ? ? ? ? ? ? 291 ALA B N     1 
+ATOM   6248 C CA    . ALA D 3 297 ? 81.691  37.621 79.997  1.00 29.55  ? ? ? ? ? ? 291 ALA B CA    1 
+ATOM   6249 C C     . ALA D 3 297 ? 81.357  39.018 80.502  1.00 41.17  ? ? ? ? ? ? 291 ALA B C     1 
+ATOM   6250 O O     . ALA D 3 297 ? 82.265  39.827 80.701  1.00 40.01  ? ? ? ? ? ? 291 ALA B O     1 
+ATOM   6251 C CB    . ALA D 3 297 ? 82.004  37.649 78.519  1.00 29.76  ? ? ? ? ? ? 291 ALA B CB    1 
+ATOM   6252 N N     . ARG D 3 298 ? 80.061  39.292 80.679  1.00 45.53  ? ? ? ? ? ? 292 ARG B N     1 
+ATOM   6253 C CA    . ARG D 3 298 ? 79.540  40.580 81.162  1.00 43.90  ? ? ? ? ? ? 292 ARG B CA    1 
+ATOM   6254 C C     . ARG D 3 298 ? 79.862  40.650 82.642  1.00 42.73  ? ? ? ? ? ? 292 ARG B C     1 
+ATOM   6255 O O     . ARG D 3 298 ? 80.364  41.647 83.142  1.00 44.84  ? ? ? ? ? ? 292 ARG B O     1 
+ATOM   6256 C CB    . ARG D 3 298 ? 78.017  40.595 81.026  1.00 45.58  ? ? ? ? ? ? 292 ARG B CB    1 
+ATOM   6257 C CG    . ARG D 3 298 ? 77.426  41.657 80.124  1.00 53.84  ? ? ? ? ? ? 292 ARG B CG    1 
+ATOM   6258 C CD    . ARG D 3 298 ? 75.917  41.451 80.015  1.00 45.34  ? ? ? ? ? ? 292 ARG B CD    1 
+ATOM   6259 N NE    . ARG D 3 298 ? 75.170  42.511 80.687  1.00 43.45  ? ? ? ? ? ? 292 ARG B NE    1 
+ATOM   6260 C CZ    . ARG D 3 298 ? 75.126  43.766 80.254  1.00 50.39  ? ? ? ? ? ? 292 ARG B CZ    1 
+ATOM   6261 N NH1   . ARG D 3 298 ? 75.789  44.107 79.158  1.00 43.25  ? ? ? ? ? ? 292 ARG B NH1   1 
+ATOM   6262 N NH2   . ARG D 3 298 ? 74.431  44.683 80.915  1.00 55.83  ? ? ? ? ? ? 292 ARG B NH2   1 
+ATOM   6263 N N     . VAL D 3 299 ? 79.556  39.570 83.344  1.00 38.40  ? ? ? ? ? ? 293 VAL B N     1 
+ATOM   6264 C CA    . VAL D 3 299 ? 79.863  39.514 84.758  1.00 39.56  ? ? ? ? ? ? 293 VAL B CA    1 
+ATOM   6265 C C     . VAL D 3 299 ? 81.380  39.633 84.856  1.00 48.15  ? ? ? ? ? ? 293 VAL B C     1 
+ATOM   6266 O O     . VAL D 3 299 ? 81.902  40.560 85.477  1.00 50.81  ? ? ? ? ? ? 293 VAL B O     1 
+ATOM   6267 C CB    . VAL D 3 299 ? 79.439  38.152 85.343  1.00 43.40  ? ? ? ? ? ? 293 VAL B CB    1 
+ATOM   6268 C CG1   . VAL D 3 299 ? 80.107  37.885 86.684  1.00 44.10  ? ? ? ? ? ? 293 VAL B CG1   1 
+ATOM   6269 C CG2   . VAL D 3 299 ? 77.919  38.026 85.409  1.00 42.30  ? ? ? ? ? ? 293 VAL B CG2   1 
+ATOM   6270 N N     . GLY D 3 300 ? 82.070  38.692 84.209  1.00 44.08  ? ? ? ? ? ? 294 GLY B N     1 
+ATOM   6271 C CA    . GLY D 3 300 ? 83.532  38.615 84.179  1.00 41.32  ? ? ? ? ? ? 294 GLY B CA    1 
+ATOM   6272 C C     . GLY D 3 300 ? 84.275  39.909 83.857  1.00 38.73  ? ? ? ? ? ? 294 GLY B C     1 
+ATOM   6273 O O     . GLY D 3 300 ? 85.274  40.222 84.511  1.00 34.71  ? ? ? ? ? ? 294 GLY B O     1 
+ATOM   6274 N N     . ALA D 3 301 ? 83.807  40.642 82.850  1.00 33.91  ? ? ? ? ? ? 295 ALA B N     1 
+ATOM   6275 C CA    . ALA D 3 301 ? 84.449  41.896 82.478  1.00 34.61  ? ? ? ? ? ? 295 ALA B CA    1 
+ATOM   6276 C C     . ALA D 3 301 ? 84.193  42.940 83.556  1.00 51.10  ? ? ? ? ? ? 295 ALA B C     1 
+ATOM   6277 O O     . ALA D 3 301 ? 85.127  43.567 84.058  1.00 51.11  ? ? ? ? ? ? 295 ALA B O     1 
+ATOM   6278 C CB    . ALA D 3 301 ? 83.919  42.387 81.154  1.00 33.97  ? ? ? ? ? ? 295 ALA B CB    1 
+ATOM   6279 N N     . ALA D 3 302 ? 82.917  43.141 83.879  1.00 53.15  ? ? ? ? ? ? 296 ALA B N     1 
+ATOM   6280 C CA    . ALA D 3 302 ? 82.523  44.110 84.896  1.00 52.15  ? ? ? ? ? ? 296 ALA B CA    1 
+ATOM   6281 C C     . ALA D 3 302 ? 83.540  43.962 86.012  1.00 50.96  ? ? ? ? ? ? 296 ALA B C     1 
+ATOM   6282 O O     . ALA D 3 302 ? 84.215  44.903 86.425  1.00 48.49  ? ? ? ? ? ? 296 ALA B O     1 
+ATOM   6283 C CB    . ALA D 3 302 ? 81.127  43.785 85.418  1.00 52.86  ? ? ? ? ? ? 296 ALA B CB    1 
+ATOM   6284 N N     . ARG D 3 303 ? 83.646  42.734 86.483  1.00 47.31  ? ? ? ? ? ? 297 ARG B N     1 
+ATOM   6285 C CA    . ARG D 3 303 ? 84.577  42.422 87.542  1.00 49.27  ? ? ? ? ? ? 297 ARG B CA    1 
+ATOM   6286 C C     . ARG D 3 303 ? 85.983  42.891 87.205  1.00 58.11  ? ? ? ? ? ? 297 ARG B C     1 
+ATOM   6287 O O     . ARG D 3 303 ? 86.448  43.876 87.767  1.00 63.22  ? ? ? ? ? ? 297 ARG B O     1 
+ATOM   6288 C CB    . ARG D 3 303 ? 84.578  40.921 87.785  1.00 49.08  ? ? ? ? ? ? 297 ARG B CB    1 
+ATOM   6289 C CG    . ARG D 3 303 ? 83.305  40.403 88.406  1.00 49.17  ? ? ? ? ? ? 297 ARG B CG    1 
+ATOM   6290 C CD    . ARG D 3 303 ? 83.690  39.408 89.472  1.00 64.65  ? ? ? ? ? ? 297 ARG B CD    1 
+ATOM   6291 N NE    . ARG D 3 303 ? 82.679  38.387 89.712  1.00 71.33  ? ? ? ? ? ? 297 ARG B NE    1 
+ATOM   6292 C CZ    . ARG D 3 303 ? 82.961  37.115 89.931  1.00 90.21  ? ? ? ? ? ? 297 ARG B CZ    1 
+ATOM   6293 N NH1   . ARG D 3 303 ? 84.221  36.702 89.952  1.00 91.71  ? ? ? ? ? ? 297 ARG B NH1   1 
+ATOM   6294 N NH2   . ARG D 3 303 ? 81.979  36.250 90.221  1.00 75.30  ? ? ? ? ? ? 297 ARG B NH2   1 
+ATOM   6295 N N     . ASP D 3 304 ? 86.668  42.196 86.302  1.00 53.26  ? ? ? ? ? ? 298 ASP B N     1 
+ATOM   6296 C CA    . ASP D 3 304 ? 88.029  42.595 85.941  1.00 52.21  ? ? ? ? ? ? 298 ASP B CA    1 
+ATOM   6297 C C     . ASP D 3 304 ? 88.272  44.107 86.024  1.00 49.73  ? ? ? ? ? ? 298 ASP B C     1 
+ATOM   6298 O O     . ASP D 3 304 ? 89.364  44.544 86.393  1.00 48.94  ? ? ? ? ? ? 298 ASP B O     1 
+ATOM   6299 C CB    . ASP D 3 304 ? 88.412  42.105 84.538  1.00 53.89  ? ? ? ? ? ? 298 ASP B CB    1 
+ATOM   6300 C CG    . ASP D 3 304 ? 88.423  40.595 84.411  1.00 52.73  ? ? ? ? ? ? 298 ASP B CG    1 
+ATOM   6301 O OD1   . ASP D 3 304 ? 88.882  39.923 85.354  1.00 54.69  ? ? ? ? ? ? 298 ASP B OD1   1 
+ATOM   6302 O OD2   . ASP D 3 304 ? 87.993  40.089 83.350  1.00 49.81  ? ? ? ? ? ? 298 ASP B OD2   1 
+ATOM   6303 N N     . MET D 3 305 ? 87.269  44.894 85.639  1.00 44.08  ? ? ? ? ? ? 299 MET B N     1 
+ATOM   6304 C CA    . MET D 3 305 ? 87.350  46.352 85.650  1.00 44.81  ? ? ? ? ? ? 299 MET B CA    1 
+ATOM   6305 C C     . MET D 3 305 ? 87.442  46.892 87.080  1.00 54.16  ? ? ? ? ? ? 299 MET B C     1 
+ATOM   6306 O O     . MET D 3 305 ? 88.219  47.810 87.351  1.00 56.15  ? ? ? ? ? ? 299 MET B O     1 
+ATOM   6307 C CB    . MET D 3 305 ? 86.127  46.944 84.948  1.00 46.90  ? ? ? ? ? ? 299 MET B CB    1 
+ATOM   6308 C CG    . MET D 3 305 ? 86.271  47.094 83.450  1.00 50.31  ? ? ? ? ? ? 299 MET B CG    1 
+ATOM   6309 S SD    . MET D 3 305 ? 84.664  47.389 82.690  1.00 55.98  ? ? ? ? ? ? 299 MET B SD    1 
+ATOM   6310 C CE    . MET D 3 305 ? 84.956  48.974 81.967  1.00 52.43  ? ? ? ? ? ? 299 MET B CE    1 
+ATOM   6311 N N     . ALA D 3 306 ? 86.646  46.326 87.983  1.00 49.90  ? ? ? ? ? ? 300 ALA B N     1 
+ATOM   6312 C CA    . ALA D 3 306 ? 86.677  46.736 89.374  1.00 49.46  ? ? ? ? ? ? 300 ALA B CA    1 
+ATOM   6313 C C     . ALA D 3 306 ? 88.134  46.613 89.787  1.00 59.33  ? ? ? ? ? ? 300 ALA B C     1 
+ATOM   6314 O O     . ALA D 3 306 ? 88.814  47.617 89.992  1.00 65.30  ? ? ? ? ? ? 300 ALA B O     1 
+ATOM   6315 C CB    . ALA D 3 306 ? 85.810  45.814 90.217  1.00 50.32  ? ? ? ? ? ? 300 ALA B CB    1 
+ATOM   6316 N N     . ARG D 3 307 ? 88.638  45.394 89.879  1.00 54.35  ? ? ? ? ? ? 301 ARG B N     1 
+ATOM   6317 C CA    . ARG D 3 307 ? 90.035  45.204 90.261  1.00 56.08  ? ? ? ? ? ? 301 ARG B CA    1 
+ATOM   6318 C C     . ARG D 3 307 ? 91.072  46.147 89.656  1.00 67.70  ? ? ? ? ? ? 301 ARG B C     1 
+ATOM   6319 O O     . ARG D 3 307 ? 91.984  46.592 90.352  1.00 71.70  ? ? ? ? ? ? 301 ARG B O     1 
+ATOM   6320 C CB    . ARG D 3 307 ? 90.490  43.829 89.812  1.00 55.75  ? ? ? ? ? ? 301 ARG B CB    1 
+ATOM   6321 C CG    . ARG D 3 307 ? 90.120  42.694 90.721  1.00 69.45  ? ? ? ? ? ? 301 ARG B CG    1 
+ATOM   6322 C CD    . ARG D 3 307 ? 91.003  41.510 90.400  1.00 81.45  ? ? ? ? ? ? 301 ARG B CD    1 
+ATOM   6323 N NE    . ARG D 3 307 ? 90.474  40.780 89.257  1.00 89.89  ? ? ? ? ? ? 301 ARG B NE    1 
+ATOM   6324 C CZ    . ARG D 3 307 ? 89.465  39.922 89.329  1.00 100.00 ? ? ? ? ? ? 301 ARG B CZ    1 
+ATOM   6325 N NH1   . ARG D 3 307 ? 88.865  39.722 90.484  1.00 96.87  ? ? ? ? ? ? 301 ARG B NH1   1 
+ATOM   6326 N NH2   . ARG D 3 307 ? 89.027  39.325 88.231  1.00 100.00 ? ? ? ? ? ? 301 ARG B NH2   1 
+ATOM   6327 N N     . ALA D 3 308 ? 91.015  46.340 88.339  1.00 65.51  ? ? ? ? ? ? 302 ALA B N     1 
+ATOM   6328 C CA    . ALA D 3 308 ? 91.985  47.172 87.618  1.00 65.10  ? ? ? ? ? ? 302 ALA B CA    1 
+ATOM   6329 C C     . ALA D 3 308 ? 92.056  48.546 88.256  1.00 71.24  ? ? ? ? ? ? 302 ALA B C     1 
+ATOM   6330 O O     . ALA D 3 308 ? 93.046  49.269 88.124  1.00 72.15  ? ? ? ? ? ? 302 ALA B O     1 
+ATOM   6331 C CB    . ALA D 3 308 ? 91.590  47.297 86.145  1.00 64.81  ? ? ? ? ? ? 302 ALA B CB    1 
+ATOM   6332 N N     . GLY D 3 309 ? 90.978  48.878 88.955  1.00 65.92  ? ? ? ? ? ? 303 GLY B N     1 
+ATOM   6333 C CA    . GLY D 3 309 ? 90.833  50.157 89.627  1.00 64.38  ? ? ? ? ? ? 303 GLY B CA    1 
+ATOM   6334 C C     . GLY D 3 309 ? 89.916  51.022 88.774  1.00 64.26  ? ? ? ? ? ? 303 GLY B C     1 
+ATOM   6335 O O     . GLY D 3 309 ? 89.769  52.216 89.032  1.00 66.67  ? ? ? ? ? ? 303 GLY B O     1 
+ATOM   6336 N N     . VAL D 3 310 ? 89.301  50.423 87.761  1.00 55.36  ? ? ? ? ? ? 304 VAL B N     1 
+ATOM   6337 C CA    . VAL D 3 310 ? 88.397  51.190 86.914  1.00 53.93  ? ? ? ? ? ? 304 VAL B CA    1 
+ATOM   6338 C C     . VAL D 3 310 ? 87.315  51.841 87.775  1.00 58.74  ? ? ? ? ? ? 304 VAL B C     1 
+ATOM   6339 O O     . VAL D 3 310 ? 86.900  51.291 88.801  1.00 56.61  ? ? ? ? ? ? 304 VAL B O     1 
+ATOM   6340 C CB    . VAL D 3 310 ? 87.754  50.341 85.803  1.00 54.59  ? ? ? ? ? ? 304 VAL B CB    1 
+ATOM   6341 C CG1   . VAL D 3 310 ? 86.725  51.163 85.039  1.00 53.66  ? ? ? ? ? ? 304 VAL B CG1   1 
+ATOM   6342 C CG2   . VAL D 3 310 ? 88.816  49.785 84.866  1.00 53.22  ? ? ? ? ? ? 304 VAL B CG2   1 
+ATOM   6343 N N     . SER D 3 311 ? 86.882  53.028 87.360  1.00 56.29  ? ? ? ? ? ? 305 SER B N     1 
+ATOM   6344 C CA    . SER D 3 311 ? 85.876  53.772 88.103  1.00 56.73  ? ? ? ? ? ? 305 SER B CA    1 
+ATOM   6345 C C     . SER D 3 311 ? 84.496  53.205 87.852  1.00 65.29  ? ? ? ? ? ? 305 SER B C     1 
+ATOM   6346 O O     . SER D 3 311 ? 84.111  52.970 86.703  1.00 62.78  ? ? ? ? ? ? 305 SER B O     1 
+ATOM   6347 C CB    . SER D 3 311 ? 85.908  55.264 87.750  1.00 56.73  ? ? ? ? ? ? 305 SER B CB    1 
+ATOM   6348 O OG    . SER D 3 311 ? 85.341  55.518 86.475  1.00 59.12  ? ? ? ? ? ? 305 SER B OG    1 
+ATOM   6349 N N     . ILE D 3 312 ? 83.755  53.000 88.937  1.00 64.48  ? ? ? ? ? ? 306 ILE B N     1 
+ATOM   6350 C CA    . ILE D 3 312 ? 82.403  52.478 88.838  1.00 63.10  ? ? ? ? ? ? 306 ILE B CA    1 
+ATOM   6351 C C     . ILE D 3 312 ? 81.712  53.220 87.708  1.00 65.01  ? ? ? ? ? ? 306 ILE B C     1 
+ATOM   6352 O O     . ILE D 3 312 ? 81.091  52.608 86.847  1.00 64.94  ? ? ? ? ? ? 306 ILE B O     1 
+ATOM   6353 C CB    . ILE D 3 312 ? 81.592  52.726 90.110  1.00 65.87  ? ? ? ? ? ? 306 ILE B CB    1 
+ATOM   6354 C CG1   . ILE D 3 312 ? 81.499  51.438 90.932  1.00 66.57  ? ? ? ? ? ? 306 ILE B CG1   1 
+ATOM   6355 C CG2   . ILE D 3 312 ? 80.195  53.191 89.729  1.00 66.06  ? ? ? ? ? ? 306 ILE B CG2   1 
+ATOM   6356 C CD1   . ILE D 3 312 ? 82.426  51.389 92.128  1.00 68.98  ? ? ? ? ? ? 306 ILE B CD1   1 
+ATOM   6357 N N     . PRO D 3 313 ? 81.827  54.543 87.708  1.00 60.74  ? ? ? ? ? ? 307 PRO B N     1 
+ATOM   6358 C CA    . PRO D 3 313 ? 81.202  55.340 86.658  1.00 60.45  ? ? ? ? ? ? 307 PRO B CA    1 
+ATOM   6359 C C     . PRO D 3 313 ? 81.643  54.852 85.293  1.00 66.14  ? ? ? ? ? ? 307 PRO B C     1 
+ATOM   6360 O O     . PRO D 3 313 ? 80.947  55.051 84.299  1.00 65.09  ? ? ? ? ? ? 307 PRO B O     1 
+ATOM   6361 C CB    . PRO D 3 313 ? 81.796  56.729 86.878  1.00 62.28  ? ? ? ? ? ? 307 PRO B CB    1 
+ATOM   6362 C CG    . PRO D 3 313 ? 82.143  56.782 88.331  1.00 66.97  ? ? ? ? ? ? 307 PRO B CG    1 
+ATOM   6363 C CD    . PRO D 3 313 ? 82.273  55.371 88.842  1.00 61.50  ? ? ? ? ? ? 307 PRO B CD    1 
+ATOM   6364 N N     . GLU D 3 314 ? 82.830  54.250 85.255  1.00 65.31  ? ? ? ? ? ? 308 GLU B N     1 
+ATOM   6365 C CA    . GLU D 3 314 ? 83.417  53.731 84.019  1.00 64.34  ? ? ? ? ? ? 308 GLU B CA    1 
+ATOM   6366 C C     . GLU D 3 314 ? 83.007  52.284 83.784  1.00 55.22  ? ? ? ? ? ? 308 GLU B C     1 
+ATOM   6367 O O     . GLU D 3 314 ? 82.638  51.909 82.674  1.00 51.13  ? ? ? ? ? ? 308 GLU B O     1 
+ATOM   6368 C CB    . GLU D 3 314 ? 84.946  53.876 84.005  1.00 67.73  ? ? ? ? ? ? 308 GLU B CB    1 
+ATOM   6369 C CG    . GLU D 3 314 ? 85.532  54.169 82.620  1.00 88.57  ? ? ? ? ? ? 308 GLU B CG    1 
+ATOM   6370 C CD    . GLU D 3 314 ? 86.966  54.698 82.643  1.00 100.00 ? ? ? ? ? ? 308 GLU B CD    1 
+ATOM   6371 O OE1   . GLU D 3 314 ? 87.476  55.039 83.734  1.00 100.00 ? ? ? ? ? ? 308 GLU B OE1   1 
+ATOM   6372 O OE2   . GLU D 3 314 ? 87.572  54.759 81.548  1.00 94.64  ? ? ? ? ? ? 308 GLU B OE2   1 
+ATOM   6373 N N     . ILE D 3 315 ? 83.068  51.485 84.842  1.00 49.43  ? ? ? ? ? ? 309 ILE B N     1 
+ATOM   6374 C CA    . ILE D 3 315 ? 82.636  50.106 84.740  1.00 48.85  ? ? ? ? ? ? 309 ILE B CA    1 
+ATOM   6375 C C     . ILE D 3 315 ? 81.215  50.167 84.188  1.00 60.77  ? ? ? ? ? ? 309 ILE B C     1 
+ATOM   6376 O O     . ILE D 3 315 ? 80.785  49.293 83.441  1.00 61.43  ? ? ? ? ? ? 309 ILE B O     1 
+ATOM   6377 C CB    . ILE D 3 315 ? 82.509  49.460 86.110  1.00 49.06  ? ? ? ? ? ? 309 ILE B CB    1 
+ATOM   6378 C CG1   . ILE D 3 315 ? 83.874  49.340 86.773  1.00 45.81  ? ? ? ? ? ? 309 ILE B CG1   1 
+ATOM   6379 C CG2   . ILE D 3 315 ? 81.823  48.109 85.988  1.00 50.12  ? ? ? ? ? ? 309 ILE B CG2   1 
+ATOM   6380 C CD1   . ILE D 3 315 ? 83.965  48.185 87.740  1.00 48.20  ? ? ? ? ? ? 309 ILE B CD1   1 
+ATOM   6381 N N     . MET D 3 316 ? 80.485  51.212 84.569  1.00 63.44  ? ? ? ? ? ? 310 MET B N     1 
+ATOM   6382 C CA    . MET D 3 316 ? 79.103  51.398 84.145  1.00 64.84  ? ? ? ? ? ? 310 MET B CA    1 
+ATOM   6383 C C     . MET D 3 316 ? 78.855  51.711 82.661  1.00 64.42  ? ? ? ? ? ? 310 MET B C     1 
+ATOM   6384 O O     . MET D 3 316 ? 77.958  51.122 82.054  1.00 64.43  ? ? ? ? ? ? 310 MET B O     1 
+ATOM   6385 C CB    . MET D 3 316 ? 78.347  52.338 85.103  1.00 69.69  ? ? ? ? ? ? 310 MET B CB    1 
+ATOM   6386 C CG    . MET D 3 316 ? 78.079  51.744 86.505  1.00 76.25  ? ? ? ? ? ? 310 MET B CG    1 
+ATOM   6387 S SD    . MET D 3 316 ? 77.386  52.903 87.733  1.00 82.78  ? ? ? ? ? ? 310 MET B SD    1 
+ATOM   6388 C CE    . MET D 3 316 ? 76.609  54.107 86.639  1.00 78.81  ? ? ? ? ? ? 310 MET B CE    1 
+ATOM   6389 N N     . GLN D 3 317 ? 79.637  52.605 82.058  1.00 58.28  ? ? ? ? ? ? 311 GLN B N     1 
+ATOM   6390 C CA    . GLN D 3 317 ? 79.443  52.893 80.632  1.00 57.03  ? ? ? ? ? ? 311 GLN B CA    1 
+ATOM   6391 C C     . GLN D 3 317 ? 79.779  51.650 79.812  1.00 63.64  ? ? ? ? ? ? 311 GLN B C     1 
+ATOM   6392 O O     . GLN D 3 317 ? 79.151  51.399 78.783  1.00 65.28  ? ? ? ? ? ? 311 GLN B O     1 
+ATOM   6393 C CB    . GLN D 3 317 ? 80.285  54.074 80.132  1.00 57.51  ? ? ? ? ? ? 311 GLN B CB    1 
+ATOM   6394 C CG    . GLN D 3 317 ? 80.644  53.995 78.640  1.00 68.34  ? ? ? ? ? ? 311 GLN B CG    1 
+ATOM   6395 C CD    . GLN D 3 317 ? 79.522  54.463 77.727  1.00 100.00 ? ? ? ? ? ? 311 GLN B CD    1 
+ATOM   6396 O OE1   . GLN D 3 317 ? 78.794  55.396 78.062  1.00 100.00 ? ? ? ? ? ? 311 GLN B OE1   1 
+ATOM   6397 N NE2   . GLN D 3 317 ? 79.368  53.809 76.578  1.00 100.00 ? ? ? ? ? ? 311 GLN B NE2   1 
+ATOM   6398 N N     . ALA D 3 318 ? 80.778  50.889 80.262  1.00 57.65  ? ? ? ? ? ? 312 ALA B N     1 
+ATOM   6399 C CA    . ALA D 3 318 ? 81.204  49.658 79.588  1.00 55.19  ? ? ? ? ? ? 312 ALA B CA    1 
+ATOM   6400 C C     . ALA D 3 318 ? 80.026  48.713 79.379  1.00 57.70  ? ? ? ? ? ? 312 ALA B C     1 
+ATOM   6401 O O     . ALA D 3 318 ? 79.809  48.205 78.275  1.00 53.13  ? ? ? ? ? ? 312 ALA B O     1 
+ATOM   6402 C CB    . ALA D 3 318 ? 82.289  48.959 80.390  1.00 55.74  ? ? ? ? ? ? 312 ALA B CB    1 
+ATOM   6403 N N     . GLY D 3 319 ? 79.269  48.488 80.451  1.00 57.80  ? ? ? ? ? ? 313 GLY B N     1 
+ATOM   6404 C CA    . GLY D 3 319 ? 78.093  47.618 80.421  1.00 58.29  ? ? ? ? ? ? 313 GLY B CA    1 
+ATOM   6405 C C     . GLY D 3 319 ? 76.820  48.328 79.959  1.00 62.58  ? ? ? ? ? ? 313 GLY B C     1 
+ATOM   6406 O O     . GLY D 3 319 ? 75.789  47.689 79.777  1.00 62.61  ? ? ? ? ? ? 313 GLY B O     1 
+ATOM   6407 N N     . GLY D 3 320 ? 76.887  49.642 79.771  1.00 60.69  ? ? ? ? ? ? 314 GLY B N     1 
+ATOM   6408 C CA    . GLY D 3 320 ? 75.730  50.414 79.305  1.00 61.28  ? ? ? ? ? ? 314 GLY B CA    1 
+ATOM   6409 C C     . GLY D 3 320 ? 74.628  50.618 80.348  1.00 66.65  ? ? ? ? ? ? 314 GLY B C     1 
+ATOM   6410 O O     . GLY D 3 320 ? 73.504  51.020 80.017  1.00 64.98  ? ? ? ? ? ? 314 GLY B O     1 
+ATOM   6411 N N     . TRP D 3 321 ? 74.969  50.369 81.606  1.00 66.19  ? ? ? ? ? ? 315 TRP B N     1 
+ATOM   6412 C CA    . TRP D 3 321 ? 74.048  50.498 82.731  1.00 69.99  ? ? ? ? ? ? 315 TRP B CA    1 
+ATOM   6413 C C     . TRP D 3 321 ? 73.770  51.943 83.122  1.00 77.97  ? ? ? ? ? ? 315 TRP B C     1 
+ATOM   6414 O O     . TRP D 3 321 ? 74.711  52.688 83.384  1.00 80.61  ? ? ? ? ? ? 315 TRP B O     1 
+ATOM   6415 C CB    . TRP D 3 321 ? 74.687  49.863 83.960  1.00 70.81  ? ? ? ? ? ? 315 TRP B CB    1 
+ATOM   6416 C CG    . TRP D 3 321 ? 74.756  48.375 83.972  1.00 74.33  ? ? ? ? ? ? 315 TRP B CG    1 
+ATOM   6417 C CD1   . TRP D 3 321 ? 73.744  47.503 84.229  1.00 77.85  ? ? ? ? ? ? 315 TRP B CD1   1 
+ATOM   6418 C CD2   . TRP D 3 321 ? 75.935  47.573 83.796  1.00 75.18  ? ? ? ? ? ? 315 TRP B CD2   1 
+ATOM   6419 N NE1   . TRP D 3 321 ? 74.215  46.209 84.254  1.00 78.28  ? ? ? ? ? ? 315 TRP B NE1   1 
+ATOM   6420 C CE2   . TRP D 3 321 ? 75.557  46.225 83.971  1.00 80.02  ? ? ? ? ? ? 315 TRP B CE2   1 
+ATOM   6421 C CE3   . TRP D 3 321 ? 77.270  47.860 83.524  1.00 76.16  ? ? ? ? ? ? 315 TRP B CE3   1 
+ATOM   6422 C CZ2   . TRP D 3 321 ? 76.474  45.170 83.845  1.00 78.83  ? ? ? ? ? ? 315 TRP B CZ2   1 
+ATOM   6423 C CZ3   . TRP D 3 321 ? 78.179  46.812 83.370  1.00 76.80  ? ? ? ? ? ? 315 TRP B CZ3   1 
+ATOM   6424 C CH2   . TRP D 3 321 ? 77.771  45.485 83.602  1.00 77.20  ? ? ? ? ? ? 315 TRP B CH2   1 
+ATOM   6425 N N     . THR D 3 322 ? 72.505  52.335 83.241  1.00 71.97  ? ? ? ? ? ? 316 THR B N     1 
+ATOM   6426 C CA    . THR D 3 322 ? 72.233  53.690 83.683  1.00 69.22  ? ? ? ? ? ? 316 THR B CA    1 
+ATOM   6427 C C     . THR D 3 322 ? 72.104  53.725 85.206  1.00 71.63  ? ? ? ? ? ? 316 THR B C     1 
+ATOM   6428 O O     . THR D 3 322 ? 71.599  54.700 85.757  1.00 74.65  ? ? ? ? ? ? 316 THR B O     1 
+ATOM   6429 C CB    . THR D 3 322 ? 71.019  54.318 82.979  1.00 80.36  ? ? ? ? ? ? 316 THR B CB    1 
+ATOM   6430 O OG1   . THR D 3 322 ? 69.865  53.493 83.169  1.00 85.18  ? ? ? ? ? ? 316 THR B OG1   1 
+ATOM   6431 C CG2   . THR D 3 322 ? 71.301  54.457 81.499  1.00 82.22  ? ? ? ? ? ? 316 THR B CG2   1 
+ATOM   6432 N N     . ASN D 3 323 ? 72.587  52.685 85.893  1.00 65.29  ? ? ? ? ? ? 317 ASN B N     1 
+ATOM   6433 C CA    . ASN D 3 323 ? 72.504  52.623 87.359  1.00 65.07  ? ? ? ? ? ? 317 ASN B CA    1 
+ATOM   6434 C C     . ASN D 3 323 ? 73.637  51.828 88.053  1.00 73.19  ? ? ? ? ? ? 317 ASN B C     1 
+ATOM   6435 O O     . ASN D 3 323 ? 74.503  51.303 87.357  1.00 78.18  ? ? ? ? ? ? 317 ASN B O     1 
+ATOM   6436 C CB    . ASN D 3 323 ? 71.122  52.113 87.751  0.00 65.73  ? ? ? ? ? ? 317 ASN B CB    1 
+ATOM   6437 C CG    . ASN D 3 323 ? 70.899  52.126 89.237  0.00 87.36  ? ? ? ? ? ? 317 ASN B CG    1 
+ATOM   6438 O OD1   . ASN D 3 323 ? 71.000  53.164 89.890  0.00 81.58  ? ? ? ? ? ? 317 ASN B OD1   1 
+ATOM   6439 N ND2   . ASN D 3 323 ? 70.598  50.958 89.790  0.00 79.12  ? ? ? ? ? ? 317 ASN B ND2   1 
+ATOM   6440 N N     . VAL D 3 324 ? 73.661  51.730 89.387  1.00 67.85  ? ? ? ? ? ? 318 VAL B N     1 
+ATOM   6441 C CA    . VAL D 3 324 ? 74.756  51.059 90.109  1.00 68.30  ? ? ? ? ? ? 318 VAL B CA    1 
+ATOM   6442 C C     . VAL D 3 324 ? 74.677  49.710 90.832  1.00 76.60  ? ? ? ? ? ? 318 VAL B C     1 
+ATOM   6443 O O     . VAL D 3 324 ? 75.687  49.233 91.336  1.00 75.55  ? ? ? ? ? ? 318 VAL B O     1 
+ATOM   6444 C CB    . VAL D 3 324 ? 75.314  52.006 91.170  1.00 73.10  ? ? ? ? ? ? 318 VAL B CB    1 
+ATOM   6445 C CG1   . VAL D 3 324 ? 76.001  53.187 90.503  1.00 73.70  ? ? ? ? ? ? 318 VAL B CG1   1 
+ATOM   6446 C CG2   . VAL D 3 324 ? 74.200  52.473 92.092  1.00 72.78  ? ? ? ? ? ? 318 VAL B CG2   1 
+ATOM   6447 N N     . ASN D 3 325 ? 73.503  49.106 90.929  1.00 78.58  ? ? ? ? ? ? 319 ASN B N     1 
+ATOM   6448 C CA    . ASN D 3 325 ? 73.318  47.851 91.664  1.00 80.29  ? ? ? ? ? ? 319 ASN B CA    1 
+ATOM   6449 C C     . ASN D 3 325 ? 73.848  46.522 91.081  1.00 86.98  ? ? ? ? ? ? 319 ASN B C     1 
+ATOM   6450 O O     . ASN D 3 325 ? 74.649  45.836 91.718  1.00 84.85  ? ? ? ? ? ? 319 ASN B O     1 
+ATOM   6451 C CB    . ASN D 3 325 ? 71.853  47.743 92.098  1.00 81.60  ? ? ? ? ? ? 319 ASN B CB    1 
+ATOM   6452 C CG    . ASN D 3 325 ? 71.235  49.101 92.406  1.00 81.01  ? ? ? ? ? ? 319 ASN B CG    1 
+ATOM   6453 O OD1   . ASN D 3 325 ? 71.771  50.143 92.025  1.00 71.10  ? ? ? ? ? ? 319 ASN B OD1   1 
+ATOM   6454 N ND2   . ASN D 3 325 ? 70.097  49.091 93.089  1.00 69.28  ? ? ? ? ? ? 319 ASN B ND2   1 
+ATOM   6455 N N     . ILE D 3 326 ? 73.379  46.139 89.893  1.00 87.37  ? ? ? ? ? ? 320 ILE B N     1 
+ATOM   6456 C CA    . ILE D 3 326 ? 73.827  44.903 89.241  1.00 87.33  ? ? ? ? ? ? 320 ILE B CA    1 
+ATOM   6457 C C     . ILE D 3 326 ? 75.330  44.962 89.370  1.00 88.33  ? ? ? ? ? ? 320 ILE B C     1 
+ATOM   6458 O O     . ILE D 3 326 ? 75.985  44.092 89.946  1.00 85.57  ? ? ? ? ? ? 320 ILE B O     1 
+ATOM   6459 C CB    . ILE D 3 326 ? 73.535  44.900 87.697  1.00 90.65  ? ? ? ? ? ? 320 ILE B CB    1 
+ATOM   6460 C CG1   . ILE D 3 326 ? 73.679  46.294 87.063  1.00 89.69  ? ? ? ? ? ? 320 ILE B CG1   1 
+ATOM   6461 C CG2   . ILE D 3 326 ? 72.190  44.274 87.383  1.00 94.17  ? ? ? ? ? ? 320 ILE B CG2   1 
+ATOM   6462 C CD1   . ILE D 3 326 ? 72.640  47.330 87.480  1.00 89.61  ? ? ? ? ? ? 320 ILE B CD1   1 
+ATOM   6463 N N     . VAL D 3 327 ? 75.835  46.057 88.819  1.00 84.36  ? ? ? ? ? ? 321 VAL B N     1 
+ATOM   6464 C CA    . VAL D 3 327 ? 77.239  46.382 88.792  1.00 83.72  ? ? ? ? ? ? 321 VAL B CA    1 
+ATOM   6465 C C     . VAL D 3 327 ? 77.807  46.062 90.151  1.00 83.73  ? ? ? ? ? ? 321 VAL B C     1 
+ATOM   6466 O O     . VAL D 3 327 ? 78.811  45.362 90.272  1.00 83.23  ? ? ? ? ? ? 321 VAL B O     1 
+ATOM   6467 C CB    . VAL D 3 327 ? 77.405  47.882 88.528  1.00 88.99  ? ? ? ? ? ? 321 VAL B CB    1 
+ATOM   6468 C CG1   . VAL D 3 327 ? 78.816  48.197 88.042  1.00 89.09  ? ? ? ? ? ? 321 VAL B CG1   1 
+ATOM   6469 C CG2   . VAL D 3 327 ? 76.343  48.375 87.548  1.00 88.46  ? ? ? ? ? ? 321 VAL B CG2   1 
+ATOM   6470 N N     . MET D 3 328 ? 77.153  46.595 91.173  1.00 79.25  ? ? ? ? ? ? 322 MET B N     1 
+ATOM   6471 C CA    . MET D 3 328 ? 77.591  46.358 92.532  1.00 79.78  ? ? ? ? ? ? 322 MET B CA    1 
+ATOM   6472 C C     . MET D 3 328 ? 77.598  44.862 92.803  1.00 86.64  ? ? ? ? ? ? 322 MET B C     1 
+ATOM   6473 O O     . MET D 3 328 ? 78.575  44.339 93.293  1.00 86.61  ? ? ? ? ? ? 322 MET B O     1 
+ATOM   6474 C CB    . MET D 3 328 ? 76.658  47.058 93.518  1.00 82.15  ? ? ? ? ? ? 322 MET B CB    1 
+ATOM   6475 C CG    . MET D 3 328 ? 76.927  48.532 93.736  1.00 85.47  ? ? ? ? ? ? 322 MET B CG    1 
+ATOM   6476 S SD    . MET D 3 328 ? 78.519  49.083 93.138  1.00 89.12  ? ? ? ? ? ? 322 MET B SD    1 
+ATOM   6477 C CE    . MET D 3 328 ? 79.529  48.640 94.539  1.00 84.79  ? ? ? ? ? ? 322 MET B CE    1 
+ATOM   6478 N N     . ASN D 3 329 ? 76.520  44.172 92.445  1.00 83.89  ? ? ? ? ? ? 323 ASN B N     1 
+ATOM   6479 C CA    . ASN D 3 329 ? 76.376  42.738 92.693  1.00 83.18  ? ? ? ? ? ? 323 ASN B CA    1 
+ATOM   6480 C C     . ASN D 3 329 ? 77.516  41.846 92.201  1.00 84.42  ? ? ? ? ? ? 323 ASN B C     1 
+ATOM   6481 O O     . ASN D 3 329 ? 78.013  41.004 92.949  1.00 83.28  ? ? ? ? ? ? 323 ASN B O     1 
+ATOM   6482 C CB    . ASN D 3 329 ? 75.017  42.198 92.209  1.00 84.28  ? ? ? ? ? ? 323 ASN B CB    1 
+ATOM   6483 C CG    . ASN D 3 329 ? 74.392  41.205 93.191  1.00 92.44  ? ? ? ? ? ? 323 ASN B CG    1 
+ATOM   6484 O OD1   . ASN D 3 329 ? 74.040  41.568 94.317  1.00 86.75  ? ? ? ? ? ? 323 ASN B OD1   1 
+ATOM   6485 N ND2   . ASN D 3 329 ? 74.247  39.952 92.769  1.00 76.31  ? ? ? ? ? ? 323 ASN B ND2   1 
+ATOM   6486 N N     . TYR D 3 330 ? 77.913  42.038 90.945  1.00 79.73  ? ? ? ? ? ? 324 TYR B N     1 
+ATOM   6487 C CA    . TYR D 3 330 ? 78.962  41.256 90.282  1.00 76.91  ? ? ? ? ? ? 324 TYR B CA    1 
+ATOM   6488 C C     . TYR D 3 330 ? 80.430  41.162 90.780  1.00 86.46  ? ? ? ? ? ? 324 TYR B C     1 
+ATOM   6489 O O     . TYR D 3 330 ? 81.155  40.289 90.301  1.00 88.69  ? ? ? ? ? ? 324 TYR B O     1 
+ATOM   6490 C CB    . TYR D 3 330 ? 78.969  41.645 88.791  1.00 72.64  ? ? ? ? ? ? 324 TYR B CB    1 
+ATOM   6491 C CG    . TYR D 3 330 ? 77.742  41.287 87.958  1.00 69.36  ? ? ? ? ? ? 324 TYR B CG    1 
+ATOM   6492 C CD1   . TYR D 3 330 ? 77.519  41.900 86.725  1.00 71.54  ? ? ? ? ? ? 324 TYR B CD1   1 
+ATOM   6493 C CD2   . TYR D 3 330 ? 76.842  40.307 88.366  1.00 67.94  ? ? ? ? ? ? 324 TYR B CD2   1 
+ATOM   6494 C CE1   . TYR D 3 330 ? 76.421  41.571 85.932  1.00 72.63  ? ? ? ? ? ? 324 TYR B CE1   1 
+ATOM   6495 C CE2   . TYR D 3 330 ? 75.745  39.967 87.578  1.00 63.89  ? ? ? ? ? ? 324 TYR B CE2   1 
+ATOM   6496 C CZ    . TYR D 3 330 ? 75.534  40.607 86.371  1.00 74.40  ? ? ? ? ? ? 324 TYR B CZ    1 
+ATOM   6497 O OH    . TYR D 3 330 ? 74.453  40.284 85.590  1.00 72.43  ? ? ? ? ? ? 324 TYR B OH    1 
+ATOM   6498 N N     . ILE D 3 331 ? 80.907  42.021 91.685  1.00 83.79  ? ? ? ? ? ? 325 ILE B N     1 
+ATOM   6499 C CA    . ILE D 3 331 ? 82.333  41.960 92.065  1.00 84.26  ? ? ? ? ? ? 325 ILE B CA    1 
+ATOM   6500 C C     . ILE D 3 331 ? 82.848  41.445 93.414  1.00 90.71  ? ? ? ? ? ? 325 ILE B C     1 
+ATOM   6501 O O     . ILE D 3 331 ? 83.994  41.022 93.509  1.00 93.18  ? ? ? ? ? ? 325 ILE B O     1 
+ATOM   6502 C CB    . ILE D 3 331 ? 83.082  43.303 91.809  1.00 86.93  ? ? ? ? ? ? 325 ILE B CB    1 
+ATOM   6503 C CG1   . ILE D 3 331 ? 82.914  44.260 93.002  1.00 88.16  ? ? ? ? ? ? 325 ILE B CG1   1 
+ATOM   6504 C CG2   . ILE D 3 331 ? 82.690  43.919 90.471  1.00 85.83  ? ? ? ? ? ? 325 ILE B CG2   1 
+ATOM   6505 C CD1   . ILE D 3 331 ? 83.209  45.717 92.690  1.00 100.00 ? ? ? ? ? ? 325 ILE B CD1   1 
+ATOM   6506 N N     . ARG D 3 332 ? 82.013  41.538 94.447  1.00 87.71  ? ? ? ? ? ? 326 ARG B N     1 
+ATOM   6507 C CA    . ARG D 3 332 ? 82.270  41.251 95.876  1.00 89.02  ? ? ? ? ? ? 326 ARG B CA    1 
+ATOM   6508 C C     . ARG D 3 332 ? 82.888  40.006 96.573  1.00 94.80  ? ? ? ? ? ? 326 ARG B C     1 
+ATOM   6509 O O     . ARG D 3 332 ? 83.303  39.048 95.905  1.00 94.63  ? ? ? ? ? ? 326 ARG B O     1 
+ATOM   6510 C CB    . ARG D 3 332 ? 81.026  41.698 96.633  1.00 91.88  ? ? ? ? ? ? 326 ARG B CB    1 
+ATOM   6511 C CG    . ARG D 3 332 ? 80.669  43.151 96.498  1.00 100.00 ? ? ? ? ? ? 326 ARG B CG    1 
+ATOM   6512 C CD    . ARG D 3 332 ? 79.346  43.367 95.763  1.00 92.02  ? ? ? ? ? ? 326 ARG B CD    1 
+ATOM   6513 N NE    . ARG D 3 332 ? 78.705  44.646 96.089  1.00 91.12  ? ? ? ? ? ? 326 ARG B NE    1 
+ATOM   6514 C CZ    . ARG D 3 332 ? 79.355  45.786 96.266  1.00 100.00 ? ? ? ? ? ? 326 ARG B CZ    1 
+ATOM   6515 N NH1   . ARG D 3 332 ? 80.660  45.903 96.082  1.00 92.71  ? ? ? ? ? ? 326 ARG B NH1   1 
+ATOM   6516 N NH2   . ARG D 3 332 ? 78.666  46.869 96.552  1.00 99.63  ? ? ? ? ? ? 326 ARG B NH2   1 
+ATOM   6517 N N     . ASN D 3 333 ? 82.967  40.065 97.923  1.00 93.01  ? ? ? ? ? ? 327 ASN B N     1 
+ATOM   6518 C CA    . ASN D 3 333 ? 83.504  39.030 98.865  1.00 93.84  ? ? ? ? ? ? 327 ASN B CA    1 
+ATOM   6519 C C     . ASN D 3 333 ? 82.733  37.697 98.861  1.00 98.19  ? ? ? ? ? ? 327 ASN B C     1 
+ATOM   6520 O O     . ASN D 3 333 ? 83.297  36.639 98.470  1.00 99.93  ? ? ? ? ? ? 327 ASN B O     1 
+ATOM   6521 C CB    . ASN D 3 333 ? 84.005  39.475 100.303 1.00 96.25  ? ? ? ? ? ? 327 ASN B CB    1 
+ATOM   6522 C CG    . ASN D 3 333 ? 83.092  40.486 101.116 1.00 100.00 ? ? ? ? ? ? 327 ASN B CG    1 
+ATOM   6523 O OD1   . ASN D 3 333 ? 81.904  40.700 100.821 1.00 97.23  ? ? ? ? ? ? 327 ASN B OD1   1 
+ATOM   6524 N ND2   . ASN D 3 333 ? 83.684  41.071 102.161 1.00 94.13  ? ? ? ? ? ? 327 ASN B ND2   1 
+ATOM   6525 N N     . LEU D 3 334 ? 81.461  37.770 99.203  1.00 92.68  ? ? ? ? ? ? 328 LEU B N     1 
+ATOM   6526 C CA    . LEU D 3 334 ? 80.450  36.715 99.127  1.00 97.82  ? ? ? ? ? ? 328 LEU B CA    1 
+ATOM   6527 C C     . LEU D 3 334 ? 80.897  35.338 98.646  1.00 100.00 ? ? ? ? ? ? 328 LEU B C     1 
+ATOM   6528 O O     . LEU D 3 334 ? 80.739  34.360 99.381  1.00 91.20  ? ? ? ? ? ? 328 LEU B O     1 
+ATOM   6529 C CB    . LEU D 3 334 ? 79.172  37.206 98.414  1.00 97.35  ? ? ? ? ? ? 328 LEU B CB    1 
+ATOM   6530 C CG    . LEU D 3 334 ? 78.817  38.668 98.774  1.00 100.00 ? ? ? ? ? ? 328 LEU B CG    1 
+ATOM   6531 C CD1   . LEU D 3 334 ? 79.768  39.820 98.580  1.00 100.00 ? ? ? ? ? ? 328 LEU B CD1   1 
+ATOM   6532 C CD2   . LEU D 3 334 ? 77.774  39.113 97.895  1.00 100.00 ? ? ? ? ? ? 328 LEU B CD2   1 
+ATOM   6533 N N     . GLY D 3 339 ? 91.092  40.220 105.067 1.00 99.00  ? ? ? ? ? ? 333 GLY B N     1 
+ATOM   6534 C CA    . GLY D 3 339 ? 90.947  41.300 104.093 1.00 97.76  ? ? ? ? ? ? 333 GLY B CA    1 
+ATOM   6535 C C     . GLY D 3 339 ? 91.576  42.613 104.534 1.00 98.65  ? ? ? ? ? ? 333 GLY B C     1 
+ATOM   6536 O O     . GLY D 3 339 ? 92.676  42.652 105.087 1.00 97.28  ? ? ? ? ? ? 333 GLY B O     1 
+ATOM   6537 N N     . ALA D 3 340 ? 90.846  43.686 104.259 1.00 94.54  ? ? ? ? ? ? 334 ALA B N     1 
+ATOM   6538 C CA    . ALA D 3 340 ? 91.289  45.021 104.603 1.00 93.92  ? ? ? ? ? ? 334 ALA B CA    1 
+ATOM   6539 C C     . ALA D 3 340 ? 91.435  45.163 106.110 1.00 96.56  ? ? ? ? ? ? 334 ALA B C     1 
+ATOM   6540 O O     . ALA D 3 340 ? 92.376  45.808 106.574 1.00 97.62  ? ? ? ? ? ? 334 ALA B O     1 
+ATOM   6541 C CB    . ALA D 3 340 ? 90.302  46.051 104.077 1.00 94.32  ? ? ? ? ? ? 334 ALA B CB    1 
+ATOM   6542 N N     . MET D 3 341 ? 90.492  44.603 106.870 1.00 87.20  ? ? ? ? ? ? 335 MET B N     1 
+ATOM   6543 C CA    . MET D 3 341 ? 90.505  44.730 108.329 1.00 83.16  ? ? ? ? ? ? 335 MET B CA    1 
+ATOM   6544 C C     . MET D 3 341 ? 91.589  43.897 108.982 1.00 80.77  ? ? ? ? ? ? 335 MET B C     1 
+ATOM   6545 O O     . MET D 3 341 ? 91.971  44.109 110.131 1.00 78.95  ? ? ? ? ? ? 335 MET B O     1 
+ATOM   6546 C CB    . MET D 3 341 ? 89.130  44.455 108.949 1.00 84.47  ? ? ? ? ? ? 335 MET B CB    1 
+ATOM   6547 C CG    . MET D 3 341 ? 88.173  45.647 108.926 1.00 85.26  ? ? ? ? ? ? 335 MET B CG    1 
+ATOM   6548 S SD    . MET D 3 341 ? 88.614  47.066 109.955 1.00 86.49  ? ? ? ? ? ? 335 MET B SD    1 
+ATOM   6549 C CE    . MET D 3 341 ? 89.906  46.373 111.005 1.00 82.81  ? ? ? ? ? ? 335 MET B CE    1 
+ATOM   6550 N N     . VAL D 3 342 ? 92.130  42.992 108.182 1.00 77.40  ? ? ? ? ? ? 336 VAL B N     1 
+ATOM   6551 C CA    . VAL D 3 342 ? 93.201  42.122 108.621 1.00 79.98  ? ? ? ? ? ? 336 VAL B CA    1 
+ATOM   6552 C C     . VAL D 3 342 ? 94.623  42.636 108.345 1.00 90.63  ? ? ? ? ? ? 336 VAL B C     1 
+ATOM   6553 O O     . VAL D 3 342 ? 95.550  41.842 108.216 1.00 92.19  ? ? ? ? ? ? 336 VAL B O     1 
+ATOM   6554 C CB    . VAL D 3 342 ? 93.015  40.718 108.035 1.00 84.74  ? ? ? ? ? ? 336 VAL B CB    1 
+ATOM   6555 C CG1   . VAL D 3 342 ? 93.625  39.669 108.957 1.00 85.37  ? ? ? ? ? ? 336 VAL B CG1   1 
+ATOM   6556 C CG2   . VAL D 3 342 ? 91.537  40.440 107.817 1.00 84.32  ? ? ? ? ? ? 336 VAL B CG2   1 
+ATOM   6557 N N     . ARG D 3 343 ? 94.803  43.948 108.261 1.00 89.07  ? ? ? ? ? ? 337 ARG B N     1 
+ATOM   6558 C CA    . ARG D 3 343 ? 96.120  44.533 108.024 1.00 87.58  ? ? ? ? ? ? 337 ARG B CA    1 
+ATOM   6559 C C     . ARG D 3 343 ? 96.215  45.672 109.019 1.00 88.17  ? ? ? ? ? ? 337 ARG B C     1 
+ATOM   6560 O O     . ARG D 3 343 ? 97.278  45.952 109.574 1.00 86.44  ? ? ? ? ? ? 337 ARG B O     1 
+ATOM   6561 C CB    . ARG D 3 343 ? 96.217  45.062 106.596 1.00 88.81  ? ? ? ? ? ? 337 ARG B CB    1 
+ATOM   6562 C CG    . ARG D 3 343 ? 96.294  43.961 105.552 1.00 99.01  ? ? ? ? ? ? 337 ARG B CG    1 
+ATOM   6563 C CD    . ARG D 3 343 ? 95.334  44.208 104.397 1.00 100.00 ? ? ? ? ? ? 337 ARG B CD    1 
+ATOM   6564 N NE    . ARG D 3 343 ? 95.139  45.633 104.127 1.00 99.60  ? ? ? ? ? ? 337 ARG B NE    1 
+ATOM   6565 C CZ    . ARG D 3 343 ? 94.698  46.131 102.979 1.00 100.00 ? ? ? ? ? ? 337 ARG B CZ    1 
+ATOM   6566 N NH1   . ARG D 3 343 ? 94.365  45.321 101.980 1.00 80.93  ? ? ? ? ? ? 337 ARG B NH1   1 
+ATOM   6567 N NH2   . ARG D 3 343 ? 94.557  47.442 102.831 1.00 99.14  ? ? ? ? ? ? 337 ARG B NH2   1 
+ATOM   6568 N N     . LEU D 3 344 ? 95.075  46.317 109.243 1.00 84.59  ? ? ? ? ? ? 338 LEU B N     1 
+ATOM   6569 C CA    . LEU D 3 344 ? 95.006  47.365 110.239 1.00 83.41  ? ? ? ? ? ? 338 LEU B CA    1 
+ATOM   6570 C C     . LEU D 3 344 ? 95.377  46.486 111.416 1.00 89.52  ? ? ? ? ? ? 338 LEU B C     1 
+ATOM   6571 O O     . LEU D 3 344 ? 96.465  46.603 111.983 1.00 91.67  ? ? ? ? ? ? 338 LEU B O     1 
+ATOM   6572 C CB    . LEU D 3 344 ? 93.569  47.863 110.403 1.00 82.33  ? ? ? ? ? ? 338 LEU B CB    1 
+ATOM   6573 C CG    . LEU D 3 344 ? 93.321  49.201 109.714 1.00 86.41  ? ? ? ? ? ? 338 LEU B CG    1 
+ATOM   6574 C CD1   . LEU D 3 344 ? 91.836  49.477 109.588 1.00 86.61  ? ? ? ? ? ? 338 LEU B CD1   1 
+ATOM   6575 C CD2   . LEU D 3 344 ? 94.023  50.326 110.460 1.00 87.53  ? ? ? ? ? ? 338 LEU B CD2   1 
+ATOM   6576 N N     . LEU D 3 345 ? 94.501  45.539 111.727 1.00 82.75  ? ? ? ? ? ? 339 LEU B N     1 
+ATOM   6577 C CA    . LEU D 3 345 ? 94.814  44.644 112.822 1.00 80.56  ? ? ? ? ? ? 339 LEU B CA    1 
+ATOM   6578 C C     . LEU D 3 345 ? 96.191  44.003 112.690 1.00 82.57  ? ? ? ? ? ? 339 LEU B C     1 
+ATOM   6579 O O     . LEU D 3 345 ? 97.048  44.217 113.542 1.00 81.21  ? ? ? ? ? ? 339 LEU B O     1 
+ATOM   6580 C CB    . LEU D 3 345 ? 93.689  43.650 113.111 1.00 79.94  ? ? ? ? ? ? 339 LEU B CB    1 
+ATOM   6581 C CG    . LEU D 3 345 ? 92.348  44.300 113.483 1.00 82.70  ? ? ? ? ? ? 339 LEU B CG    1 
+ATOM   6582 C CD1   . LEU D 3 345 ? 91.175  43.440 113.039 1.00 81.91  ? ? ? ? ? ? 339 LEU B CD1   1 
+ATOM   6583 C CD2   . LEU D 3 345 ? 92.210  44.674 114.955 1.00 81.25  ? ? ? ? ? ? 339 LEU B CD2   1 
+ATOM   6584 N N     . GLU D 3 346 ? 96.411  43.248 111.618 1.00 79.74  ? ? ? ? ? ? 340 GLU B N     1 
+ATOM   6585 C CA    . GLU D 3 346 ? 97.690  42.581 111.383 1.00 80.32  ? ? ? ? ? ? 340 GLU B CA    1 
+ATOM   6586 C C     . GLU D 3 346 ? 98.893  43.520 111.498 1.00 86.61  ? ? ? ? ? ? 340 GLU B C     1 
+ATOM   6587 O O     . GLU D 3 346 ? 99.928  43.132 112.042 1.00 88.56  ? ? ? ? ? ? 340 GLU B O     1 
+ATOM   6588 C CB    . GLU D 3 346 ? 97.673  41.832 110.045 1.00 81.76  ? ? ? ? ? ? 340 GLU B CB    1 
+ATOM   6589 C CG    . GLU D 3 346 ? 97.062  40.436 110.100 1.00 88.25  ? ? ? ? ? ? 340 GLU B CG    1 
+ATOM   6590 C CD    . GLU D 3 346 ? 97.901  39.460 110.874 1.00 100.00 ? ? ? ? ? ? 340 GLU B CD    1 
+ATOM   6591 O OE1   . GLU D 3 346 ? 98.839  39.857 111.596 1.00 100.00 ? ? ? ? ? ? 340 GLU B OE1   1 
+ATOM   6592 O OE2   . GLU D 3 346 ? 97.522  38.305 110.821 1.00 100.00 ? ? ? ? ? ? 340 GLU B OE2   1 
+ATOM   6593 N N     . ASP D 3 347 ? 98.741  44.743 110.995 1.00 82.39  ? ? ? ? ? ? 341 ASP B N     1 
+ATOM   6594 C CA    . ASP D 3 347 ? 99.794  45.752 111.046 1.00 84.87  ? ? ? ? ? ? 341 ASP B CA    1 
+ATOM   6595 C C     . ASP D 3 347 ? 100.880 45.618 109.983 1.00 100.00 ? ? ? ? ? ? 341 ASP B C     1 
+ATOM   6596 O O     . ASP D 3 347 ? 101.541 46.596 109.629 1.00 100.00 ? ? ? ? ? ? 341 ASP B O     1 
+ATOM   6597 C CB    . ASP D 3 347 ? 100.388 45.857 112.446 1.00 85.86  ? ? ? ? ? ? 341 ASP B CB    1 
+ATOM   6598 C CG    . ASP D 3 347 ? 99.690  46.892 113.264 1.00 96.83  ? ? ? ? ? ? 341 ASP B CG    1 
+ATOM   6599 O OD1   . ASP D 3 347 ? 98.466  47.039 113.084 1.00 98.68  ? ? ? ? ? ? 341 ASP B OD1   1 
+ATOM   6600 O OD2   . ASP D 3 347 ? 100.353 47.577 114.065 1.00 100.00 ? ? ? ? ? ? 341 ASP B OD2   1 
+HETATM 6601 O O     . HOH E 4 .   ? 46.426  36.957 103.388 1.00 30.42  ? ? ? ? ? ? 344 HOH A O     1 
+HETATM 6602 O O     . HOH E 4 .   ? 80.411  53.864 130.822 1.00 63.19  ? ? ? ? ? ? 345 HOH A O     1 
+HETATM 6603 O O     . HOH E 4 .   ? 75.279  45.611 115.551 1.00 46.04  ? ? ? ? ? ? 346 HOH A O     1 
+HETATM 6604 O O     . HOH E 4 .   ? 30.510  39.647 105.547 1.00 44.27  ? ? ? ? ? ? 347 HOH A O     1 
+HETATM 6605 O O     . HOH E 4 .   ? 69.681  35.989 119.559 1.00 38.27  ? ? ? ? ? ? 348 HOH A O     1 
+HETATM 6606 O O     . HOH E 4 .   ? 68.092  44.551 122.726 1.00 37.32  ? ? ? ? ? ? 349 HOH A O     1 
+HETATM 6607 O O     . HOH E 4 .   ? 59.449  66.247 120.580 1.00 54.92  ? ? ? ? ? ? 350 HOH A O     1 
+HETATM 6608 O O     . HOH E 4 .   ? 74.049  32.999 132.496 1.00 53.00  ? ? ? ? ? ? 351 HOH A O     1 
+HETATM 6609 O O     . HOH E 4 .   ? 90.121  35.347 124.411 1.00 51.47  ? ? ? ? ? ? 352 HOH A O     1 
+HETATM 6610 O O     . HOH E 4 .   ? 81.258  35.073 138.848 1.00 53.07  ? ? ? ? ? ? 353 HOH A O     1 
+HETATM 6611 O O     . HOH E 4 .   ? 73.758  55.081 127.243 1.00 62.74  ? ? ? ? ? ? 354 HOH A O     1 
+HETATM 6612 O O     . HOH E 4 .   ? 67.353  41.361 115.577 1.00 49.54  ? ? ? ? ? ? 355 HOH A O     1 
+HETATM 6613 O O     . HOH E 4 .   ? 79.774  46.451 115.960 1.00 49.26  ? ? ? ? ? ? 356 HOH A O     1 
+HETATM 6614 O O     . HOH E 4 .   ? 39.948  59.574 115.633 1.00 52.29  ? ? ? ? ? ? 357 HOH A O     1 
+HETATM 6615 O O     . HOH E 4 .   ? 55.072  45.684 121.269 1.00 50.29  ? ? ? ? ? ? 358 HOH A O     1 
+HETATM 6616 O O     . HOH E 4 .   ? 67.892  44.531 119.550 1.00 66.01  ? ? ? ? ? ? 359 HOH A O     1 
+HETATM 6617 O O     . HOH E 4 .   ? 81.280  43.076 108.203 1.00 63.39  ? ? ? ? ? ? 360 HOH A O     1 
+HETATM 6618 O O     . HOH E 4 .   ? 55.122  52.788 120.973 1.00 47.03  ? ? ? ? ? ? 361 HOH A O     1 
+HETATM 6619 O O     . HOH E 4 .   ? 50.704  40.902 107.143 1.00 58.69  ? ? ? ? ? ? 362 HOH A O     1 
+HETATM 6620 O O     . HOH E 4 .   ? 72.893  52.312 117.024 1.00 45.82  ? ? ? ? ? ? 363 HOH A O     1 
+HETATM 6621 O O     . HOH E 4 .   ? 53.557  70.077 120.483 1.00 63.30  ? ? ? ? ? ? 364 HOH A O     1 
+HETATM 6622 O O     . HOH E 4 .   ? 68.518  38.117 119.968 1.00 46.34  ? ? ? ? ? ? 365 HOH A O     1 
+HETATM 6623 O O     . HOH E 4 .   ? 54.048  51.917 107.054 1.00 61.26  ? ? ? ? ? ? 366 HOH A O     1 
+HETATM 6624 O O     . HOH E 4 .   ? 60.890  37.280 112.233 1.00 63.35  ? ? ? ? ? ? 367 HOH A O     1 
+HETATM 6625 O O     . HOH E 4 .   ? 77.479  25.809 135.680 1.00 63.07  ? ? ? ? ? ? 368 HOH A O     1 
+HETATM 6626 O O     . HOH E 4 .   ? 55.812  49.376 108.570 1.00 46.62  ? ? ? ? ? ? 369 HOH A O     1 
+HETATM 6627 O O     . HOH E 4 .   ? 49.241  56.888 124.670 1.00 64.44  ? ? ? ? ? ? 370 HOH A O     1 
+HETATM 6628 O O     . HOH E 4 .   ? 94.647  80.999 104.123 1.00 67.58  ? ? ? ? ? ? 371 HOH A O     1 
+HETATM 6629 O O     . HOH E 4 .   ? 75.084  53.244 115.579 1.00 57.32  ? ? ? ? ? ? 372 HOH A O     1 
+HETATM 6630 O O     . HOH E 4 .   ? 53.351  43.050 122.246 1.00 57.93  ? ? ? ? ? ? 373 HOH A O     1 
+HETATM 6631 O O     . HOH E 4 .   ? 47.696  59.160 126.436 1.00 48.46  ? ? ? ? ? ? 374 HOH A O     1 
+HETATM 6632 O O     . HOH E 4 .   ? 80.484  44.703 114.741 1.00 48.58  ? ? ? ? ? ? 375 HOH A O     1 
+HETATM 6633 O O     . HOH E 4 .   ? 72.237  41.898 111.751 1.00 54.94  ? ? ? ? ? ? 376 HOH A O     1 
+HETATM 6634 O O     . HOH E 4 .   ? 86.541  71.940 103.842 1.00 55.76  ? ? ? ? ? ? 377 HOH A O     1 
+HETATM 6635 O O     . HOH E 4 .   ? 84.218  70.198 105.672 1.00 72.26  ? ? ? ? ? ? 378 HOH A O     1 
+HETATM 6636 O O     . HOH E 4 .   ? 67.496  39.780 122.275 1.00 49.34  ? ? ? ? ? ? 379 HOH A O     1 
+HETATM 6637 O O     . HOH E 4 .   ? 77.354  53.850 121.700 1.00 70.05  ? ? ? ? ? ? 380 HOH A O     1 
+HETATM 6638 O O     . HOH E 4 .   ? 75.116  33.020 120.599 1.00 49.96  ? ? ? ? ? ? 381 HOH A O     1 
+HETATM 6639 O O     . HOH E 4 .   ? 51.949  33.652 108.058 1.00 54.48  ? ? ? ? ? ? 382 HOH A O     1 
+HETATM 6640 O O     . HOH E 4 .   ? 43.986  69.188 115.677 1.00 70.26  ? ? ? ? ? ? 383 HOH A O     1 
+HETATM 6641 O O     . HOH E 4 .   ? 47.471  67.565 120.998 1.00 69.02  ? ? ? ? ? ? 384 HOH A O     1 
+HETATM 6642 O O     . HOH E 4 .   ? 55.900  58.758 108.456 1.00 63.18  ? ? ? ? ? ? 385 HOH A O     1 
+HETATM 6643 O O     . HOH E 4 .   ? 57.212  56.774 107.352 1.00 64.51  ? ? ? ? ? ? 386 HOH A O     1 
+HETATM 6644 O O     . HOH E 4 .   ? 54.293  54.984 105.751 1.00 61.06  ? ? ? ? ? ? 387 HOH A O     1 
+HETATM 6645 O O     . HOH E 4 .   ? 88.636  58.861 116.693 1.00 68.47  ? ? ? ? ? ? 388 HOH A O     1 
+HETATM 6646 O O     . HOH E 4 .   ? 82.942  61.780 105.130 1.00 78.96  ? ? ? ? ? ? 389 HOH A O     1 
+HETATM 6647 O O     . HOH E 4 .   ? 77.071  38.340 102.860 1.00 65.49  ? ? ? ? ? ? 390 HOH A O     1 
+HETATM 6648 O O     . HOH E 4 .   ? 73.032  48.824 124.768 1.00 66.35  ? ? ? ? ? ? 391 HOH A O     1 
+HETATM 6649 O O     . HOH E 4 .   ? 46.103  51.126 124.968 1.00 75.89  ? ? ? ? ? ? 392 HOH A O     1 
+HETATM 6650 O O     . HOH E 4 .   ? 40.489  53.887 122.509 1.00 67.68  ? ? ? ? ? ? 393 HOH A O     1 
+HETATM 6651 O O     . HOH E 4 .   ? 59.837  70.429 107.404 1.00 74.62  ? ? ? ? ? ? 394 HOH A O     1 
+HETATM 6652 O O     . HOH E 4 .   ? 62.019  75.087 118.051 1.00 63.44  ? ? ? ? ? ? 395 HOH A O     1 
+HETATM 6653 O O     . HOH E 4 .   ? 70.575  68.811 113.121 1.00 70.84  ? ? ? ? ? ? 396 HOH A O     1 
+HETATM 6654 O O     . HOH E 4 .   ? 68.929  70.293 115.134 1.00 69.88  ? ? ? ? ? ? 397 HOH A O     1 
+HETATM 6655 O O     . HOH E 4 .   ? 74.726  29.314 122.398 1.00 76.09  ? ? ? ? ? ? 398 HOH A O     1 
+HETATM 6656 O O     . HOH E 4 .   ? 67.616  34.195 120.969 1.00 79.41  ? ? ? ? ? ? 399 HOH A O     1 
+HETATM 6657 O O     . HOH E 4 .   ? 70.284  36.606 116.003 1.00 76.35  ? ? ? ? ? ? 400 HOH A O     1 
+HETATM 6658 O O     . HOH E 4 .   ? 80.437  58.680 127.362 1.00 79.43  ? ? ? ? ? ? 401 HOH A O     1 
+HETATM 6659 O O     . HOH E 4 .   ? 73.287  47.631 127.538 1.00 79.61  ? ? ? ? ? ? 402 HOH A O     1 
+HETATM 6660 O O     . HOH F 4 .   ? 77.187  30.513 83.579  1.00 28.42  ? ? ? ? ? ? 344 HOH B O     1 
+HETATM 6661 O O     . HOH F 4 .   ? 93.078  41.949 73.012  1.00 25.24  ? ? ? ? ? ? 345 HOH B O     1 
+HETATM 6662 O O     . HOH F 4 .   ? 96.947  25.662 70.030  1.00 32.30  ? ? ? ? ? ? 346 HOH B O     1 
+HETATM 6663 O O     . HOH F 4 .   ? 40.418  33.281 89.663  1.00 36.41  ? ? ? ? ? ? 347 HOH B O     1 
+HETATM 6664 O O     . HOH F 4 .   ? 59.864  28.201 96.419  1.00 35.38  ? ? ? ? ? ? 348 HOH B O     1 
+HETATM 6665 O O     . HOH F 4 .   ? 89.686  29.278 81.427  1.00 36.23  ? ? ? ? ? ? 349 HOH B O     1 
+HETATM 6666 O O     . HOH F 4 .   ? 78.932  39.729 76.991  1.00 34.28  ? ? ? ? ? ? 350 HOH B O     1 
+HETATM 6667 O O     . HOH F 4 .   ? 43.872  32.208 99.396  1.00 34.16  ? ? ? ? ? ? 351 HOH B O     1 
+HETATM 6668 O O     . HOH F 4 .   ? 73.351  34.865 60.343  1.00 35.60  ? ? ? ? ? ? 352 HOH B O     1 
+HETATM 6669 O O     . HOH F 4 .   ? 98.984  30.383 71.012  1.00 47.27  ? ? ? ? ? ? 353 HOH B O     1 
+HETATM 6670 O O     . HOH F 4 .   ? 84.212  24.470 61.042  1.00 42.32  ? ? ? ? ? ? 354 HOH B O     1 
+HETATM 6671 O O     . HOH F 4 .   ? 59.769  37.543 79.202  1.00 43.70  ? ? ? ? ? ? 355 HOH B O     1 
+HETATM 6672 O O     . HOH F 4 .   ? 88.709  34.708 65.337  1.00 36.13  ? ? ? ? ? ? 356 HOH B O     1 
+HETATM 6673 O O     . HOH F 4 .   ? 75.211  25.044 61.058  1.00 32.32  ? ? ? ? ? ? 357 HOH B O     1 
+HETATM 6674 O O     . HOH F 4 .   ? 76.024  39.189 64.527  1.00 40.77  ? ? ? ? ? ? 358 HOH B O     1 
+HETATM 6675 O O     . HOH F 4 .   ? 65.003  33.932 92.980  1.00 37.39  ? ? ? ? ? ? 359 HOH B O     1 
+HETATM 6676 O O     . HOH F 4 .   ? 65.575  34.124 72.445  1.00 53.33  ? ? ? ? ? ? 360 HOH B O     1 
+HETATM 6677 O O     . HOH F 4 .   ? 57.448  29.287 84.866  1.00 37.12  ? ? ? ? ? ? 361 HOH B O     1 
+HETATM 6678 O O     . HOH F 4 .   ? 96.250  34.708 74.780  1.00 46.71  ? ? ? ? ? ? 362 HOH B O     1 
+HETATM 6679 O O     . HOH F 4 .   ? 74.117  37.881 77.559  1.00 42.72  ? ? ? ? ? ? 363 HOH B O     1 
+HETATM 6680 O O     . HOH F 4 .   ? 68.064  25.185 84.027  1.00 55.76  ? ? ? ? ? ? 364 HOH B O     1 
+HETATM 6681 O O     . HOH F 4 .   ? 43.489  29.742 100.856 1.00 42.00  ? ? ? ? ? ? 365 HOH B O     1 
+HETATM 6682 O O     . HOH F 4 .   ? 69.389  35.539 67.486  1.00 42.78  ? ? ? ? ? ? 366 HOH B O     1 
+HETATM 6683 O O     . HOH F 4 .   ? 90.868  30.600 65.519  1.00 37.59  ? ? ? ? ? ? 367 HOH B O     1 
+HETATM 6684 O O     . HOH F 4 .   ? 73.665  36.790 64.122  1.00 39.25  ? ? ? ? ? ? 368 HOH B O     1 
+HETATM 6685 O O     . HOH F 4 .   ? 60.672  38.167 88.077  1.00 50.57  ? ? ? ? ? ? 369 HOH B O     1 
+HETATM 6686 O O     . HOH F 4 .   ? 85.196  26.410 86.301  1.00 52.00  ? ? ? ? ? ? 370 HOH B O     1 
+HETATM 6687 O O     . HOH F 4 .   ? 95.036  44.388 71.846  1.00 49.04  ? ? ? ? ? ? 371 HOH B O     1 
+HETATM 6688 O O     . HOH F 4 .   ? 72.281  34.939 83.569  1.00 49.04  ? ? ? ? ? ? 372 HOH B O     1 
+HETATM 6689 O O     . HOH F 4 .   ? 54.045  29.814 102.646 1.00 44.72  ? ? ? ? ? ? 373 HOH B O     1 
+HETATM 6690 O O     . HOH F 4 .   ? 91.429  32.945 65.313  1.00 37.43  ? ? ? ? ? ? 374 HOH B O     1 
+HETATM 6691 O O     . HOH F 4 .   ? 81.713  22.124 81.406  1.00 34.51  ? ? ? ? ? ? 375 HOH B O     1 
+HETATM 6692 O O     . HOH F 4 .   ? 55.063  30.888 75.232  1.00 44.23  ? ? ? ? ? ? 376 HOH B O     1 
+HETATM 6693 O O     . HOH F 4 .   ? 89.577  35.230 86.373  1.00 47.59  ? ? ? ? ? ? 377 HOH B O     1 
+HETATM 6694 O O     . HOH F 4 .   ? 87.261  18.322 77.517  1.00 59.54  ? ? ? ? ? ? 378 HOH B O     1 
+HETATM 6695 O O     . HOH F 4 .   ? 86.536  22.987 59.517  1.00 34.80  ? ? ? ? ? ? 379 HOH B O     1 
+HETATM 6696 O O     . HOH F 4 .   ? 69.243  31.588 85.479  1.00 38.77  ? ? ? ? ? ? 380 HOH B O     1 
+HETATM 6697 O O     . HOH F 4 .   ? 37.556  23.484 94.153  1.00 32.11  ? ? ? ? ? ? 381 HOH B O     1 
+HETATM 6698 O O     . HOH F 4 .   ? 74.284  46.658 65.749  1.00 43.85  ? ? ? ? ? ? 382 HOH B O     1 
+HETATM 6699 O O     . HOH F 4 .   ? 46.647  24.425 94.930  1.00 54.98  ? ? ? ? ? ? 383 HOH B O     1 
+HETATM 6700 O O     . HOH F 4 .   ? 73.217  32.265 60.581  1.00 39.08  ? ? ? ? ? ? 384 HOH B O     1 
+HETATM 6701 O O     . HOH F 4 .   ? 93.115  23.607 62.578  1.00 39.27  ? ? ? ? ? ? 385 HOH B O     1 
+HETATM 6702 O O     . HOH F 4 .   ? 84.935  24.394 54.459  1.00 50.83  ? ? ? ? ? ? 386 HOH B O     1 
+HETATM 6703 O O     . HOH F 4 .   ? 75.692  36.398 58.639  1.00 46.15  ? ? ? ? ? ? 387 HOH B O     1 
+HETATM 6704 O O     . HOH F 4 .   ? 69.405  42.218 74.711  1.00 38.11  ? ? ? ? ? ? 388 HOH B O     1 
+HETATM 6705 O O     . HOH F 4 .   ? 42.338  44.185 99.488  1.00 51.14  ? ? ? ? ? ? 389 HOH B O     1 
+HETATM 6706 O O     . HOH F 4 .   ? 52.060  44.456 65.716  1.00 59.38  ? ? ? ? ? ? 390 HOH B O     1 
+HETATM 6707 O O     . HOH F 4 .   ? 78.206  37.965 78.510  1.00 45.15  ? ? ? ? ? ? 391 HOH B O     1 
+HETATM 6708 O O     . HOH F 4 .   ? 47.675  26.794 97.285  1.00 45.87  ? ? ? ? ? ? 392 HOH B O     1 
+HETATM 6709 O O     . HOH F 4 .   ? 38.422  39.804 89.665  1.00 64.18  ? ? ? ? ? ? 393 HOH B O     1 
+HETATM 6710 O O     . HOH F 4 .   ? 38.798  36.591 95.512  1.00 37.99  ? ? ? ? ? ? 394 HOH B O     1 
+HETATM 6711 O O     . HOH F 4 .   ? 45.539  47.422 76.288  1.00 52.98  ? ? ? ? ? ? 395 HOH B O     1 
+HETATM 6712 O O     . HOH F 4 .   ? 69.230  29.804 88.440  1.00 43.40  ? ? ? ? ? ? 396 HOH B O     1 
+HETATM 6713 O O     . HOH F 4 .   ? 49.767  24.753 86.625  1.00 55.15  ? ? ? ? ? ? 397 HOH B O     1 
+HETATM 6714 O O     . HOH F 4 .   ? 74.940  20.408 79.209  1.00 50.61  ? ? ? ? ? ? 398 HOH B O     1 
+HETATM 6715 O O     . HOH F 4 .   ? 80.192  52.202 63.965  1.00 46.25  ? ? ? ? ? ? 399 HOH B O     1 
+HETATM 6716 O O     . HOH F 4 .   ? 76.903  26.176 55.143  1.00 56.11  ? ? ? ? ? ? 400 HOH B O     1 
+HETATM 6717 O O     . HOH F 4 .   ? 86.778  24.913 58.238  1.00 48.62  ? ? ? ? ? ? 401 HOH B O     1 
+HETATM 6718 O O     . HOH F 4 .   ? 84.323  48.185 74.246  1.00 52.87  ? ? ? ? ? ? 402 HOH B O     1 
+HETATM 6719 O O     . HOH F 4 .   ? 90.924  42.820 80.791  1.00 61.89  ? ? ? ? ? ? 403 HOH B O     1 
+HETATM 6720 O O     . HOH F 4 .   ? 62.340  26.372 97.366  1.00 77.16  ? ? ? ? ? ? 404 HOH B O     1 
+HETATM 6721 O O     . HOH F 4 .   ? 72.743  26.091 56.431  1.00 64.53  ? ? ? ? ? ? 405 HOH B O     1 
+HETATM 6722 O O     . HOH F 4 .   ? 81.558  38.342 94.008  1.00 57.44  ? ? ? ? ? ? 406 HOH B O     1 
+HETATM 6723 O O     . HOH F 4 .   ? 64.214  38.327 103.491 1.00 56.13  ? ? ? ? ? ? 407 HOH B O     1 
+HETATM 6724 O O     . HOH F 4 .   ? 64.818  25.733 82.829  1.00 70.25  ? ? ? ? ? ? 408 HOH B O     1 
+HETATM 6725 O O     . HOH F 4 .   ? 34.959  28.962 90.668  1.00 42.26  ? ? ? ? ? ? 409 HOH B O     1 
+HETATM 6726 O O     . HOH F 4 .   ? 69.575  29.111 59.493  1.00 56.50  ? ? ? ? ? ? 410 HOH B O     1 
+HETATM 6727 O O     . HOH F 4 .   ? 40.654  27.384 83.174  1.00 49.43  ? ? ? ? ? ? 411 HOH B O     1 
+HETATM 6728 O O     . HOH F 4 .   ? 79.825  21.967 79.495  1.00 53.83  ? ? ? ? ? ? 412 HOH B O     1 
+HETATM 6729 O O     . HOH F 4 .   ? 54.223  43.015 89.314  1.00 65.43  ? ? ? ? ? ? 413 HOH B O     1 
+HETATM 6730 O O     . HOH F 4 .   ? 68.558  38.604 68.627  1.00 52.22  ? ? ? ? ? ? 414 HOH B O     1 
+HETATM 6731 O O     . HOH F 4 .   ? 84.185  39.114 54.238  1.00 63.02  ? ? ? ? ? ? 415 HOH B O     1 
+HETATM 6732 O O     . HOH F 4 .   ? 40.974  42.093 88.696  1.00 60.47  ? ? ? ? ? ? 416 HOH B O     1 
+HETATM 6733 O O     . HOH F 4 .   ? 54.173  31.385 73.109  1.00 67.56  ? ? ? ? ? ? 417 HOH B O     1 
+HETATM 6734 O O     . HOH F 4 .   ? 53.964  44.747 99.005  1.00 46.21  ? ? ? ? ? ? 418 HOH B O     1 
+HETATM 6735 O O     . HOH F 4 .   ? 94.664  35.600 68.864  1.00 64.70  ? ? ? ? ? ? 419 HOH B O     1 
+HETATM 6736 O O     . HOH F 4 .   ? 44.452  48.219 86.819  1.00 57.59  ? ? ? ? ? ? 420 HOH B O     1 
+HETATM 6737 O O     . HOH F 4 .   ? 78.415  28.871 88.824  1.00 51.39  ? ? ? ? ? ? 421 HOH B O     1 
+HETATM 6738 O O     . HOH F 4 .   ? 77.449  46.782 76.830  1.00 56.86  ? ? ? ? ? ? 422 HOH B O     1 
+HETATM 6739 O O     . HOH F 4 .   ? 52.729  42.224 94.634  1.00 55.33  ? ? ? ? ? ? 423 HOH B O     1 
+HETATM 6740 O O     . HOH F 4 .   ? 54.122  42.356 97.513  1.00 58.63  ? ? ? ? ? ? 424 HOH B O     1 
+HETATM 6741 O O     . HOH F 4 .   ? 61.494  30.604 72.229  1.00 57.63  ? ? ? ? ? ? 425 HOH B O     1 
+HETATM 6742 O O     . HOH F 4 .   ? 54.345  26.001 87.088  1.00 55.71  ? ? ? ? ? ? 426 HOH B O     1 
+HETATM 6743 O O     . HOH F 4 .   ? 68.183  43.035 72.863  1.00 64.69  ? ? ? ? ? ? 427 HOH B O     1 
+HETATM 6744 O O     . HOH F 4 .   ? 56.332  35.798 71.468  1.00 44.60  ? ? ? ? ? ? 428 HOH B O     1 
+HETATM 6745 O O     . HOH F 4 .   ? 55.070  28.671 83.183  1.00 59.20  ? ? ? ? ? ? 429 HOH B O     1 
+HETATM 6746 O O     . HOH F 4 .   ? 72.196  31.162 57.677  1.00 71.96  ? ? ? ? ? ? 430 HOH B O     1 
+HETATM 6747 O O     . HOH F 4 .   ? 75.564  27.668 78.557  1.00 60.93  ? ? ? ? ? ? 431 HOH B O     1 
+HETATM 6748 O O     . HOH F 4 .   ? 37.312  39.563 94.467  1.00 54.61  ? ? ? ? ? ? 432 HOH B O     1 
+HETATM 6749 O O     . HOH F 4 .   ? 92.495  33.253 57.372  1.00 60.48  ? ? ? ? ? ? 433 HOH B O     1 
+HETATM 6750 O O     . HOH F 4 .   ? 75.044  24.499 80.013  1.00 47.85  ? ? ? ? ? ? 434 HOH B O     1 
+HETATM 6751 O O     . HOH F 4 .   ? 82.060  23.654 61.164  1.00 51.65  ? ? ? ? ? ? 435 HOH B O     1 
+HETATM 6752 O O     . HOH F 4 .   ? 85.884  34.159 89.683  1.00 75.72  ? ? ? ? ? ? 436 HOH B O     1 
+HETATM 6753 O O     . HOH F 4 .   ? 80.974  22.701 84.556  1.00 65.30  ? ? ? ? ? ? 437 HOH B O     1 
+HETATM 6754 O O     . HOH F 4 .   ? 82.303  33.175 89.019  1.00 61.77  ? ? ? ? ? ? 438 HOH B O     1 
+HETATM 6755 O O     . HOH F 4 .   ? 43.004  50.591 74.303  1.00 55.62  ? ? ? ? ? ? 439 HOH B O     1 
+HETATM 6756 O O     . HOH F 4 .   ? 74.520  25.955 76.313  1.00 50.36  ? ? ? ? ? ? 440 HOH B O     1 
+HETATM 6757 O O     . HOH F 4 .   ? 67.160  31.178 70.966  1.00 39.14  ? ? ? ? ? ? 441 HOH B O     1 
+HETATM 6758 O O     . HOH F 4 .   ? 54.180  34.162 71.434  1.00 53.95  ? ? ? ? ? ? 442 HOH B O     1 
+HETATM 6759 O O     . HOH F 4 .   ? 56.896  37.387 69.683  1.00 60.72  ? ? ? ? ? ? 443 HOH B O     1 
+HETATM 6760 O O     . HOH F 4 .   ? 70.377  26.013 89.645  1.00 53.78  ? ? ? ? ? ? 444 HOH B O     1 
+HETATM 6761 O O     . HOH F 4 .   ? 71.901  49.889 76.447  1.00 62.70  ? ? ? ? ? ? 445 HOH B O     1 
+HETATM 6762 O O     . HOH F 4 .   ? 85.020  19.446 62.025  1.00 60.41  ? ? ? ? ? ? 446 HOH B O     1 
+HETATM 6763 O O     . HOH F 4 .   ? 69.523  33.316 55.964  1.00 67.32  ? ? ? ? ? ? 447 HOH B O     1 
+HETATM 6764 O O     . HOH F 4 .   ? 51.382  25.570 100.005 1.00 69.25  ? ? ? ? ? ? 448 HOH B O     1 
+HETATM 6765 O O     . HOH F 4 .   ? 49.963  23.863 97.453  1.00 50.73  ? ? ? ? ? ? 449 HOH B O     1 
+HETATM 6766 O O     . HOH F 4 .   ? 68.477  27.884 88.907  1.00 54.40  ? ? ? ? ? ? 450 HOH B O     1 
+HETATM 6767 O O     . HOH F 4 .   ? 85.323  25.710 69.900  1.00 59.90  ? ? ? ? ? ? 451 HOH B O     1 
+HETATM 6768 O O     . HOH F 4 .   ? 86.573  23.994 70.553  1.00 64.54  ? ? ? ? ? ? 452 HOH B O     1 
+HETATM 6769 O O     . HOH F 4 .   ? 61.513  41.476 70.177  1.00 78.65  ? ? ? ? ? ? 453 HOH B O     1 
+HETATM 6770 O O     . HOH F 4 .   ? 44.823  21.335 84.238  1.00 79.95  ? ? ? ? ? ? 454 HOH B O     1 
+HETATM 6771 O O     . HOH F 4 .   ? 46.950  25.147 80.385  1.00 65.79  ? ? ? ? ? ? 455 HOH B O     1 
+HETATM 6772 O O     . HOH F 4 .   ? 45.665  27.259 78.125  1.00 67.58  ? ? ? ? ? ? 456 HOH B O     1 
+HETATM 6773 O O     . HOH F 4 .   ? 38.760  28.851 84.141  1.00 70.71  ? ? ? ? ? ? 457 HOH B O     1 
+HETATM 6774 O O     . HOH F 4 .   ? 39.878  21.427 94.601  1.00 72.62  ? ? ? ? ? ? 458 HOH B O     1 
+HETATM 6775 O O     . HOH F 4 .   ? 37.974  38.256 97.174  1.00 63.59  ? ? ? ? ? ? 459 HOH B O     1 
+HETATM 6776 O O     . HOH F 4 .   ? 77.168  31.129 89.598  1.00 65.82  ? ? ? ? ? ? 460 HOH B O     1 
+HETATM 6777 O O     . HOH F 4 .   ? 82.807  47.721 76.963  1.00 63.71  ? ? ? ? ? ? 461 HOH B O     1 
+HETATM 6778 O O     . HOH F 4 .   ? 76.241  26.096 81.754  1.00 69.53  ? ? ? ? ? ? 462 HOH B O     1 
+HETATM 6779 O O     . HOH F 4 .   ? 93.818  43.030 101.872 1.00 75.86  ? ? ? ? ? ? 463 HOH B O     1 
+HETATM 6780 O O     . HOH F 4 .   ? 73.030  23.192 76.758  1.00 70.59  ? ? ? ? ? ? 464 HOH B O     1 
+HETATM 6781 O O     . HOH F 4 .   ? 89.576  19.250 78.441  1.00 71.09  ? ? ? ? ? ? 465 HOH B O     1 
+HETATM 6782 O O     . HOH F 4 .   ? 42.120  40.628 90.049  1.00 79.87  ? ? ? ? ? ? 466 HOH B O     1 
+HETATM 6783 O O     . HOH F 4 .   ? 70.448  45.793 68.688  1.00 75.97  ? ? ? ? ? ? 467 HOH B O     1 
+HETATM 6784 O O     . HOH G 4 .   ? 64.980  46.740 90.316  1.00 58.15  ? ? ? ? ? ? 35  HOH C O     1 
+HETATM 6785 O O     . HOH G 4 .   ? 74.306  22.893 61.049  1.00 44.26  ? ? ? ? ? ? 36  HOH C O     1 
+HETATM 6786 O O     . HOH G 4 .   ? 61.908  35.748 86.762  1.00 46.67  ? ? ? ? ? ? 37  HOH C O     1 
+HETATM 6787 O O     . HOH G 4 .   ? 71.071  30.713 61.341  1.00 41.26  ? ? ? ? ? ? 38  HOH C O     1 
+HETATM 6788 O O     . HOH G 4 .   ? 66.359  29.582 72.347  1.00 44.33  ? ? ? ? ? ? 39  HOH C O     1 
+HETATM 6789 O O     . HOH G 4 .   ? 79.414  21.489 67.567  1.00 49.41  ? ? ? ? ? ? 40  HOH C O     1 
+HETATM 6790 O O     . HOH G 4 .   ? 64.033  74.571 73.602  1.00 59.46  ? ? ? ? ? ? 41  HOH C O     1 
+HETATM 6791 O O     . HOH G 4 .   ? 77.189  19.821 67.575  1.00 47.79  ? ? ? ? ? ? 42  HOH C O     1 
+HETATM 6792 O O     . HOH G 4 .   ? 73.874  17.407 68.012  1.00 56.10  ? ? ? ? ? ? 43  HOH C O     1 
+HETATM 6793 O O     . HOH G 4 .   ? 72.558  37.886 91.064  1.00 53.30  ? ? ? ? ? ? 44  HOH C O     1 
+HETATM 6794 O O     . HOH G 4 .   ? 63.981  30.587 74.128  1.00 51.13  ? ? ? ? ? ? 45  HOH C O     1 
+HETATM 6795 O O     . HOH G 4 .   ? 68.278  38.308 82.136  1.00 45.94  ? ? ? ? ? ? 46  HOH C O     1 
+HETATM 6796 O O     . HOH G 4 .   ? 54.603  26.567 84.596  1.00 52.81  ? ? ? ? ? ? 47  HOH C O     1 
+HETATM 6797 O O     . HOH G 4 .   ? 72.701  20.298 69.451  1.00 73.18  ? ? ? ? ? ? 48  HOH C O     1 
+HETATM 6798 O O     . HOH G 4 .   ? 61.087  87.684 40.876  1.00 57.30  ? ? ? ? ? ? 49  HOH C O     1 
+HETATM 6799 O O     . HOH G 4 .   ? 69.103  40.214 80.849  1.00 51.64  ? ? ? ? ? ? 50  HOH C O     1 
+HETATM 6800 O O     . HOH G 4 .   ? 65.886  84.497 38.194  1.00 73.08  ? ? ? ? ? ? 51  HOH C O     1 
+HETATM 6801 O O     . HOH G 4 .   ? 77.531  17.506 68.106  1.00 70.15  ? ? ? ? ? ? 52  HOH C O     1 
+HETATM 6802 O O     . HOH G 4 .   ? 63.146  71.240 48.955  1.00 70.48  ? ? ? ? ? ? 53  HOH C O     1 
+HETATM 6803 O O     . HOH G 4 .   ? 71.311  90.897 43.842  1.00 74.58  ? ? ? ? ? ? 54  HOH C O     1 
+HETATM 6804 O O     . HOH H 4 .   ? 68.250  30.440 74.516  1.00 48.41  ? ? ? ? ? ? 35  HOH D O     1 
+HETATM 6805 O O     . HOH H 4 .   ? 59.987  40.705 101.128 1.00 42.67  ? ? ? ? ? ? 36  HOH D O     1 
+HETATM 6806 O O     . HOH H 4 .   ? 67.958  33.536 83.534  1.00 42.38  ? ? ? ? ? ? 37  HOH D O     1 
+HETATM 6807 O O     . HOH H 4 .   ? 68.297  15.122 64.842  1.00 51.03  ? ? ? ? ? ? 38  HOH D O     1 
+HETATM 6808 O O     . HOH H 4 .   ? 67.395  32.558 76.126  1.00 44.61  ? ? ? ? ? ? 39  HOH D O     1 
+HETATM 6809 O O     . HOH H 4 .   ? 72.640  27.183 78.097  1.00 38.82  ? ? ? ? ? ? 40  HOH D O     1 
+HETATM 6810 O O     . HOH H 4 .   ? 60.917  41.258 89.671  1.00 57.38  ? ? ? ? ? ? 41  HOH D O     1 
+HETATM 6811 O O     . HOH H 4 .   ? 58.700  39.944 87.333  1.00 41.79  ? ? ? ? ? ? 42  HOH D O     1 
+HETATM 6812 O O     . HOH H 4 .   ? 61.668  33.939 76.454  1.00 54.14  ? ? ? ? ? ? 43  HOH D O     1 
+HETATM 6813 O O     . HOH H 4 .   ? 62.640  37.297 131.422 1.00 65.61  ? ? ? ? ? ? 44  HOH D O     1 
+HETATM 6814 O O     . HOH H 4 .   ? 70.424  22.083 72.917  1.00 53.37  ? ? ? ? ? ? 45  HOH D O     1 
+HETATM 6815 O O     . HOH H 4 .   ? 65.969  22.745 80.603  1.00 58.80  ? ? ? ? ? ? 46  HOH D O     1 
+HETATM 6816 O O     . HOH H 4 .   ? 74.625  32.935 137.257 1.00 55.50  ? ? ? ? ? ? 47  HOH D O     1 
+HETATM 6817 O O     . HOH H 4 .   ? 67.841  34.363 74.775  1.00 50.53  ? ? ? ? ? ? 48  HOH D O     1 
+HETATM 6818 O O     . HOH H 4 .   ? 66.573  42.219 123.245 1.00 44.69  ? ? ? ? ? ? 49  HOH D O     1 
+HETATM 6819 O O     . HOH H 4 .   ? 62.522  53.632 125.596 1.00 52.35  ? ? ? ? ? ? 50  HOH D O     1 
+HETATM 6820 O O     . HOH H 4 .   ? 69.030  39.482 152.529 1.00 51.45  ? ? ? ? ? ? 51  HOH D O     1 
+HETATM 6821 O O     . HOH H 4 .   ? 64.633  32.169 75.522  1.00 52.25  ? ? ? ? ? ? 52  HOH D O     1 
+HETATM 6822 O O     . HOH H 4 .   ? 66.578  46.260 108.481 1.00 58.99  ? ? ? ? ? ? 53  HOH D O     1 
+HETATM 6823 O O     . HOH H 4 .   ? 68.297  52.808 117.748 1.00 54.71  ? ? ? ? ? ? 54  HOH D O     1 
+HETATM 6824 O O     . HOH H 4 .   ? 69.628  35.921 82.978  1.00 44.07  ? ? ? ? ? ? 55  HOH D O     1 
+HETATM 6825 O O     . HOH H 4 .   ? 57.661  55.352 121.294 1.00 55.56  ? ? ? ? ? ? 56  HOH D O     1 
+HETATM 6826 O O     . HOH H 4 .   ? 77.675  40.648 134.967 1.00 52.91  ? ? ? ? ? ? 57  HOH D O     1 
+HETATM 6827 O O     . HOH H 4 .   ? 70.889  42.979 130.137 1.00 43.48  ? ? ? ? ? ? 58  HOH D O     1 
+HETATM 6828 O O     . HOH H 4 .   ? 69.101  49.883 113.487 1.00 64.91  ? ? ? ? ? ? 59  HOH D O     1 
+HETATM 6829 O O     . HOH H 4 .   ? 70.211  51.569 115.994 1.00 51.60  ? ? ? ? ? ? 60  HOH D O     1 
+HETATM 6830 O O     . HOH H 4 .   ? 70.487  56.662 109.680 1.00 46.87  ? ? ? ? ? ? 61  HOH D O     1 
+HETATM 6831 O O     . HOH H 4 .   ? 70.866  47.921 111.661 1.00 54.45  ? ? ? ? ? ? 62  HOH D O     1 
+HETATM 6832 O O     . HOH H 4 .   ? 74.634  24.305 83.786  1.00 48.57  ? ? ? ? ? ? 63  HOH D O     1 
+HETATM 6833 O O     . HOH H 4 .   ? 77.820  20.422 55.941  1.00 63.25  ? ? ? ? ? ? 64  HOH D O     1 
+HETATM 6834 O O     . HOH H 4 .   ? 77.603  22.947 54.803  1.00 65.58  ? ? ? ? ? ? 65  HOH D O     1 
+HETATM 6835 O O     . HOH H 4 .   ? 67.858  47.881 109.127 1.00 71.59  ? ? ? ? ? ? 66  HOH D O     1 
+HETATM 6836 O O     . HOH H 4 .   ? 61.442  55.075 113.407 1.00 71.63  ? ? ? ? ? ? 67  HOH D O     1 
+HETATM 6837 O O     . HOH H 4 .   ? 72.612  33.676 134.301 1.00 65.25  ? ? ? ? ? ? 68  HOH D O     1 
+# 
+loop_
+_pdbx_poly_seq_scheme.asym_id 
+_pdbx_poly_seq_scheme.entity_id 
+_pdbx_poly_seq_scheme.seq_id 
+_pdbx_poly_seq_scheme.mon_id 
+_pdbx_poly_seq_scheme.ndb_seq_num 
+_pdbx_poly_seq_scheme.pdb_seq_num 
+_pdbx_poly_seq_scheme.auth_seq_num 
+_pdbx_poly_seq_scheme.pdb_mon_id 
+_pdbx_poly_seq_scheme.auth_mon_id 
+_pdbx_poly_seq_scheme.pdb_strand_id 
+_pdbx_poly_seq_scheme.pdb_ins_code 
+_pdbx_poly_seq_scheme.hetero 
+A 1 1   DA  1   1   1   DA  A   C . n 
+A 1 2   DT  2   2   2   DT  T   C . n 
+A 1 3   DA  3   3   3   DA  A   C . n 
+A 1 4   DA  4   4   4   DA  A   C . n 
+A 1 5   DG  5   5   5   DG  G   C . n 
+A 1 6   DT  6   6   6   DT  T   C . n 
+A 1 7   DT  7   7   7   DT  T   C . n 
+A 1 8   DC  8   8   8   DC  C   C . n 
+A 1 9   DG  9   9   9   DG  G   C . n 
+A 1 10  DT  10  10  10  DT  T   C . n 
+A 1 11  DA  11  11  11  DA  A   C . n 
+A 1 12  DT  12  12  12  DT  T   C . n 
+A 1 13  DA  13  13  13  DA  A   C . n 
+A 1 14  DA  14  14  14  DA  A   C . n 
+A 1 15  DT  15  15  15  DT  T   C . n 
+A 1 16  DG  16  16  16  DG  G   C . n 
+A 1 17  DT  17  17  17  DT  T   C . n 
+A 1 18  DA  18  18  18  DA  A   C . n 
+A 1 19  DT  19  19  19  DT  T   C . n 
+A 1 20  DG  20  20  20  DG  G   C . n 
+A 1 21  DC  21  21  21  DC  C   C . n 
+A 1 22  DT  22  22  22  DT  T   C . n 
+A 1 23  DA  23  23  23  DA  A   C . n 
+A 1 24  DT  24  24  24  DT  T   C . n 
+A 1 25  DA  25  25  25  DA  A   C . n 
+A 1 26  DC  26  26  26  DC  C   C . n 
+A 1 27  DG  27  27  27  DG  G   C . n 
+A 1 28  DA  28  28  28  DA  A   C . n 
+A 1 29  DA  29  29  29  DA  A   C . n 
+A 1 30  DG  30  30  30  DG  G   C . n 
+A 1 31  DT  31  31  31  DT  T   C . n 
+A 1 32  DT  32  32  32  DT  T   C . n 
+A 1 33  DA  33  33  33  DA  A   C . n 
+A 1 34  DT  34  34  34  DT  T   C . n 
+B 2 1   DA  1   1   1   DA  A   D . n 
+B 2 2   DT  2   2   2   DT  T   D . n 
+B 2 3   DA  3   3   3   DA  A   D . n 
+B 2 4   DA  4   4   4   DA  A   D . n 
+B 2 5   DC  5   5   5   DC  C   D . n 
+B 2 6   DT  6   6   6   DT  T   D . n 
+B 2 7   DT  7   7   7   DT  T   D . n 
+B 2 8   DC  8   8   8   DC  C   D . n 
+B 2 9   DG  9   9   9   DG  G   D . n 
+B 2 10  DT  10  10  10  DT  T   D . n 
+B 2 11  DA  11  11  11  DA  A   D . n 
+B 2 12  DT  12  12  12  DT  T   D . n 
+B 2 13  DA  13  13  13  DA  A   D . n 
+B 2 14  DG  14  14  14  DG  G   D . n 
+B 2 15  DC  15  15  15  DC  C   D . n 
+B 2 16  DA  16  16  16  DA  A   D . n 
+B 2 17  DT  17  17  17  DT  T   D . n 
+B 2 18  DA  18  18  18  DA  A   D . n 
+B 2 19  DC  19  19  19  DC  C   D . n 
+B 2 20  DA  20  20  20  DA  A   D . n 
+B 2 21  DT  21  21  21  DT  T   D . n 
+B 2 22  DT  22  22  22  DT  T   D . n 
+B 2 23  DA  23  23  23  DA  A   D . n 
+B 2 24  DT  24  24  24  DT  T   D . n 
+B 2 25  DA  25  25  25  DA  A   D . n 
+B 2 26  DC  26  26  26  DC  C   D . n 
+B 2 27  DG  27  27  27  DG  G   D . n 
+B 2 28  DA  28  28  28  DA  A   D . n 
+B 2 29  DA  29  29  29  DA  A   D . n 
+B 2 30  DC  30  30  30  DC  C   D . n 
+B 2 31  DT  31  31  31  DT  T   D . n 
+B 2 32  DT  32  32  32  DT  T   D . n 
+B 2 33  DA  33  33  33  DA  A   D . n 
+B 2 34  DT  34  34  34  DT  T   D . n 
+C 3 1   MET 1   -5  ?   ?   ?   A . n 
+C 3 2   HIS 2   -4  ?   ?   ?   A . n 
+C 3 3   HIS 3   -3  ?   ?   ?   A . n 
+C 3 4   HIS 4   -2  ?   ?   ?   A . n 
+C 3 5   HIS 5   -1  ?   ?   ?   A . n 
+C 3 6   HIS 6   0   ?   ?   ?   A . n 
+C 3 7   HIS 7   1   ?   ?   ?   A . n 
+C 3 8   SER 8   2   ?   ?   ?   A . n 
+C 3 9   ASN 9   3   ?   ?   ?   A . n 
+C 3 10  LEU 10  4   ?   ?   ?   A . n 
+C 3 11  LEU 11  5   ?   ?   ?   A . n 
+C 3 12  THR 12  6   ?   ?   ?   A . n 
+C 3 13  VAL 13  7   ?   ?   ?   A . n 
+C 3 14  HIS 14  8   ?   ?   ?   A . n 
+C 3 15  GLN 15  9   ?   ?   ?   A . n 
+C 3 16  ASN 16  10  ?   ?   ?   A . n 
+C 3 17  LEU 17  11  ?   ?   ?   A . n 
+C 3 18  PRO 18  12  ?   ?   ?   A . n 
+C 3 19  ALA 19  13  ?   ?   ?   A . n 
+C 3 20  LEU 20  14  ?   ?   ?   A . n 
+C 3 21  PRO 21  15  ?   ?   ?   A . n 
+C 3 22  VAL 22  16  ?   ?   ?   A . n 
+C 3 23  ASP 23  17  ?   ?   ?   A . n 
+C 3 24  ALA 24  18  18  ALA ALA A . n 
+C 3 25  THR 25  19  19  THR THR A . n 
+C 3 26  SER 26  20  20  SER SER A . n 
+C 3 27  ASP 27  21  21  ASP ASP A . n 
+C 3 28  GLU 28  22  22  GLU GLU A . n 
+C 3 29  VAL 29  23  23  VAL VAL A . n 
+C 3 30  ARG 30  24  24  ARG ARG A . n 
+C 3 31  LYS 31  25  25  LYS LYS A . n 
+C 3 32  ASN 32  26  26  ASN ASN A . n 
+C 3 33  LEU 33  27  27  LEU LEU A . n 
+C 3 34  MET 34  28  28  MET MET A . n 
+C 3 35  ASP 35  29  29  ASP ASP A . n 
+C 3 36  MET 36  30  30  MET MET A . n 
+C 3 37  PHE 37  31  31  PHE PHE A . n 
+C 3 38  ARG 38  32  32  ARG ARG A . n 
+C 3 39  ASP 39  33  33  ASP ASP A . n 
+C 3 40  ARG 40  34  34  ARG ARG A . n 
+C 3 41  GLN 41  35  35  GLN GLN A . n 
+C 3 42  ALA 42  36  36  ALA ALA A . n 
+C 3 43  PHE 43  37  37  PHE PHE A . n 
+C 3 44  SER 44  38  38  SER SER A . n 
+C 3 45  GLU 45  39  39  GLU GLU A . n 
+C 3 46  HIS 46  40  40  HIS HIS A . n 
+C 3 47  THR 47  41  41  THR THR A . n 
+C 3 48  TRP 48  42  42  TRP TRP A . n 
+C 3 49  LYS 49  43  43  LYS LYS A . n 
+C 3 50  MET 50  44  44  MET MET A . n 
+C 3 51  LEU 51  45  45  LEU LEU A . n 
+C 3 52  LEU 52  46  46  LEU LEU A . n 
+C 3 53  SER 53  47  47  SER SER A . n 
+C 3 54  VAL 54  48  48  VAL VAL A . n 
+C 3 55  CYS 55  49  49  CYS CYS A . n 
+C 3 56  ARG 56  50  50  ARG ARG A . n 
+C 3 57  SER 57  51  51  SER SER A . n 
+C 3 58  TRP 58  52  52  TRP TRP A . n 
+C 3 59  ALA 59  53  53  ALA ALA A . n 
+C 3 60  ALA 60  54  54  ALA ALA A . n 
+C 3 61  TRP 61  55  55  TRP TRP A . n 
+C 3 62  CYS 62  56  56  CYS CYS A . n 
+C 3 63  LYS 63  57  57  LYS LYS A . n 
+C 3 64  LEU 64  58  58  LEU LEU A . n 
+C 3 65  ASN 65  59  59  ASN ASN A . n 
+C 3 66  ASN 66  60  60  ASN ASN A . n 
+C 3 67  ARG 67  61  61  ARG ARG A . n 
+C 3 68  LYS 68  62  62  LYS LYS A . n 
+C 3 69  TRP 69  63  63  TRP TRP A . n 
+C 3 70  PHE 70  64  64  PHE PHE A . n 
+C 3 71  PRO 71  65  65  PRO PRO A . n 
+C 3 72  ALA 72  66  66  ALA ALA A . n 
+C 3 73  GLU 73  67  67  GLU GLU A . n 
+C 3 74  PRO 74  68  68  PRO PRO A . n 
+C 3 75  GLU 75  69  69  GLU GLU A . n 
+C 3 76  ASP 76  70  70  ASP ASP A . n 
+C 3 77  VAL 77  71  71  VAL VAL A . n 
+C 3 78  ARG 78  72  72  ARG ARG A . n 
+C 3 79  ASP 79  73  73  ASP ASP A . n 
+C 3 80  TYR 80  74  74  TYR TYR A . n 
+C 3 81  LEU 81  75  75  LEU LEU A . n 
+C 3 82  LEU 82  76  76  LEU LEU A . n 
+C 3 83  TYR 83  77  77  TYR TYR A . n 
+C 3 84  LEU 84  78  78  LEU LEU A . n 
+C 3 85  GLN 85  79  79  GLN GLN A . n 
+C 3 86  ALA 86  80  80  ALA ALA A . n 
+C 3 87  ARG 87  81  81  ARG ARG A . n 
+C 3 88  GLY 88  82  82  GLY GLY A . n 
+C 3 89  LEU 89  83  83  LEU LEU A . n 
+C 3 90  ALA 90  84  84  ALA ALA A . n 
+C 3 91  VAL 91  85  85  VAL VAL A . n 
+C 3 92  LYS 92  86  86  LYS LYS A . n 
+C 3 93  THR 93  87  87  THR THR A . n 
+C 3 94  ILE 94  88  88  ILE ILE A . n 
+C 3 95  GLN 95  89  89  GLN GLN A . n 
+C 3 96  GLN 96  90  90  GLN GLN A . n 
+C 3 97  HIS 97  91  91  HIS HIS A . n 
+C 3 98  LEU 98  92  92  LEU LEU A . n 
+C 3 99  GLY 99  93  93  GLY GLY A . n 
+C 3 100 GLN 100 94  94  GLN GLN A . n 
+C 3 101 LEU 101 95  95  LEU LEU A . n 
+C 3 102 ASN 102 96  96  ASN ASN A . n 
+C 3 103 MET 103 97  97  MET MET A . n 
+C 3 104 LEU 104 98  98  LEU LEU A . n 
+C 3 105 HIS 105 99  99  HIS HIS A . n 
+C 3 106 ARG 106 100 100 ARG ARG A . n 
+C 3 107 ARG 107 101 101 ARG ARG A . n 
+C 3 108 SER 108 102 102 SER SER A . n 
+C 3 109 GLY 109 103 103 GLY GLY A . n 
+C 3 110 LEU 110 104 104 LEU LEU A . n 
+C 3 111 PRO 111 105 105 PRO PRO A . n 
+C 3 112 ARG 112 106 106 ARG ARG A . n 
+C 3 113 PRO 113 107 107 PRO PRO A . n 
+C 3 114 SER 114 108 108 SER SER A . n 
+C 3 115 ASP 115 109 109 ASP ASP A . n 
+C 3 116 SER 116 110 110 SER SER A . n 
+C 3 117 ASN 117 111 111 ASN ASN A . n 
+C 3 118 ALA 118 112 112 ALA ALA A . n 
+C 3 119 VAL 119 113 113 VAL VAL A . n 
+C 3 120 SER 120 114 114 SER SER A . n 
+C 3 121 LEU 121 115 115 LEU LEU A . n 
+C 3 122 VAL 122 116 116 VAL VAL A . n 
+C 3 123 MET 123 117 117 MET MET A . n 
+C 3 124 ARG 124 118 118 ARG ARG A . n 
+C 3 125 ARG 125 119 119 ARG ARG A . n 
+C 3 126 ILE 126 120 120 ILE ILE A . n 
+C 3 127 ARG 127 121 121 ARG ARG A . n 
+C 3 128 LYS 128 122 122 LYS LYS A . n 
+C 3 129 GLU 129 123 123 GLU GLU A . n 
+C 3 130 ASN 130 124 124 ASN ASN A . n 
+C 3 131 VAL 131 125 125 VAL VAL A . n 
+C 3 132 ASP 132 126 126 ASP ASP A . n 
+C 3 133 ALA 133 127 127 ALA ALA A . n 
+C 3 134 GLY 134 128 128 GLY GLY A . n 
+C 3 135 GLU 135 129 129 GLU GLU A . n 
+C 3 136 ARG 136 130 130 ARG ARG A . n 
+C 3 137 ALA 137 131 131 ALA ALA A . n 
+C 3 138 LYS 138 132 132 LYS LYS A . n 
+C 3 139 GLN 139 133 133 GLN GLN A . n 
+C 3 140 ALA 140 134 134 ALA ALA A . n 
+C 3 141 LEU 141 135 135 LEU LEU A . n 
+C 3 142 ALA 142 136 136 ALA ALA A . n 
+C 3 143 PHE 143 137 137 PHE PHE A . n 
+C 3 144 GLU 144 138 138 GLU GLU A . n 
+C 3 145 ARG 145 139 139 ARG ARG A . n 
+C 3 146 THR 146 140 140 THR THR A . n 
+C 3 147 ASP 147 141 141 ASP ASP A . n 
+C 3 148 PHE 148 142 142 PHE PHE A . n 
+C 3 149 ASP 149 143 143 ASP ASP A . n 
+C 3 150 GLN 150 144 144 GLN GLN A . n 
+C 3 151 VAL 151 145 145 VAL VAL A . n 
+C 3 152 ARG 152 146 146 ARG ARG A . n 
+C 3 153 SER 153 147 147 SER SER A . n 
+C 3 154 LEU 154 148 148 LEU LEU A . n 
+C 3 155 MET 155 149 149 MET MET A . n 
+C 3 156 GLU 156 150 150 GLU GLU A . n 
+C 3 157 ASN 157 151 151 ASN ASN A . n 
+C 3 158 SER 158 152 152 SER SER A . n 
+C 3 159 ASP 159 153 153 ASP ASP A . n 
+C 3 160 ARG 160 154 154 ARG ARG A . n 
+C 3 161 CYS 161 155 155 CYS CYS A . n 
+C 3 162 GLN 162 156 156 GLN GLN A . n 
+C 3 163 ASP 163 157 157 ASP ASP A . n 
+C 3 164 ILE 164 158 158 ILE ILE A . n 
+C 3 165 ARG 165 159 159 ARG ARG A . n 
+C 3 166 ASN 166 160 160 ASN ASN A . n 
+C 3 167 LEU 167 161 161 LEU LEU A . n 
+C 3 168 ALA 168 162 162 ALA ALA A . n 
+C 3 169 PHE 169 163 163 PHE PHE A . n 
+C 3 170 LEU 170 164 164 LEU LEU A . n 
+C 3 171 GLY 171 165 165 GLY GLY A . n 
+C 3 172 ILE 172 166 166 ILE ILE A . n 
+C 3 173 ALA 173 167 167 ALA ALA A . n 
+C 3 174 TYR 174 168 168 TYR TYR A . n 
+C 3 175 ASN 175 169 169 ASN ASN A . n 
+C 3 176 THR 176 170 170 THR THR A . n 
+C 3 177 LEU 177 171 171 LEU LEU A . n 
+C 3 178 LEU 178 172 172 LEU LEU A . n 
+C 3 179 ARG 179 173 173 ARG ARG A . n 
+C 3 180 ILE 180 174 174 ILE ILE A . n 
+C 3 181 ALA 181 175 175 ALA ALA A . n 
+C 3 182 GLU 182 176 176 GLU GLU A . n 
+C 3 183 ILE 183 177 177 ILE ILE A . n 
+C 3 184 ALA 184 178 178 ALA ALA A . n 
+C 3 185 ARG 185 179 179 ARG ARG A . n 
+C 3 186 ILE 186 180 180 ILE ILE A . n 
+C 3 187 ARG 187 181 181 ARG ARG A . n 
+C 3 188 VAL 188 182 182 VAL VAL A . n 
+C 3 189 LYS 189 183 183 LYS LYS A . n 
+C 3 190 ASP 190 184 184 ASP ASP A . n 
+C 3 191 ILE 191 185 185 ILE ILE A . n 
+C 3 192 SER 192 186 186 SER SER A . n 
+C 3 193 ARG 193 187 187 ARG ARG A . n 
+C 3 194 THR 194 188 188 THR THR A . n 
+C 3 195 ASP 195 189 189 ASP ASP A . n 
+C 3 196 GLY 196 190 190 GLY GLY A . n 
+C 3 197 GLY 197 191 191 GLY GLY A . n 
+C 3 198 ARG 198 192 192 ARG ARG A . n 
+C 3 199 MET 199 193 193 MET MET A . n 
+C 3 200 LEU 200 194 194 LEU LEU A . n 
+C 3 201 ILE 201 195 195 ILE ILE A . n 
+C 3 202 HIS 202 196 196 HIS HIS A . n 
+C 3 203 ILE 203 197 197 ILE ILE A . n 
+C 3 204 GLY 204 198 198 GLY GLY A . n 
+C 3 205 ARG 205 199 199 ARG ARG A . n 
+C 3 206 THR 206 200 200 THR THR A . n 
+C 3 207 LYS 207 201 201 LYS LYS A . n 
+C 3 208 THR 208 202 202 THR THR A . n 
+C 3 209 LEU 209 203 203 LEU LEU A . n 
+C 3 210 VAL 210 204 204 VAL VAL A . n 
+C 3 211 SER 211 205 205 SER SER A . n 
+C 3 212 THR 212 206 206 THR THR A . n 
+C 3 213 ALA 213 207 207 ALA ALA A . n 
+C 3 214 GLY 214 208 208 GLY GLY A . n 
+C 3 215 VAL 215 209 209 VAL VAL A . n 
+C 3 216 GLU 216 210 210 GLU GLU A . n 
+C 3 217 LYS 217 211 211 LYS LYS A . n 
+C 3 218 ALA 218 212 212 ALA ALA A . n 
+C 3 219 LEU 219 213 213 LEU LEU A . n 
+C 3 220 SER 220 214 214 SER SER A . n 
+C 3 221 LEU 221 215 215 LEU LEU A . n 
+C 3 222 GLY 222 216 216 GLY GLY A . n 
+C 3 223 VAL 223 217 217 VAL VAL A . n 
+C 3 224 THR 224 218 218 THR THR A . n 
+C 3 225 LYS 225 219 219 LYS LYS A . n 
+C 3 226 LEU 226 220 220 LEU LEU A . n 
+C 3 227 VAL 227 221 221 VAL VAL A . n 
+C 3 228 GLU 228 222 222 GLU GLU A . n 
+C 3 229 ARG 229 223 223 ARG ARG A . n 
+C 3 230 TRP 230 224 224 TRP TRP A . n 
+C 3 231 ILE 231 225 225 ILE ILE A . n 
+C 3 232 SER 232 226 226 SER SER A . n 
+C 3 233 VAL 233 227 227 VAL VAL A . n 
+C 3 234 SER 234 228 228 SER SER A . n 
+C 3 235 GLY 235 229 229 GLY GLY A . n 
+C 3 236 VAL 236 230 230 VAL VAL A . n 
+C 3 237 ALA 237 231 231 ALA ALA A . n 
+C 3 238 ASP 238 232 232 ASP ASP A . n 
+C 3 239 ASP 239 233 233 ASP ASP A . n 
+C 3 240 PRO 240 234 234 PRO PRO A . n 
+C 3 241 ASN 241 235 235 ASN ASN A . n 
+C 3 242 ASN 242 236 236 ASN ASN A . n 
+C 3 243 TYR 243 237 237 TYR TYR A . n 
+C 3 244 LEU 244 238 238 LEU LEU A . n 
+C 3 245 PHE 245 239 239 PHE PHE A . n 
+C 3 246 CYS 246 240 240 CYS CYS A . n 
+C 3 247 ARG 247 241 241 ARG ARG A . n 
+C 3 248 VAL 248 242 242 VAL VAL A . n 
+C 3 249 ARG 249 243 243 ARG ARG A . n 
+C 3 250 LYS 250 244 244 LYS LYS A . n 
+C 3 251 ASN 251 245 245 ASN ASN A . n 
+C 3 252 GLY 252 246 246 GLY GLY A . n 
+C 3 253 VAL 253 247 247 VAL VAL A . n 
+C 3 254 ALA 254 248 248 ALA ALA A . n 
+C 3 255 ALA 255 249 249 ALA ALA A . n 
+C 3 256 PRO 256 250 250 PRO PRO A . n 
+C 3 257 SER 257 251 251 SER SER A . n 
+C 3 258 ALA 258 252 252 ALA ALA A . n 
+C 3 259 THR 259 253 253 THR THR A . n 
+C 3 260 SER 260 254 254 SER SER A . n 
+C 3 261 GLN 261 255 255 GLN GLN A . n 
+C 3 262 LEU 262 256 256 LEU LEU A . n 
+C 3 263 SER 263 257 257 SER SER A . n 
+C 3 264 THR 264 258 258 THR THR A . n 
+C 3 265 ARG 265 259 259 ARG ARG A . n 
+C 3 266 ALA 266 260 260 ALA ALA A . n 
+C 3 267 LEU 267 261 261 LEU LEU A . n 
+C 3 268 GLU 268 262 262 GLU GLU A . n 
+C 3 269 GLY 269 263 263 GLY GLY A . n 
+C 3 270 ILE 270 264 264 ILE ILE A . n 
+C 3 271 PHE 271 265 265 PHE PHE A . n 
+C 3 272 GLU 272 266 266 GLU GLU A . n 
+C 3 273 ALA 273 267 267 ALA ALA A . n 
+C 3 274 THR 274 268 268 THR THR A . n 
+C 3 275 HIS 275 269 269 HIS HIS A . n 
+C 3 276 ARG 276 270 270 ARG ARG A . n 
+C 3 277 LEU 277 271 271 LEU LEU A . n 
+C 3 278 ILE 278 272 272 ILE ILE A . n 
+C 3 279 TYR 279 273 273 TYR TYR A . n 
+C 3 280 GLY 280 274 274 GLY GLY A . n 
+C 3 281 ALA 281 275 275 ALA ALA A . n 
+C 3 282 LYS 282 276 276 LYS LYS A . n 
+C 3 283 ASP 283 277 277 ASP ASP A . n 
+C 3 284 ASP 284 278 278 ASP ASP A . n 
+C 3 285 SER 285 279 279 SER SER A . n 
+C 3 286 GLY 286 280 280 GLY GLY A . n 
+C 3 287 GLN 287 281 281 GLN GLN A . n 
+C 3 288 ARG 288 282 282 ARG ARG A . n 
+C 3 289 TYR 289 283 283 TYR TYR A . n 
+C 3 290 LEU 290 284 284 LEU LEU A . n 
+C 3 291 ALA 291 285 285 ALA ALA A . n 
+C 3 292 TRP 292 286 286 TRP TRP A . n 
+C 3 293 SER 293 287 287 SER SER A . n 
+C 3 294 GLY 294 288 288 GLY GLY A . n 
+C 3 295 HIS 295 289 289 HIS HIS A . n 
+C 3 296 SER 296 290 290 SER SER A . n 
+C 3 297 ALA 297 291 291 ALA ALA A . n 
+C 3 298 ARG 298 292 292 ARG ARG A . n 
+C 3 299 VAL 299 293 293 VAL VAL A . n 
+C 3 300 GLY 300 294 294 GLY GLY A . n 
+C 3 301 ALA 301 295 295 ALA ALA A . n 
+C 3 302 ALA 302 296 296 ALA ALA A . n 
+C 3 303 ARG 303 297 297 ARG ARG A . n 
+C 3 304 ASP 304 298 298 ASP ASP A . n 
+C 3 305 MET 305 299 299 MET MET A . n 
+C 3 306 ALA 306 300 300 ALA ALA A . n 
+C 3 307 ARG 307 301 301 ARG ARG A . n 
+C 3 308 ALA 308 302 302 ALA ALA A . n 
+C 3 309 GLY 309 303 303 GLY GLY A . n 
+C 3 310 VAL 310 304 304 VAL VAL A . n 
+C 3 311 SER 311 305 305 SER SER A . n 
+C 3 312 ILE 312 306 306 ILE ILE A . n 
+C 3 313 PRO 313 307 307 PRO PRO A . n 
+C 3 314 GLU 314 308 308 GLU GLU A . n 
+C 3 315 ILE 315 309 309 ILE ILE A . n 
+C 3 316 MET 316 310 310 MET MET A . n 
+C 3 317 GLN 317 311 311 GLN GLN A . n 
+C 3 318 ALA 318 312 312 ALA ALA A . n 
+C 3 319 GLY 319 313 313 GLY GLY A . n 
+C 3 320 GLY 320 314 314 GLY GLY A . n 
+C 3 321 TRP 321 315 315 TRP TRP A . n 
+C 3 322 THR 322 316 316 THR THR A . n 
+C 3 323 ASN 323 317 317 ASN ASN A . n 
+C 3 324 VAL 324 318 318 VAL VAL A . n 
+C 3 325 ASN 325 319 319 ASN ASN A . n 
+C 3 326 ILE 326 320 320 ILE ILE A . n 
+C 3 327 VAL 327 321 321 VAL VAL A . n 
+C 3 328 MET 328 322 322 MET MET A . n 
+C 3 329 ASN 329 323 323 ASN ASN A . n 
+C 3 330 TYR 330 324 324 TYR TYR A . n 
+C 3 331 ILE 331 325 325 ILE ILE A . n 
+C 3 332 ARG 332 326 326 ARG ARG A . n 
+C 3 333 ASN 333 327 327 ASN ASN A . n 
+C 3 334 LEU 334 328 328 LEU LEU A . n 
+C 3 335 ASP 335 329 329 ASP ASP A . n 
+C 3 336 SER 336 330 330 SER SER A . n 
+C 3 337 GLU 337 331 331 GLU GLU A . n 
+C 3 338 THR 338 332 332 THR THR A . n 
+C 3 339 GLY 339 333 333 GLY GLY A . n 
+C 3 340 ALA 340 334 334 ALA ALA A . n 
+C 3 341 MET 341 335 335 MET MET A . n 
+C 3 342 VAL 342 336 336 VAL VAL A . n 
+C 3 343 ARG 343 337 337 ARG ARG A . n 
+C 3 344 LEU 344 338 338 LEU LEU A . n 
+C 3 345 LEU 345 339 339 LEU LEU A . n 
+C 3 346 GLU 346 340 340 GLU GLU A . n 
+C 3 347 ASP 347 341 341 ASP ASP A . n 
+C 3 348 GLY 348 342 ?   ?   ?   A . n 
+C 3 349 ASP 349 343 ?   ?   ?   A . n 
+D 3 1   MET 1   -5  ?   ?   ?   B . n 
+D 3 2   HIS 2   -4  ?   ?   ?   B . n 
+D 3 3   HIS 3   -3  ?   ?   ?   B . n 
+D 3 4   HIS 4   -2  ?   ?   ?   B . n 
+D 3 5   HIS 5   -1  ?   ?   ?   B . n 
+D 3 6   HIS 6   0   ?   ?   ?   B . n 
+D 3 7   HIS 7   1   ?   ?   ?   B . n 
+D 3 8   SER 8   2   ?   ?   ?   B . n 
+D 3 9   ASN 9   3   ?   ?   ?   B . n 
+D 3 10  LEU 10  4   ?   ?   ?   B . n 
+D 3 11  LEU 11  5   ?   ?   ?   B . n 
+D 3 12  THR 12  6   ?   ?   ?   B . n 
+D 3 13  VAL 13  7   ?   ?   ?   B . n 
+D 3 14  HIS 14  8   ?   ?   ?   B . n 
+D 3 15  GLN 15  9   ?   ?   ?   B . n 
+D 3 16  ASN 16  10  ?   ?   ?   B . n 
+D 3 17  LEU 17  11  ?   ?   ?   B . n 
+D 3 18  PRO 18  12  ?   ?   ?   B . n 
+D 3 19  ALA 19  13  ?   ?   ?   B . n 
+D 3 20  LEU 20  14  ?   ?   ?   B . n 
+D 3 21  PRO 21  15  ?   ?   ?   B . n 
+D 3 22  VAL 22  16  ?   ?   ?   B . n 
+D 3 23  ASP 23  17  ?   ?   ?   B . n 
+D 3 24  ALA 24  18  ?   ?   ?   B . n 
+D 3 25  THR 25  19  19  THR THR B . n 
+D 3 26  SER 26  20  20  SER SER B . n 
+D 3 27  ASP 27  21  21  ASP ASP B . n 
+D 3 28  GLU 28  22  22  GLU GLU B . n 
+D 3 29  VAL 29  23  23  VAL VAL B . n 
+D 3 30  ARG 30  24  24  ARG ARG B . n 
+D 3 31  LYS 31  25  25  LYS LYS B . n 
+D 3 32  ASN 32  26  26  ASN ASN B . n 
+D 3 33  LEU 33  27  27  LEU LEU B . n 
+D 3 34  MET 34  28  28  MET MET B . n 
+D 3 35  ASP 35  29  29  ASP ASP B . n 
+D 3 36  MET 36  30  30  MET MET B . n 
+D 3 37  PHE 37  31  31  PHE PHE B . n 
+D 3 38  ARG 38  32  32  ARG ARG B . n 
+D 3 39  ASP 39  33  33  ASP ASP B . n 
+D 3 40  ARG 40  34  34  ARG ARG B . n 
+D 3 41  GLN 41  35  35  GLN GLN B . n 
+D 3 42  ALA 42  36  36  ALA ALA B . n 
+D 3 43  PHE 43  37  37  PHE PHE B . n 
+D 3 44  SER 44  38  38  SER SER B . n 
+D 3 45  GLU 45  39  39  GLU GLU B . n 
+D 3 46  HIS 46  40  40  HIS HIS B . n 
+D 3 47  THR 47  41  41  THR THR B . n 
+D 3 48  TRP 48  42  42  TRP TRP B . n 
+D 3 49  LYS 49  43  43  LYS LYS B . n 
+D 3 50  MET 50  44  44  MET MET B . n 
+D 3 51  LEU 51  45  45  LEU LEU B . n 
+D 3 52  LEU 52  46  46  LEU LEU B . n 
+D 3 53  SER 53  47  47  SER SER B . n 
+D 3 54  VAL 54  48  48  VAL VAL B . n 
+D 3 55  CYS 55  49  49  CYS CYS B . n 
+D 3 56  ARG 56  50  50  ARG ARG B . n 
+D 3 57  SER 57  51  51  SER SER B . n 
+D 3 58  TRP 58  52  52  TRP TRP B . n 
+D 3 59  ALA 59  53  53  ALA ALA B . n 
+D 3 60  ALA 60  54  54  ALA ALA B . n 
+D 3 61  TRP 61  55  55  TRP TRP B . n 
+D 3 62  CYS 62  56  56  CYS CYS B . n 
+D 3 63  LYS 63  57  57  LYS LYS B . n 
+D 3 64  LEU 64  58  58  LEU LEU B . n 
+D 3 65  ASN 65  59  59  ASN ASN B . n 
+D 3 66  ASN 66  60  60  ASN ASN B . n 
+D 3 67  ARG 67  61  61  ARG ARG B . n 
+D 3 68  LYS 68  62  62  LYS LYS B . n 
+D 3 69  TRP 69  63  63  TRP TRP B . n 
+D 3 70  PHE 70  64  64  PHE PHE B . n 
+D 3 71  PRO 71  65  65  PRO PRO B . n 
+D 3 72  ALA 72  66  66  ALA ALA B . n 
+D 3 73  GLU 73  67  67  GLU GLU B . n 
+D 3 74  PRO 74  68  68  PRO PRO B . n 
+D 3 75  GLU 75  69  69  GLU GLU B . n 
+D 3 76  ASP 76  70  70  ASP ASP B . n 
+D 3 77  VAL 77  71  71  VAL VAL B . n 
+D 3 78  ARG 78  72  72  ARG ARG B . n 
+D 3 79  ASP 79  73  73  ASP ASP B . n 
+D 3 80  TYR 80  74  74  TYR TYR B . n 
+D 3 81  LEU 81  75  75  LEU LEU B . n 
+D 3 82  LEU 82  76  76  LEU LEU B . n 
+D 3 83  TYR 83  77  77  TYR TYR B . n 
+D 3 84  LEU 84  78  78  LEU LEU B . n 
+D 3 85  GLN 85  79  79  GLN GLN B . n 
+D 3 86  ALA 86  80  80  ALA ALA B . n 
+D 3 87  ARG 87  81  81  ARG ARG B . n 
+D 3 88  GLY 88  82  82  GLY GLY B . n 
+D 3 89  LEU 89  83  83  LEU LEU B . n 
+D 3 90  ALA 90  84  84  ALA ALA B . n 
+D 3 91  VAL 91  85  85  VAL VAL B . n 
+D 3 92  LYS 92  86  86  LYS LYS B . n 
+D 3 93  THR 93  87  87  THR THR B . n 
+D 3 94  ILE 94  88  88  ILE ILE B . n 
+D 3 95  GLN 95  89  89  GLN GLN B . n 
+D 3 96  GLN 96  90  90  GLN GLN B . n 
+D 3 97  HIS 97  91  91  HIS HIS B . n 
+D 3 98  LEU 98  92  92  LEU LEU B . n 
+D 3 99  GLY 99  93  93  GLY GLY B . n 
+D 3 100 GLN 100 94  94  GLN GLN B . n 
+D 3 101 LEU 101 95  95  LEU LEU B . n 
+D 3 102 ASN 102 96  96  ASN ASN B . n 
+D 3 103 MET 103 97  97  MET MET B . n 
+D 3 104 LEU 104 98  98  LEU LEU B . n 
+D 3 105 HIS 105 99  99  HIS HIS B . n 
+D 3 106 ARG 106 100 100 ARG ARG B . n 
+D 3 107 ARG 107 101 101 ARG ARG B . n 
+D 3 108 SER 108 102 102 SER SER B . n 
+D 3 109 GLY 109 103 103 GLY GLY B . n 
+D 3 110 LEU 110 104 104 LEU LEU B . n 
+D 3 111 PRO 111 105 105 PRO PRO B . n 
+D 3 112 ARG 112 106 106 ARG ARG B . n 
+D 3 113 PRO 113 107 107 PRO PRO B . n 
+D 3 114 SER 114 108 108 SER SER B . n 
+D 3 115 ASP 115 109 109 ASP ASP B . n 
+D 3 116 SER 116 110 110 SER SER B . n 
+D 3 117 ASN 117 111 111 ASN ASN B . n 
+D 3 118 ALA 118 112 112 ALA ALA B . n 
+D 3 119 VAL 119 113 113 VAL VAL B . n 
+D 3 120 SER 120 114 114 SER SER B . n 
+D 3 121 LEU 121 115 115 LEU LEU B . n 
+D 3 122 VAL 122 116 116 VAL VAL B . n 
+D 3 123 MET 123 117 117 MET MET B . n 
+D 3 124 ARG 124 118 118 ARG ARG B . n 
+D 3 125 ARG 125 119 119 ARG ARG B . n 
+D 3 126 ILE 126 120 120 ILE ILE B . n 
+D 3 127 ARG 127 121 121 ARG ARG B . n 
+D 3 128 LYS 128 122 122 LYS LYS B . n 
+D 3 129 GLU 129 123 123 GLU GLU B . n 
+D 3 130 ASN 130 124 124 ASN ASN B . n 
+D 3 131 VAL 131 125 125 VAL VAL B . n 
+D 3 132 ASP 132 126 126 ASP ASP B . n 
+D 3 133 ALA 133 127 127 ALA ALA B . n 
+D 3 134 GLY 134 128 128 GLY GLY B . n 
+D 3 135 GLU 135 129 129 GLU GLU B . n 
+D 3 136 ARG 136 130 130 ARG ARG B . n 
+D 3 137 ALA 137 131 131 ALA ALA B . n 
+D 3 138 LYS 138 132 132 LYS LYS B . n 
+D 3 139 GLN 139 133 133 GLN GLN B . n 
+D 3 140 ALA 140 134 134 ALA ALA B . n 
+D 3 141 LEU 141 135 135 LEU LEU B . n 
+D 3 142 ALA 142 136 136 ALA ALA B . n 
+D 3 143 PHE 143 137 137 PHE PHE B . n 
+D 3 144 GLU 144 138 138 GLU GLU B . n 
+D 3 145 ARG 145 139 139 ARG ARG B . n 
+D 3 146 THR 146 140 140 THR THR B . n 
+D 3 147 ASP 147 141 141 ASP ASP B . n 
+D 3 148 PHE 148 142 142 PHE PHE B . n 
+D 3 149 ASP 149 143 143 ASP ASP B . n 
+D 3 150 GLN 150 144 144 GLN GLN B . n 
+D 3 151 VAL 151 145 145 VAL VAL B . n 
+D 3 152 ARG 152 146 146 ARG ARG B . n 
+D 3 153 SER 153 147 147 SER SER B . n 
+D 3 154 LEU 154 148 148 LEU LEU B . n 
+D 3 155 MET 155 149 149 MET MET B . n 
+D 3 156 GLU 156 150 150 GLU GLU B . n 
+D 3 157 ASN 157 151 151 ASN ASN B . n 
+D 3 158 SER 158 152 152 SER SER B . n 
+D 3 159 ASP 159 153 153 ASP ASP B . n 
+D 3 160 ARG 160 154 154 ARG ARG B . n 
+D 3 161 CYS 161 155 155 CYS CYS B . n 
+D 3 162 GLN 162 156 156 GLN GLN B . n 
+D 3 163 ASP 163 157 157 ASP ASP B . n 
+D 3 164 ILE 164 158 158 ILE ILE B . n 
+D 3 165 ARG 165 159 159 ARG ARG B . n 
+D 3 166 ASN 166 160 160 ASN ASN B . n 
+D 3 167 LEU 167 161 161 LEU LEU B . n 
+D 3 168 ALA 168 162 162 ALA ALA B . n 
+D 3 169 PHE 169 163 163 PHE PHE B . n 
+D 3 170 LEU 170 164 164 LEU LEU B . n 
+D 3 171 GLY 171 165 165 GLY GLY B . n 
+D 3 172 ILE 172 166 166 ILE ILE B . n 
+D 3 173 ALA 173 167 167 ALA ALA B . n 
+D 3 174 TYR 174 168 168 TYR TYR B . n 
+D 3 175 ASN 175 169 169 ASN ASN B . n 
+D 3 176 THR 176 170 170 THR THR B . n 
+D 3 177 LEU 177 171 171 LEU LEU B . n 
+D 3 178 LEU 178 172 172 LEU LEU B . n 
+D 3 179 ARG 179 173 173 ARG ARG B . n 
+D 3 180 ILE 180 174 174 ILE ILE B . n 
+D 3 181 ALA 181 175 175 ALA ALA B . n 
+D 3 182 GLU 182 176 176 GLU GLU B . n 
+D 3 183 ILE 183 177 177 ILE ILE B . n 
+D 3 184 ALA 184 178 178 ALA ALA B . n 
+D 3 185 ARG 185 179 179 ARG ARG B . n 
+D 3 186 ILE 186 180 180 ILE ILE B . n 
+D 3 187 ARG 187 181 181 ARG ARG B . n 
+D 3 188 VAL 188 182 182 VAL VAL B . n 
+D 3 189 LYS 189 183 183 LYS LYS B . n 
+D 3 190 ASP 190 184 184 ASP ASP B . n 
+D 3 191 ILE 191 185 185 ILE ILE B . n 
+D 3 192 SER 192 186 186 SER SER B . n 
+D 3 193 ARG 193 187 187 ARG ARG B . n 
+D 3 194 THR 194 188 188 THR THR B . n 
+D 3 195 ASP 195 189 189 ASP ASP B . n 
+D 3 196 GLY 196 190 190 GLY GLY B . n 
+D 3 197 GLY 197 191 191 GLY GLY B . n 
+D 3 198 ARG 198 192 192 ARG ARG B . n 
+D 3 199 MET 199 193 193 MET MET B . n 
+D 3 200 LEU 200 194 194 LEU LEU B . n 
+D 3 201 ILE 201 195 195 ILE ILE B . n 
+D 3 202 HIS 202 196 196 HIS HIS B . n 
+D 3 203 ILE 203 197 197 ILE ILE B . n 
+D 3 204 GLY 204 198 198 GLY GLY B . n 
+D 3 205 ARG 205 199 199 ARG ARG B . n 
+D 3 206 THR 206 200 200 THR THR B . n 
+D 3 207 LYS 207 201 201 LYS LYS B . n 
+D 3 208 THR 208 202 202 THR THR B . n 
+D 3 209 LEU 209 203 203 LEU LEU B . n 
+D 3 210 VAL 210 204 204 VAL VAL B . n 
+D 3 211 SER 211 205 205 SER SER B . n 
+D 3 212 THR 212 206 206 THR THR B . n 
+D 3 213 ALA 213 207 207 ALA ALA B . n 
+D 3 214 GLY 214 208 208 GLY GLY B . n 
+D 3 215 VAL 215 209 209 VAL VAL B . n 
+D 3 216 GLU 216 210 210 GLU GLU B . n 
+D 3 217 LYS 217 211 211 LYS LYS B . n 
+D 3 218 ALA 218 212 212 ALA ALA B . n 
+D 3 219 LEU 219 213 213 LEU LEU B . n 
+D 3 220 SER 220 214 214 SER SER B . n 
+D 3 221 LEU 221 215 215 LEU LEU B . n 
+D 3 222 GLY 222 216 216 GLY GLY B . n 
+D 3 223 VAL 223 217 217 VAL VAL B . n 
+D 3 224 THR 224 218 218 THR THR B . n 
+D 3 225 LYS 225 219 219 LYS LYS B . n 
+D 3 226 LEU 226 220 220 LEU LEU B . n 
+D 3 227 VAL 227 221 221 VAL VAL B . n 
+D 3 228 GLU 228 222 222 GLU GLU B . n 
+D 3 229 ARG 229 223 223 ARG ARG B . n 
+D 3 230 TRP 230 224 224 TRP TRP B . n 
+D 3 231 ILE 231 225 225 ILE ILE B . n 
+D 3 232 SER 232 226 226 SER SER B . n 
+D 3 233 VAL 233 227 227 VAL VAL B . n 
+D 3 234 SER 234 228 228 SER SER B . n 
+D 3 235 GLY 235 229 229 GLY GLY B . n 
+D 3 236 VAL 236 230 230 VAL VAL B . n 
+D 3 237 ALA 237 231 231 ALA ALA B . n 
+D 3 238 ASP 238 232 232 ASP ASP B . n 
+D 3 239 ASP 239 233 233 ASP ASP B . n 
+D 3 240 PRO 240 234 234 PRO PRO B . n 
+D 3 241 ASN 241 235 235 ASN ASN B . n 
+D 3 242 ASN 242 236 236 ASN ASN B . n 
+D 3 243 TYR 243 237 237 TYR TYR B . n 
+D 3 244 LEU 244 238 238 LEU LEU B . n 
+D 3 245 PHE 245 239 239 PHE PHE B . n 
+D 3 246 CYS 246 240 240 CYS CYS B . n 
+D 3 247 ARG 247 241 241 ARG ARG B . n 
+D 3 248 VAL 248 242 242 VAL VAL B . n 
+D 3 249 ARG 249 243 243 ARG ARG B . n 
+D 3 250 LYS 250 244 244 LYS LYS B . n 
+D 3 251 ASN 251 245 245 ASN ASN B . n 
+D 3 252 GLY 252 246 246 GLY GLY B . n 
+D 3 253 VAL 253 247 247 VAL VAL B . n 
+D 3 254 ALA 254 248 248 ALA ALA B . n 
+D 3 255 ALA 255 249 249 ALA ALA B . n 
+D 3 256 PRO 256 250 250 PRO PRO B . n 
+D 3 257 SER 257 251 251 SER SER B . n 
+D 3 258 ALA 258 252 252 ALA ALA B . n 
+D 3 259 THR 259 253 253 THR THR B . n 
+D 3 260 SER 260 254 254 SER SER B . n 
+D 3 261 GLN 261 255 255 GLN GLN B . n 
+D 3 262 LEU 262 256 256 LEU LEU B . n 
+D 3 263 SER 263 257 257 SER SER B . n 
+D 3 264 THR 264 258 258 THR THR B . n 
+D 3 265 ARG 265 259 259 ARG ARG B . n 
+D 3 266 ALA 266 260 260 ALA ALA B . n 
+D 3 267 LEU 267 261 261 LEU LEU B . n 
+D 3 268 GLU 268 262 262 GLU GLU B . n 
+D 3 269 GLY 269 263 263 GLY GLY B . n 
+D 3 270 ILE 270 264 264 ILE ILE B . n 
+D 3 271 PHE 271 265 265 PHE PHE B . n 
+D 3 272 GLU 272 266 266 GLU GLU B . n 
+D 3 273 ALA 273 267 267 ALA ALA B . n 
+D 3 274 THR 274 268 268 THR THR B . n 
+D 3 275 HIS 275 269 269 HIS HIS B . n 
+D 3 276 ARG 276 270 270 ARG ARG B . n 
+D 3 277 LEU 277 271 271 LEU LEU B . n 
+D 3 278 ILE 278 272 272 ILE ILE B . n 
+D 3 279 TYR 279 273 273 TYR TYR B . n 
+D 3 280 GLY 280 274 274 GLY GLY B . n 
+D 3 281 ALA 281 275 275 ALA ALA B . n 
+D 3 282 LYS 282 276 276 LYS LYS B . n 
+D 3 283 ASP 283 277 277 ASP ASP B . n 
+D 3 284 ASP 284 278 278 ASP ASP B . n 
+D 3 285 SER 285 279 279 SER SER B . n 
+D 3 286 GLY 286 280 280 GLY GLY B . n 
+D 3 287 GLN 287 281 281 GLN GLN B . n 
+D 3 288 ARG 288 282 282 ARG ARG B . n 
+D 3 289 TYR 289 283 283 TYR TYR B . n 
+D 3 290 LEU 290 284 284 LEU LEU B . n 
+D 3 291 ALA 291 285 285 ALA ALA B . n 
+D 3 292 TRP 292 286 286 TRP TRP B . n 
+D 3 293 SER 293 287 287 SER SER B . n 
+D 3 294 GLY 294 288 288 GLY GLY B . n 
+D 3 295 HIS 295 289 289 HIS HIS B . n 
+D 3 296 SER 296 290 290 SER SER B . n 
+D 3 297 ALA 297 291 291 ALA ALA B . n 
+D 3 298 ARG 298 292 292 ARG ARG B . n 
+D 3 299 VAL 299 293 293 VAL VAL B . n 
+D 3 300 GLY 300 294 294 GLY GLY B . n 
+D 3 301 ALA 301 295 295 ALA ALA B . n 
+D 3 302 ALA 302 296 296 ALA ALA B . n 
+D 3 303 ARG 303 297 297 ARG ARG B . n 
+D 3 304 ASP 304 298 298 ASP ASP B . n 
+D 3 305 MET 305 299 299 MET MET B . n 
+D 3 306 ALA 306 300 300 ALA ALA B . n 
+D 3 307 ARG 307 301 301 ARG ARG B . n 
+D 3 308 ALA 308 302 302 ALA ALA B . n 
+D 3 309 GLY 309 303 303 GLY GLY B . n 
+D 3 310 VAL 310 304 304 VAL VAL B . n 
+D 3 311 SER 311 305 305 SER SER B . n 
+D 3 312 ILE 312 306 306 ILE ILE B . n 
+D 3 313 PRO 313 307 307 PRO PRO B . n 
+D 3 314 GLU 314 308 308 GLU GLU B . n 
+D 3 315 ILE 315 309 309 ILE ILE B . n 
+D 3 316 MET 316 310 310 MET MET B . n 
+D 3 317 GLN 317 311 311 GLN GLN B . n 
+D 3 318 ALA 318 312 312 ALA ALA B . n 
+D 3 319 GLY 319 313 313 GLY GLY B . n 
+D 3 320 GLY 320 314 314 GLY GLY B . n 
+D 3 321 TRP 321 315 315 TRP TRP B . n 
+D 3 322 THR 322 316 316 THR THR B . n 
+D 3 323 ASN 323 317 317 ASN ASN B . n 
+D 3 324 VAL 324 318 318 VAL VAL B . n 
+D 3 325 ASN 325 319 319 ASN ASN B . n 
+D 3 326 ILE 326 320 320 ILE ILE B . n 
+D 3 327 VAL 327 321 321 VAL VAL B . n 
+D 3 328 MET 328 322 322 MET MET B . n 
+D 3 329 ASN 329 323 323 ASN ASN B . n 
+D 3 330 TYR 330 324 324 TYR TYR B . n 
+D 3 331 ILE 331 325 325 ILE ILE B . n 
+D 3 332 ARG 332 326 326 ARG ARG B . n 
+D 3 333 ASN 333 327 327 ASN ASN B . n 
+D 3 334 LEU 334 328 328 LEU LEU B . n 
+D 3 335 ASP 335 329 ?   ?   ?   B . n 
+D 3 336 SER 336 330 ?   ?   ?   B . n 
+D 3 337 GLU 337 331 ?   ?   ?   B . n 
+D 3 338 THR 338 332 ?   ?   ?   B . n 
+D 3 339 GLY 339 333 333 GLY GLY B . n 
+D 3 340 ALA 340 334 334 ALA ALA B . n 
+D 3 341 MET 341 335 335 MET MET B . n 
+D 3 342 VAL 342 336 336 VAL VAL B . n 
+D 3 343 ARG 343 337 337 ARG ARG B . n 
+D 3 344 LEU 344 338 338 LEU LEU B . n 
+D 3 345 LEU 345 339 339 LEU LEU B . n 
+D 3 346 GLU 346 340 340 GLU GLU B . n 
+D 3 347 ASP 347 341 341 ASP ASP B . n 
+D 3 348 GLY 348 342 ?   ?   ?   B . n 
+D 3 349 ASP 349 343 ?   ?   ?   B . n 
+# 
+loop_
+_pdbx_version.entry_id 
+_pdbx_version.revision_date 
+_pdbx_version.major_version 
+_pdbx_version.minor_version 
+_pdbx_version.revision_type 
+_pdbx_version.details 
+1KBU 2008-04-27 3 2    'Version format compliance' 'compliance with PDB format V.3.15'          
+1KBU 2011-07-13 4 0000 'Version format compliance' 'compliance with PDB Exchange Dictionary V4' 
+# 
+loop_
+_software.name 
+_software.classification 
+_software.version 
+_software.citation_id 
+_software.pdbx_ordinal 
+TNT 'model building' . ? 1 
+TNT refinement       . ? 2 
+# 
+loop_
+_ndb_struct_conf_na.entry_id 
+_ndb_struct_conf_na.feature 
+1KBU 'double helix'        
+1KBU 'b-form double helix' 
+# 
+loop_
+_ndb_struct_na_base_pair.model_number 
+_ndb_struct_na_base_pair.i_label_asym_id 
+_ndb_struct_na_base_pair.i_label_comp_id 
+_ndb_struct_na_base_pair.i_label_seq_id 
+_ndb_struct_na_base_pair.i_symmetry 
+_ndb_struct_na_base_pair.j_label_asym_id 
+_ndb_struct_na_base_pair.j_label_comp_id 
+_ndb_struct_na_base_pair.j_label_seq_id 
+_ndb_struct_na_base_pair.j_symmetry 
+_ndb_struct_na_base_pair.shear 
+_ndb_struct_na_base_pair.stretch 
+_ndb_struct_na_base_pair.stagger 
+_ndb_struct_na_base_pair.buckle 
+_ndb_struct_na_base_pair.opening 
+_ndb_struct_na_base_pair.pair_number 
+_ndb_struct_na_base_pair.pair_name 
+_ndb_struct_na_base_pair.i_auth_asym_id 
+_ndb_struct_na_base_pair.i_auth_seq_id 
+_ndb_struct_na_base_pair.i_PDB_ins_code 
+_ndb_struct_na_base_pair.j_auth_asym_id 
+_ndb_struct_na_base_pair.j_auth_seq_id 
+_ndb_struct_na_base_pair.j_PDB_ins_code 
+_ndb_struct_na_base_pair.hbond_type_28 
+_ndb_struct_na_base_pair.hbond_type_12 
+1 A DA 1  1_555 B DT 34 1_555 0.199  0.071  0.020  -4.332  12.924 1  C_DA1:DT34_D  C 1  ? D 34 ? ?  1 
+1 A DT 2  1_555 B DA 33 1_555 -0.664 -0.655 0.321  -3.672  -5.043 2  C_DT2:DA33_D  C 2  ? D 33 ? 20 1 
+1 A DA 3  1_555 B DT 32 1_555 0.429  -0.068 -0.064 3.078   2.441  3  C_DA3:DT32_D  C 3  ? D 32 ? 20 1 
+1 A DA 4  1_555 B DT 31 1_555 0.169  0.053  0.192  14.551  -2.953 4  C_DA4:DT31_D  C 4  ? D 31 ? 20 1 
+1 A DG 5  1_555 B DC 30 1_555 0.532  -0.535 0.553  6.060   -1.219 5  C_DG5:DC30_D  C 5  ? D 30 ? 19 1 
+1 A DT 6  1_555 B DA 29 1_555 0.352  -0.500 -0.297 1.848   -1.801 6  C_DT6:DA29_D  C 6  ? D 29 ? 20 1 
+1 A DT 7  1_555 B DA 28 1_555 -0.232 -0.204 -0.404 -1.768  -3.022 7  C_DT7:DA28_D  C 7  ? D 28 ? 20 1 
+1 A DC 8  1_555 B DG 27 1_555 0.312  -0.131 -0.210 -2.697  0.099  8  C_DC8:DG27_D  C 8  ? D 27 ? 19 1 
+1 A DG 9  1_555 B DC 26 1_555 -0.146 -0.219 -0.015 -3.584  -2.327 9  C_DG9:DC26_D  C 9  ? D 26 ? 19 1 
+1 A DT 10 1_555 B DA 25 1_555 0.192  0.077  0.124  10.016  8.628  10 C_DT10:DA25_D C 10 ? D 25 ? 20 1 
+1 A DA 11 1_555 B DT 24 1_555 -0.281 -0.343 -0.002 -0.596  -2.007 11 C_DA11:DT24_D C 11 ? D 24 ? 20 1 
+1 A DT 12 1_555 B DA 23 1_555 0.088  -0.349 0.386  -2.910  0.316  12 C_DT12:DA23_D C 12 ? D 23 ? 20 1 
+1 A DA 13 1_555 B DT 22 1_555 -0.128 -0.011 -0.397 -16.276 -1.902 13 C_DA13:DT22_D C 13 ? D 22 ? 20 1 
+1 A DA 14 1_555 B DT 21 1_555 -0.125 0.059  -0.305 -9.161  1.991  14 C_DA14:DT21_D C 14 ? D 21 ? 20 1 
+1 A DT 15 1_555 B DA 20 1_555 -0.267 0.182  0.052  1.027   11.918 15 C_DT15:DA20_D C 15 ? D 20 ? ?  ? 
+1 A DG 16 1_555 B DC 19 1_555 -0.019 -0.083 0.332  8.931   -5.524 16 C_DG16:DC19_D C 16 ? D 19 ? 19 1 
+# 
+loop_
+_ndb_struct_na_base_pair_step.model_number 
+_ndb_struct_na_base_pair_step.i_label_asym_id_1 
+_ndb_struct_na_base_pair_step.i_label_comp_id_1 
+_ndb_struct_na_base_pair_step.i_label_seq_id_1 
+_ndb_struct_na_base_pair_step.i_symmetry_1 
+_ndb_struct_na_base_pair_step.j_label_asym_id_1 
+_ndb_struct_na_base_pair_step.j_label_comp_id_1 
+_ndb_struct_na_base_pair_step.j_label_seq_id_1 
+_ndb_struct_na_base_pair_step.j_symmetry_1 
+_ndb_struct_na_base_pair_step.i_label_asym_id_2 
+_ndb_struct_na_base_pair_step.i_label_comp_id_2 
+_ndb_struct_na_base_pair_step.i_label_seq_id_2 
+_ndb_struct_na_base_pair_step.i_symmetry_2 
+_ndb_struct_na_base_pair_step.j_label_asym_id_2 
+_ndb_struct_na_base_pair_step.j_label_comp_id_2 
+_ndb_struct_na_base_pair_step.j_label_seq_id_2 
+_ndb_struct_na_base_pair_step.j_symmetry_2 
+_ndb_struct_na_base_pair_step.shift 
+_ndb_struct_na_base_pair_step.slide 
+_ndb_struct_na_base_pair_step.rise 
+_ndb_struct_na_base_pair_step.tilt 
+_ndb_struct_na_base_pair_step.roll 
+_ndb_struct_na_base_pair_step.twist 
+_ndb_struct_na_base_pair_step.x_displacement 
+_ndb_struct_na_base_pair_step.y_displacement 
+_ndb_struct_na_base_pair_step.helical_rise 
+_ndb_struct_na_base_pair_step.inclination 
+_ndb_struct_na_base_pair_step.tip 
+_ndb_struct_na_base_pair_step.helical_twist 
+_ndb_struct_na_base_pair_step.step_number 
+_ndb_struct_na_base_pair_step.step_name 
+_ndb_struct_na_base_pair_step.i_auth_asym_id_1 
+_ndb_struct_na_base_pair_step.i_auth_seq_id_1 
+_ndb_struct_na_base_pair_step.i_PDB_ins_code_1 
+_ndb_struct_na_base_pair_step.j_auth_asym_id_1 
+_ndb_struct_na_base_pair_step.j_auth_seq_id_1 
+_ndb_struct_na_base_pair_step.j_PDB_ins_code_1 
+_ndb_struct_na_base_pair_step.i_auth_asym_id_2 
+_ndb_struct_na_base_pair_step.i_auth_seq_id_2 
+_ndb_struct_na_base_pair_step.i_PDB_ins_code_2 
+_ndb_struct_na_base_pair_step.j_auth_asym_id_2 
+_ndb_struct_na_base_pair_step.j_auth_seq_id_2 
+_ndb_struct_na_base_pair_step.j_PDB_ins_code_2 
+1 A DA 1  1_555 B DT 34 1_555 A DT 2  1_555 B DA 33 1_555 -0.852 -0.967 3.435 -3.480 -1.798 20.477 -1.837 0.735  3.599 -4.999  
+9.676  20.845 1  CC_DA1DT2:DA33DT34_DD   C 1  ? D 34 ? C 2  ? D 33 ? 
+1 A DT 2  1_555 B DA 33 1_555 A DA 3  1_555 B DT 32 1_555 -0.263 1.871  3.093 4.326  -2.080 48.153 2.434  0.634  2.982 -2.542  
+-5.286 48.377 2  CC_DT2DA3:DT32DA33_DD   C 2  ? D 33 ? C 3  ? D 32 ? 
+1 A DA 3  1_555 B DT 32 1_555 A DA 4  1_555 B DT 31 1_555 0.343  -0.113 3.154 -2.513 1.300  25.640 -0.601 -1.442 3.097 2.918   
+5.642  25.793 3  CC_DA3DA4:DT31DT32_DD   C 3  ? D 32 ? C 4  ? D 31 ? 
+1 A DA 4  1_555 B DT 31 1_555 A DG 5  1_555 B DC 30 1_555 0.965  -1.112 3.418 -1.864 3.423  35.060 -2.353 -1.875 3.245 5.661   
+3.082  35.269 4  CC_DA4DG5:DC30DT31_DD   C 4  ? D 31 ? C 5  ? D 30 ? 
+1 A DG 5  1_555 B DC 30 1_555 A DT 6  1_555 B DA 29 1_555 -0.648 -0.681 3.315 5.850  3.003  35.933 -1.498 1.835  3.110 4.818   
+-9.385 36.510 5  CC_DG5DT6:DA29DC30_DD   C 5  ? D 30 ? C 6  ? D 29 ? 
+1 A DT 6  1_555 B DA 29 1_555 A DT 7  1_555 B DA 28 1_555 0.431  -0.079 3.362 2.518  1.168  35.128 -0.310 -0.327 3.380 1.931   
+-4.163 35.234 6  CC_DT6DT7:DA28DA29_DD   C 6  ? D 29 ? C 7  ? D 28 ? 
+1 A DT 7  1_555 B DA 28 1_555 A DC 8  1_555 B DG 27 1_555 0.164  -0.181 3.292 -0.636 7.596  29.940 -1.816 -0.431 3.148 14.410  
+1.207  30.873 7  CC_DT7DC8:DG27DA28_DD   C 7  ? D 28 ? C 8  ? D 27 ? 
+1 A DC 8  1_555 B DG 27 1_555 A DG 9  1_555 B DC 26 1_555 0.289  0.586  3.395 -0.898 3.786  35.428 0.383  -0.609 3.429 6.198   
+1.470  35.634 8  CC_DC8DG9:DC26DG27_DD   C 8  ? D 27 ? C 9  ? D 26 ? 
+1 A DG 9  1_555 B DC 26 1_555 A DT 10 1_555 B DA 25 1_555 0.195  -0.021 3.018 0.532  5.877  28.211 -1.253 -0.283 2.956 11.893  
+-1.077 28.809 9  CC_DG9DT10:DA25DC26_DD  C 9  ? D 26 ? C 10 ? D 25 ? 
+1 A DT 10 1_555 B DA 25 1_555 A DA 11 1_555 B DT 24 1_555 0.320  -1.147 3.499 2.379  4.226  35.615 -2.494 -0.161 3.359 6.870   
+-3.868 35.933 10 CC_DT10DA11:DT24DA25_DD C 10 ? D 25 ? C 11 ? D 24 ? 
+1 A DA 11 1_555 B DT 24 1_555 A DT 12 1_555 B DA 23 1_555 0.730  -1.106 3.503 -1.819 1.177  33.053 -2.149 -1.605 3.419 2.066   
+3.193  33.122 11 CC_DA11DT12:DA23DT24_DD C 11 ? D 24 ? C 12 ? D 23 ? 
+1 A DT 12 1_555 B DA 23 1_555 A DA 13 1_555 B DT 22 1_555 -0.942 -0.811 3.555 2.544  -7.580 36.857 -0.172 1.822  3.576 -11.819 
+-3.966 37.685 12 CC_DT12DA13:DT22DA23_DD C 12 ? D 23 ? C 13 ? D 22 ? 
+1 A DA 13 1_555 B DT 22 1_555 A DA 14 1_555 B DT 21 1_555 0.020  -0.518 3.306 0.088  -0.766 36.577 -0.719 -0.019 3.315 -1.221  
+-0.140 36.585 13 CC_DA13DA14:DT21DT22_DD C 13 ? D 22 ? C 14 ? D 21 ? 
+1 A DA 14 1_555 B DT 21 1_555 A DT 15 1_555 B DA 20 1_555 -0.333 -0.469 2.973 -3.412 2.948  23.607 -1.990 -0.199 2.912 7.122   
+8.244  24.028 14 CC_DA14DT15:DA20DT21_DD C 14 ? D 21 ? C 15 ? D 20 ? 
+1 A DT 15 1_555 B DA 20 1_555 A DG 16 1_555 B DC 19 1_555 -1.892 1.104  3.307 -5.034 -3.638 40.222 2.004  2.147  3.401 -5.252  
+7.268  40.679 15 CC_DT15DG16:DC19DA20_DD C 15 ? D 20 ? C 16 ? D 19 ? 
+# 
+loop_
+_pdbx_unobs_or_zero_occ_residues.id 
+_pdbx_unobs_or_zero_occ_residues.polymer_flag 
+_pdbx_unobs_or_zero_occ_residues.occupancy_flag 
+_pdbx_unobs_or_zero_occ_residues.PDB_model_num 
+_pdbx_unobs_or_zero_occ_residues.auth_asym_id 
+_pdbx_unobs_or_zero_occ_residues.auth_comp_id 
+_pdbx_unobs_or_zero_occ_residues.auth_seq_id 
+_pdbx_unobs_or_zero_occ_residues.PDB_ins_code 
+1  Y 1 1 A MET -5  ? 
+2  Y 1 1 A HIS -4  ? 
+3  Y 1 1 A HIS -3  ? 
+4  Y 1 1 A HIS -2  ? 
+5  Y 1 1 A HIS -1  ? 
+6  Y 1 1 A HIS 0   ? 
+7  Y 1 1 A HIS 1   ? 
+8  Y 1 1 A SER 2   ? 
+9  Y 1 1 A ASN 3   ? 
+10 Y 1 1 A LEU 4   ? 
+11 Y 1 1 A LEU 5   ? 
+12 Y 1 1 A THR 6   ? 
+13 Y 1 1 A VAL 7   ? 
+14 Y 1 1 A HIS 8   ? 
+15 Y 1 1 A GLN 9   ? 
+16 Y 1 1 A ASN 10  ? 
+17 Y 1 1 A LEU 11  ? 
+18 Y 1 1 A PRO 12  ? 
+19 Y 1 1 A ALA 13  ? 
+20 Y 1 1 A LEU 14  ? 
+21 Y 1 1 A PRO 15  ? 
+22 Y 1 1 A VAL 16  ? 
+23 Y 1 1 A ASP 17  ? 
+24 Y 0 1 A GLY 191 ? 
+25 Y 0 1 A LEU 215 ? 
+26 Y 0 1 A ALA 312 ? 
+27 Y 0 1 A THR 316 ? 
+28 Y 1 1 A GLY 342 ? 
+29 Y 1 1 A ASP 343 ? 
+30 Y 1 1 B MET -5  ? 
+31 Y 1 1 B HIS -4  ? 
+32 Y 1 1 B HIS -3  ? 
+33 Y 1 1 B HIS -2  ? 
+34 Y 1 1 B HIS -1  ? 
+35 Y 1 1 B HIS 0   ? 
+36 Y 1 1 B HIS 1   ? 
+37 Y 1 1 B SER 2   ? 
+38 Y 1 1 B ASN 3   ? 
+39 Y 1 1 B LEU 4   ? 
+40 Y 1 1 B LEU 5   ? 
+41 Y 1 1 B THR 6   ? 
+42 Y 1 1 B VAL 7   ? 
+43 Y 1 1 B HIS 8   ? 
+44 Y 1 1 B GLN 9   ? 
+45 Y 1 1 B ASN 10  ? 
+46 Y 1 1 B LEU 11  ? 
+47 Y 1 1 B PRO 12  ? 
+48 Y 1 1 B ALA 13  ? 
+49 Y 1 1 B LEU 14  ? 
+50 Y 1 1 B PRO 15  ? 
+51 Y 1 1 B VAL 16  ? 
+52 Y 1 1 B ASP 17  ? 
+53 Y 1 1 B ALA 18  ? 
+54 Y 1 1 B ASP 329 ? 
+55 Y 1 1 B SER 330 ? 
+56 Y 1 1 B GLU 331 ? 
+57 Y 1 1 B THR 332 ? 
+58 Y 1 1 B GLY 342 ? 
+59 Y 1 1 B ASP 343 ? 
+# 
+loop_
+_pdbx_unobs_or_zero_occ_atoms.id 
+_pdbx_unobs_or_zero_occ_atoms.polymer_flag 
+_pdbx_unobs_or_zero_occ_atoms.occupancy_flag 
+_pdbx_unobs_or_zero_occ_atoms.PDB_model_num 
+_pdbx_unobs_or_zero_occ_atoms.auth_asym_id 
+_pdbx_unobs_or_zero_occ_atoms.auth_comp_id 
+_pdbx_unobs_or_zero_occ_atoms.auth_seq_id 
+_pdbx_unobs_or_zero_occ_atoms.PDB_ins_code 
+_pdbx_unobs_or_zero_occ_atoms.auth_atom_id 
+_pdbx_unobs_or_zero_occ_atoms.label_alt_id 
+1  Y 0 1 A VAL 182 ? CB  ? 
+2  Y 0 1 A VAL 182 ? CG1 ? 
+3  Y 0 1 A VAL 182 ? CG2 ? 
+4  Y 0 1 A VAL 221 ? CB  ? 
+5  Y 0 1 A VAL 221 ? CG1 ? 
+6  Y 0 1 A VAL 221 ? CG2 ? 
+7  Y 0 1 A GLU 222 ? CB  ? 
+8  Y 0 1 A GLU 222 ? CG  ? 
+9  Y 0 1 A GLU 222 ? CD  ? 
+10 Y 0 1 A GLU 222 ? OE1 ? 
+11 Y 0 1 A GLU 222 ? OE2 ? 
+12 Y 0 1 A PRO 234 ? CB  ? 
+13 Y 0 1 A PRO 234 ? CG  ? 
+14 Y 0 1 A PRO 234 ? CD  ? 
+15 Y 0 1 A ALA 302 ? CB  ? 
+16 Y 0 1 A PRO 307 ? CB  ? 
+17 Y 0 1 A PRO 307 ? CG  ? 
+18 Y 0 1 A PRO 307 ? CD  ? 
+19 Y 0 1 A GLN 311 ? CB  ? 
+20 Y 0 1 A GLN 311 ? CG  ? 
+21 Y 0 1 A GLN 311 ? CD  ? 
+22 Y 0 1 A GLN 311 ? OE1 ? 
+23 Y 0 1 A GLN 311 ? NE2 ? 
+24 Y 0 1 A ASN 317 ? CB  ? 
+25 Y 0 1 A ASN 317 ? CG  ? 
+26 Y 0 1 A ASN 317 ? OD1 ? 
+27 Y 0 1 A ASN 317 ? ND2 ? 
+28 Y 0 1 A ASN 323 ? CG  ? 
+29 Y 0 1 A ASN 323 ? OD1 ? 
+30 Y 0 1 A ASN 323 ? ND2 ? 
+31 Y 0 1 B GLU 22  ? CG  ? 
+32 Y 0 1 B GLU 22  ? CD  ? 
+33 Y 0 1 B GLU 22  ? OE1 ? 
+34 Y 0 1 B GLU 22  ? OE2 ? 
+35 Y 0 1 B MET 28  ? CB  ? 
+36 Y 0 1 B MET 28  ? CG  ? 
+37 Y 0 1 B MET 28  ? SD  ? 
+38 Y 0 1 B MET 28  ? CE  ? 
+39 Y 0 1 B ASN 317 ? CB  ? 
+40 Y 0 1 B ASN 317 ? CG  ? 
+41 Y 0 1 B ASN 317 ? OD1 ? 
+42 Y 0 1 B ASN 317 ? ND2 ? 
+# 
+_pdbx_struct_assembly.id                   1 
+_pdbx_struct_assembly.details              author_defined_assembly 
+_pdbx_struct_assembly.method_details       ? 
+_pdbx_struct_assembly.oligomeric_details   octameric 
+_pdbx_struct_assembly.oligomeric_count     8 
+# 
+_pdbx_struct_assembly_gen.assembly_id       1 
+_pdbx_struct_assembly_gen.oper_expression   1,2 
+_pdbx_struct_assembly_gen.asym_id_list      A,G,B,H,C,E,D,F 
+# 
+loop_
+_pdbx_struct_oper_list.id 
+_pdbx_struct_oper_list.type 
+_pdbx_struct_oper_list.name 
+_pdbx_struct_oper_list.symmetry_operation 
+_pdbx_struct_oper_list.matrix[1][1] 
+_pdbx_struct_oper_list.matrix[1][2] 
+_pdbx_struct_oper_list.matrix[1][3] 
+_pdbx_struct_oper_list.vector[1] 
+_pdbx_struct_oper_list.matrix[2][1] 
+_pdbx_struct_oper_list.matrix[2][2] 
+_pdbx_struct_oper_list.matrix[2][3] 
+_pdbx_struct_oper_list.vector[2] 
+_pdbx_struct_oper_list.matrix[3][1] 
+_pdbx_struct_oper_list.matrix[3][2] 
+_pdbx_struct_oper_list.matrix[3][3] 
+_pdbx_struct_oper_list.vector[3] 
+1 'identity operation'         1_555 x,y,z       1.0000000000 0.0000000000 0.0000000000 0.0000000000 0.0000000000 1.0000000000  
+0.0000000000 0.0000000000   0.0000000000 0.0000000000 1.0000000000  0.0000000000   
+2 'crystal symmetry operation' 4_566 x,-y+1,-z+1 1.0000000000 0.0000000000 0.0000000000 0.0000000000 0.0000000000 -1.0000000000 
+0.0000000000 121.6000000000 0.0000000000 0.0000000000 -1.0000000000 179.3100000000 
+# 
+loop_
+_pdbx_nonpoly_scheme.asym_id 
+_pdbx_nonpoly_scheme.entity_id 
+_pdbx_nonpoly_scheme.mon_id 
+_pdbx_nonpoly_scheme.ndb_seq_num 
+_pdbx_nonpoly_scheme.pdb_seq_num 
+_pdbx_nonpoly_scheme.auth_seq_num 
+_pdbx_nonpoly_scheme.pdb_mon_id 
+_pdbx_nonpoly_scheme.auth_mon_id 
+_pdbx_nonpoly_scheme.pdb_strand_id 
+_pdbx_nonpoly_scheme.pdb_ins_code 
+E 4 HOH 1   344 9   HOH HOH A . 
+E 4 HOH 2   345 21  HOH HOH A . 
+E 4 HOH 3   346 26  HOH HOH A . 
+E 4 HOH 4   347 33  HOH HOH A . 
+E 4 HOH 5   348 35  HOH HOH A . 
+E 4 HOH 6   349 36  HOH HOH A . 
+E 4 HOH 7   350 39  HOH HOH A . 
+E 4 HOH 8   351 42  HOH HOH A . 
+E 4 HOH 9   352 60  HOH HOH A . 
+E 4 HOH 10  353 69  HOH HOH A . 
+E 4 HOH 11  354 70  HOH HOH A . 
+E 4 HOH 12  355 71  HOH HOH A . 
+E 4 HOH 13  356 74  HOH HOH A . 
+E 4 HOH 14  357 76  HOH HOH A . 
+E 4 HOH 15  358 86  HOH HOH A . 
+E 4 HOH 16  359 91  HOH HOH A . 
+E 4 HOH 17  360 100 HOH HOH A . 
+E 4 HOH 18  361 103 HOH HOH A . 
+E 4 HOH 19  362 112 HOH HOH A . 
+E 4 HOH 20  363 124 HOH HOH A . 
+E 4 HOH 21  364 130 HOH HOH A . 
+E 4 HOH 22  365 132 HOH HOH A . 
+E 4 HOH 23  366 135 HOH HOH A . 
+E 4 HOH 24  367 136 HOH HOH A . 
+E 4 HOH 25  368 137 HOH HOH A . 
+E 4 HOH 26  369 139 HOH HOH A . 
+E 4 HOH 27  370 141 HOH HOH A . 
+E 4 HOH 28  371 142 HOH HOH A . 
+E 4 HOH 29  372 146 HOH HOH A . 
+E 4 HOH 30  373 148 HOH HOH A . 
+E 4 HOH 31  374 154 HOH HOH A . 
+E 4 HOH 32  375 155 HOH HOH A . 
+E 4 HOH 33  376 156 HOH HOH A . 
+E 4 HOH 34  377 158 HOH HOH A . 
+E 4 HOH 35  378 168 HOH HOH A . 
+E 4 HOH 36  379 170 HOH HOH A . 
+E 4 HOH 37  380 172 HOH HOH A . 
+E 4 HOH 38  381 181 HOH HOH A . 
+E 4 HOH 39  382 194 HOH HOH A . 
+E 4 HOH 40  383 195 HOH HOH A . 
+E 4 HOH 41  384 196 HOH HOH A . 
+E 4 HOH 42  385 197 HOH HOH A . 
+E 4 HOH 43  386 198 HOH HOH A . 
+E 4 HOH 44  387 199 HOH HOH A . 
+E 4 HOH 45  388 200 HOH HOH A . 
+E 4 HOH 46  389 201 HOH HOH A . 
+E 4 HOH 47  390 203 HOH HOH A . 
+E 4 HOH 48  391 205 HOH HOH A . 
+E 4 HOH 49  392 207 HOH HOH A . 
+E 4 HOH 50  393 208 HOH HOH A . 
+E 4 HOH 51  394 210 HOH HOH A . 
+E 4 HOH 52  395 211 HOH HOH A . 
+E 4 HOH 53  396 212 HOH HOH A . 
+E 4 HOH 54  397 213 HOH HOH A . 
+E 4 HOH 55  398 215 HOH HOH A . 
+E 4 HOH 56  399 216 HOH HOH A . 
+E 4 HOH 57  400 217 HOH HOH A . 
+E 4 HOH 58  401 218 HOH HOH A . 
+E 4 HOH 59  402 235 HOH HOH A . 
+F 4 HOH 1   344 1   HOH HOH B . 
+F 4 HOH 2   345 2   HOH HOH B . 
+F 4 HOH 3   346 3   HOH HOH B . 
+F 4 HOH 4   347 4   HOH HOH B . 
+F 4 HOH 5   348 5   HOH HOH B . 
+F 4 HOH 6   349 6   HOH HOH B . 
+F 4 HOH 7   350 7   HOH HOH B . 
+F 4 HOH 8   351 8   HOH HOH B . 
+F 4 HOH 9   352 10  HOH HOH B . 
+F 4 HOH 10  353 11  HOH HOH B . 
+F 4 HOH 11  354 12  HOH HOH B . 
+F 4 HOH 12  355 13  HOH HOH B . 
+F 4 HOH 13  356 15  HOH HOH B . 
+F 4 HOH 14  357 16  HOH HOH B . 
+F 4 HOH 15  358 17  HOH HOH B . 
+F 4 HOH 16  359 18  HOH HOH B . 
+F 4 HOH 17  360 20  HOH HOH B . 
+F 4 HOH 18  361 22  HOH HOH B . 
+F 4 HOH 19  362 23  HOH HOH B . 
+F 4 HOH 20  363 25  HOH HOH B . 
+F 4 HOH 21  364 27  HOH HOH B . 
+F 4 HOH 22  365 29  HOH HOH B . 
+F 4 HOH 23  366 30  HOH HOH B . 
+F 4 HOH 24  367 31  HOH HOH B . 
+F 4 HOH 25  368 32  HOH HOH B . 
+F 4 HOH 26  369 34  HOH HOH B . 
+F 4 HOH 27  370 37  HOH HOH B . 
+F 4 HOH 28  371 40  HOH HOH B . 
+F 4 HOH 29  372 41  HOH HOH B . 
+F 4 HOH 30  373 43  HOH HOH B . 
+F 4 HOH 31  374 44  HOH HOH B . 
+F 4 HOH 32  375 45  HOH HOH B . 
+F 4 HOH 33  376 46  HOH HOH B . 
+F 4 HOH 34  377 47  HOH HOH B . 
+F 4 HOH 35  378 50  HOH HOH B . 
+F 4 HOH 36  379 51  HOH HOH B . 
+F 4 HOH 37  380 52  HOH HOH B . 
+F 4 HOH 38  381 53  HOH HOH B . 
+F 4 HOH 39  382 54  HOH HOH B . 
+F 4 HOH 40  383 58  HOH HOH B . 
+F 4 HOH 41  384 59  HOH HOH B . 
+F 4 HOH 42  385 61  HOH HOH B . 
+F 4 HOH 43  386 62  HOH HOH B . 
+F 4 HOH 44  387 63  HOH HOH B . 
+F 4 HOH 45  388 65  HOH HOH B . 
+F 4 HOH 46  389 68  HOH HOH B . 
+F 4 HOH 47  390 72  HOH HOH B . 
+F 4 HOH 48  391 73  HOH HOH B . 
+F 4 HOH 49  392 77  HOH HOH B . 
+F 4 HOH 50  393 78  HOH HOH B . 
+F 4 HOH 51  394 80  HOH HOH B . 
+F 4 HOH 52  395 81  HOH HOH B . 
+F 4 HOH 53  396 82  HOH HOH B . 
+F 4 HOH 54  397 83  HOH HOH B . 
+F 4 HOH 55  398 88  HOH HOH B . 
+F 4 HOH 56  399 89  HOH HOH B . 
+F 4 HOH 57  400 90  HOH HOH B . 
+F 4 HOH 58  401 92  HOH HOH B . 
+F 4 HOH 59  402 95  HOH HOH B . 
+F 4 HOH 60  403 97  HOH HOH B . 
+F 4 HOH 61  404 99  HOH HOH B . 
+F 4 HOH 62  405 101 HOH HOH B . 
+F 4 HOH 63  406 102 HOH HOH B . 
+F 4 HOH 64  407 106 HOH HOH B . 
+F 4 HOH 65  408 107 HOH HOH B . 
+F 4 HOH 66  409 108 HOH HOH B . 
+F 4 HOH 67  410 110 HOH HOH B . 
+F 4 HOH 68  411 111 HOH HOH B . 
+F 4 HOH 69  412 115 HOH HOH B . 
+F 4 HOH 70  413 116 HOH HOH B . 
+F 4 HOH 71  414 118 HOH HOH B . 
+F 4 HOH 72  415 121 HOH HOH B . 
+F 4 HOH 73  416 122 HOH HOH B . 
+F 4 HOH 74  417 123 HOH HOH B . 
+F 4 HOH 75  418 128 HOH HOH B . 
+F 4 HOH 76  419 129 HOH HOH B . 
+F 4 HOH 77  420 133 HOH HOH B . 
+F 4 HOH 78  421 134 HOH HOH B . 
+F 4 HOH 79  422 138 HOH HOH B . 
+F 4 HOH 80  423 140 HOH HOH B . 
+F 4 HOH 81  424 144 HOH HOH B . 
+F 4 HOH 82  425 145 HOH HOH B . 
+F 4 HOH 83  426 147 HOH HOH B . 
+F 4 HOH 84  427 149 HOH HOH B . 
+F 4 HOH 85  428 150 HOH HOH B . 
+F 4 HOH 86  429 157 HOH HOH B . 
+F 4 HOH 87  430 162 HOH HOH B . 
+F 4 HOH 88  431 164 HOH HOH B . 
+F 4 HOH 89  432 166 HOH HOH B . 
+F 4 HOH 90  433 169 HOH HOH B . 
+F 4 HOH 91  434 171 HOH HOH B . 
+F 4 HOH 92  435 173 HOH HOH B . 
+F 4 HOH 93  436 174 HOH HOH B . 
+F 4 HOH 94  437 175 HOH HOH B . 
+F 4 HOH 95  438 176 HOH HOH B . 
+F 4 HOH 96  439 177 HOH HOH B . 
+F 4 HOH 97  440 178 HOH HOH B . 
+F 4 HOH 98  441 179 HOH HOH B . 
+F 4 HOH 99  442 180 HOH HOH B . 
+F 4 HOH 100 443 182 HOH HOH B . 
+F 4 HOH 101 444 183 HOH HOH B . 
+F 4 HOH 102 445 184 HOH HOH B . 
+F 4 HOH 103 446 186 HOH HOH B . 
+F 4 HOH 104 447 187 HOH HOH B . 
+F 4 HOH 105 448 188 HOH HOH B . 
+F 4 HOH 106 449 189 HOH HOH B . 
+F 4 HOH 107 450 191 HOH HOH B . 
+F 4 HOH 108 451 192 HOH HOH B . 
+F 4 HOH 109 452 193 HOH HOH B . 
+F 4 HOH 110 453 219 HOH HOH B . 
+F 4 HOH 111 454 220 HOH HOH B . 
+F 4 HOH 112 455 221 HOH HOH B . 
+F 4 HOH 113 456 222 HOH HOH B . 
+F 4 HOH 114 457 223 HOH HOH B . 
+F 4 HOH 115 458 224 HOH HOH B . 
+F 4 HOH 116 459 225 HOH HOH B . 
+F 4 HOH 117 460 226 HOH HOH B . 
+F 4 HOH 118 461 227 HOH HOH B . 
+F 4 HOH 119 462 228 HOH HOH B . 
+F 4 HOH 120 463 229 HOH HOH B . 
+F 4 HOH 121 464 232 HOH HOH B . 
+F 4 HOH 122 465 233 HOH HOH B . 
+F 4 HOH 123 466 234 HOH HOH B . 
+F 4 HOH 124 467 236 HOH HOH B . 
+G 4 HOH 1   35  24  HOH HOH C . 
+G 4 HOH 2   36  57  HOH HOH C . 
+G 4 HOH 3   37  64  HOH HOH C . 
+G 4 HOH 4   38  66  HOH HOH C . 
+G 4 HOH 5   39  67  HOH HOH C . 
+G 4 HOH 6   40  87  HOH HOH C . 
+G 4 HOH 7   41  96  HOH HOH C . 
+G 4 HOH 8   42  98  HOH HOH C . 
+G 4 HOH 9   43  105 HOH HOH C . 
+G 4 HOH 10  44  117 HOH HOH C . 
+G 4 HOH 11  45  119 HOH HOH C . 
+G 4 HOH 12  46  126 HOH HOH C . 
+G 4 HOH 13  47  160 HOH HOH C . 
+G 4 HOH 14  48  161 HOH HOH C . 
+G 4 HOH 15  49  163 HOH HOH C . 
+G 4 HOH 16  50  190 HOH HOH C . 
+G 4 HOH 17  51  206 HOH HOH C . 
+G 4 HOH 18  52  230 HOH HOH C . 
+G 4 HOH 19  53  231 HOH HOH C . 
+G 4 HOH 20  54  237 HOH HOH C . 
+H 4 HOH 1   35  14  HOH HOH D . 
+H 4 HOH 2   36  19  HOH HOH D . 
+H 4 HOH 3   37  28  HOH HOH D . 
+H 4 HOH 4   38  38  HOH HOH D . 
+H 4 HOH 5   39  48  HOH HOH D . 
+H 4 HOH 6   40  49  HOH HOH D . 
+H 4 HOH 7   41  55  HOH HOH D . 
+H 4 HOH 8   42  56  HOH HOH D . 
+H 4 HOH 9   43  75  HOH HOH D . 
+H 4 HOH 10  44  79  HOH HOH D . 
+H 4 HOH 11  45  84  HOH HOH D . 
+H 4 HOH 12  46  85  HOH HOH D . 
+H 4 HOH 13  47  93  HOH HOH D . 
+H 4 HOH 14  48  94  HOH HOH D . 
+H 4 HOH 15  49  104 HOH HOH D . 
+H 4 HOH 16  50  109 HOH HOH D . 
+H 4 HOH 17  51  113 HOH HOH D . 
+H 4 HOH 18  52  114 HOH HOH D . 
+H 4 HOH 19  53  120 HOH HOH D . 
+H 4 HOH 20  54  125 HOH HOH D . 
+H 4 HOH 21  55  127 HOH HOH D . 
+H 4 HOH 22  56  131 HOH HOH D . 
+H 4 HOH 23  57  143 HOH HOH D . 
+H 4 HOH 24  58  151 HOH HOH D . 
+H 4 HOH 25  59  152 HOH HOH D . 
+H 4 HOH 26  60  153 HOH HOH D . 
+H 4 HOH 27  61  159 HOH HOH D . 
+H 4 HOH 28  62  165 HOH HOH D . 
+H 4 HOH 29  63  167 HOH HOH D . 
+H 4 HOH 30  64  185 HOH HOH D . 
+H 4 HOH 31  65  202 HOH HOH D . 
+H 4 HOH 32  66  204 HOH HOH D . 
+H 4 HOH 33  67  209 HOH HOH D . 
+H 4 HOH 34  68  214 HOH HOH D . 
+# 
+loop_
+_pdbx_validate_close_contact.id 
+_pdbx_validate_close_contact.PDB_model_num 
+_pdbx_validate_close_contact.auth_atom_id_1 
+_pdbx_validate_close_contact.auth_asym_id_1 
+_pdbx_validate_close_contact.auth_comp_id_1 
+_pdbx_validate_close_contact.auth_seq_id_1 
+_pdbx_validate_close_contact.PDB_ins_code_1 
+_pdbx_validate_close_contact.label_alt_id_1 
+_pdbx_validate_close_contact.auth_atom_id_2 
+_pdbx_validate_close_contact.auth_asym_id_2 
+_pdbx_validate_close_contact.auth_comp_id_2 
+_pdbx_validate_close_contact.auth_seq_id_2 
+_pdbx_validate_close_contact.PDB_ins_code_2 
+_pdbx_validate_close_contact.label_alt_id_2 
+_pdbx_validate_close_contact.dist 
+1 1 O   B HOH 396 ? ? O B HOH 450 ? ? 2.11 
+2 1 NH2 A ARG 301 ? ? O A HOH 388 ? ? 2.15 
+3 1 O   D HOH 53  ? ? O D HOH 66  ? ? 2.16 
+# 
+loop_
+_pdbx_validate_rmsd_angle.id 
+_pdbx_validate_rmsd_angle.PDB_model_num 
+_pdbx_validate_rmsd_angle.auth_atom_id_1 
+_pdbx_validate_rmsd_angle.auth_asym_id_1 
+_pdbx_validate_rmsd_angle.auth_comp_id_1 
+_pdbx_validate_rmsd_angle.auth_seq_id_1 
+_pdbx_validate_rmsd_angle.PDB_ins_code_1 
+_pdbx_validate_rmsd_angle.label_alt_id_1 
+_pdbx_validate_rmsd_angle.auth_atom_id_2 
+_pdbx_validate_rmsd_angle.auth_asym_id_2 
+_pdbx_validate_rmsd_angle.auth_comp_id_2 
+_pdbx_validate_rmsd_angle.auth_seq_id_2 
+_pdbx_validate_rmsd_angle.PDB_ins_code_2 
+_pdbx_validate_rmsd_angle.label_alt_id_2 
+_pdbx_validate_rmsd_angle.auth_atom_id_3 
+_pdbx_validate_rmsd_angle.auth_asym_id_3 
+_pdbx_validate_rmsd_angle.auth_comp_id_3 
+_pdbx_validate_rmsd_angle.auth_seq_id_3 
+_pdbx_validate_rmsd_angle.PDB_ins_code_3 
+_pdbx_validate_rmsd_angle.label_alt_id_3 
+_pdbx_validate_rmsd_angle.angle_deviation 
+1  1 "O4'" C DT  2   ? ? "C1'" C DT  2   ? ? N1    C DT  2   ? ? 2.4   
+2  1 "O4'" C DA  3   ? ? "C1'" C DA  3   ? ? N9    C DA  3   ? ? -4.6  
+3  1 "O4'" C DA  4   ? ? "C1'" C DA  4   ? ? N9    C DA  4   ? ? 5.8   
+4  1 "C3'" C DG  5   ? ? "O3'" C DG  5   ? ? P     C DT  6   ? ? -7.3  
+5  1 "C3'" C DC  8   ? ? "C2'" C DC  8   ? ? "C1'" C DC  8   ? ? -4.8  
+6  1 "O4'" C DC  8   ? ? "C1'" C DC  8   ? ? N1    C DC  8   ? ? 4.2   
+7  1 "O4'" C DT  12  ? ? "C1'" C DT  12  ? ? N1    C DT  12  ? ? 2.7   
+8  1 "C3'" C DA  14  ? ? "C2'" C DA  14  ? ? "C1'" C DA  14  ? ? -6.3  
+9  1 "C3'" C DG  20  ? ? "C2'" C DG  20  ? ? "C1'" C DG  20  ? ? -5.7  
+10 1 C8    C DG  20  ? ? N9    C DG  20  ? ? "C1'" C DG  20  ? ? 10.9  
+11 1 C4    C DG  20  ? ? N9    C DG  20  ? ? "C1'" C DG  20  ? ? -12.4 
+12 1 "C3'" C DT  22  ? ? "C2'" C DT  22  ? ? "C1'" C DT  22  ? ? -5.1  
+13 1 "O4'" C DT  22  ? ? "C1'" C DT  22  ? ? N1    C DT  22  ? ? 3.0   
+14 1 "O4'" C DA  28  ? ? "C1'" C DA  28  ? ? N9    C DA  28  ? ? 3.9   
+15 1 P     C DT  32  ? ? "O5'" C DT  32  ? ? "C5'" C DT  32  ? ? -11.1 
+16 1 "O4'" C DT  34  ? ? "C1'" C DT  34  ? ? N1    C DT  34  ? ? 1.8   
+17 1 "O4'" D DA  4   ? ? "C1'" D DA  4   ? ? N9    D DA  4   ? ? 5.2   
+18 1 P     D DC  8   ? ? "O5'" D DC  8   ? ? "C5'" D DC  8   ? ? -11.3 
+19 1 "O4'" D DC  8   ? ? "C1'" D DC  8   ? ? N1    D DC  8   ? ? -4.7  
+20 1 "C3'" D DT  10  ? ? "C2'" D DT  10  ? ? "C1'" D DT  10  ? ? -5.8  
+21 1 "O4'" D DT  17  ? A "C1'" D DT  17  ? A N1    D DT  17  ? A 3.9   
+22 1 "O4'" D DA  18  ? A "C4'" D DA  18  ? A "C3'" D DA  18  ? A -2.8  
+23 1 P     D DT  21  ? ? "O5'" D DT  21  ? ? "C5'" D DT  21  ? ? -10.5 
+24 1 "C1'" D DT  21  ? ? "O4'" D DT  21  ? ? "C4'" D DT  21  ? ? -9.7  
+25 1 N3    D DT  21  ? ? C4    D DT  21  ? ? O4    D DT  21  ? ? -4.3  
+26 1 C4    D DT  24  ? ? C5    D DT  24  ? ? C7    D DT  24  ? ? 6.8   
+27 1 C6    D DT  24  ? ? C5    D DT  24  ? ? C7    D DT  24  ? ? -7.0  
+28 1 "O4'" D DA  25  ? ? "C1'" D DA  25  ? ? N9    D DA  25  ? ? -4.6  
+29 1 "C3'" D DT  24  ? ? "O3'" D DT  24  ? ? P     D DA  25  ? ? 7.5   
+30 1 "O4'" D DA  28  ? ? "C1'" D DA  28  ? ? N9    D DA  28  ? ? 2.9   
+31 1 N     A VAL 217 ? ? CA    A VAL 217 ? ? C     A VAL 217 ? ? 17.5  
+32 1 C     A ASP 233 ? ? N     A PRO 234 ? ? CD    A PRO 234 ? ? -17.6 
+33 1 N     A SER 279 ? ? CA    A SER 279 ? ? C     A SER 279 ? ? 25.8  
+34 1 CG    A MET 299 ? ? SD    A MET 299 ? ? CE    A MET 299 ? ? -13.3 
+35 1 NE    A ARG 301 ? ? CZ    A ARG 301 ? ? NH1   A ARG 301 ? ? 4.9   
+36 1 NE    A ARG 301 ? ? CZ    A ARG 301 ? ? NH2   A ARG 301 ? ? -10.9 
+37 1 C     A ILE 306 ? ? N     A PRO 307 ? ? CD    A PRO 307 ? ? -25.0 
+38 1 N     A VAL 318 ? ? CA    A VAL 318 ? ? C     A VAL 318 ? ? 19.7  
+39 1 N     B ARG 326 ? ? CA    B ARG 326 ? ? C     B ARG 326 ? ? 20.1  
+40 1 CB    B LEU 328 ? ? CG    B LEU 328 ? ? CD1   B LEU 328 ? ? 12.2  
+# 
+loop_
+_pdbx_validate_torsion.id 
+_pdbx_validate_torsion.PDB_model_num 
+_pdbx_validate_torsion.auth_comp_id 
+_pdbx_validate_torsion.auth_asym_id 
+_pdbx_validate_torsion.auth_seq_id 
+_pdbx_validate_torsion.PDB_ins_code 
+_pdbx_validate_torsion.phi 
+_pdbx_validate_torsion.psi 
+1  1 THR A 19  ? 56.19   117.74  
+2  1 ASP A 33  ? -114.94 51.80   
+3  1 GLN A 35  ? -68.67  11.53   
+4  1 GLU A 129 ? -44.58  109.82  
+5  1 MET A 149 ? -133.42 -36.14  
+6  1 GLU A 150 ? -48.44  -15.59  
+7  1 SER A 186 ? -121.48 -163.93 
+8  1 THR A 188 ? -2.33   145.43  
+9  1 ASP A 189 ? 35.20   15.69   
+10 1 ARG A 192 ? -68.38  -122.69 
+11 1 MET A 193 ? 159.24  140.37  
+12 1 ILE A 197 ? -102.86 -130.80 
+13 1 LYS A 201 ? -148.51 37.14   
+14 1 VAL A 204 ? -96.39  57.17   
+15 1 SER A 205 ? -126.51 -106.47 
+16 1 SER A 214 ? -92.17  -158.98 
+17 1 VAL A 221 ? -65.79  6.28    
+18 1 ASN A 236 ? -31.80  171.88  
+19 1 PRO A 250 ? -57.34  175.11  
+20 1 SER A 251 ? -175.34 127.24  
+21 1 ALA A 275 ? -37.07  134.01  
+22 1 LYS A 276 ? -35.98  134.14  
+23 1 ASP A 277 ? -94.79  -120.48 
+24 1 ASP A 278 ? -49.17  61.83   
+25 1 SER A 279 ? 104.76  -48.25  
+26 1 ALA A 285 ? -117.60 -145.37 
+27 1 SER A 305 ? -15.05  142.55  
+28 1 ILE A 306 ? -57.94  10.25   
+29 1 PRO A 307 ? -75.70  -96.52  
+30 1 GLU A 308 ? -54.64  27.91   
+31 1 ILE A 309 ? -124.23 -79.20  
+32 1 MET A 310 ? -75.33  24.56   
+33 1 GLN A 311 ? -140.18 -53.57  
+34 1 ALA A 312 ? -36.72  -32.44  
+35 1 ASN A 317 ? 173.81  62.78   
+36 1 VAL A 318 ? -40.34  157.73  
+37 1 ASN A 319 ? 122.47  -30.86  
+38 1 SER B 20  ? 12.79   -55.80  
+39 1 ASP B 33  ? -98.70  54.89   
+40 1 ASP B 126 ? -63.63  11.26   
+41 1 GLU B 129 ? 1.41    121.60  
+42 1 ASP B 189 ? 121.91  -43.51  
+43 1 ALA B 207 ? -78.04  -87.50  
+44 1 ALA B 231 ? -58.55  -1.12   
+45 1 ALA B 249 ? -150.64 70.07   
+46 1 ASP B 277 ? -33.94  177.64  
+47 1 TYR B 283 ? 72.13   30.56   
+48 1 ARG B 297 ? -52.92  -74.21  
+49 1 ASP B 298 ? -31.56  -37.62  
+50 1 ARG B 326 ? -51.07  -179.29 
+51 1 ARG B 337 ? -134.64 -35.73  
+# 
+loop_
+_pdbx_validate_chiral.id 
+_pdbx_validate_chiral.PDB_model_num 
+_pdbx_validate_chiral.auth_comp_id 
+_pdbx_validate_chiral.auth_asym_id 
+_pdbx_validate_chiral.auth_seq_id 
+_pdbx_validate_chiral.PDB_ins_code 
+_pdbx_validate_chiral.details 
+_pdbx_validate_chiral.omega 
+1  1 THR A 19  ? 'Expecting L Found L OUTSIDE RANGE' 23.553 
+2  1 MET A 149 ? 'Expecting L Found L OUTSIDE RANGE' 23.170 
+3  1 THR A 170 ? 'Expecting L Found L OUTSIDE RANGE' 20.144 
+4  1 ILE A 174 ? 'Expecting L Found L OUTSIDE RANGE' 24.370 
+5  1 ASP A 189 ? 'Expecting L Found L OUTSIDE RANGE' 20.989 
+6  1 ILE A 197 ? 'Expecting L Found L OUTSIDE RANGE' 16.809 
+7  1 VAL A 217 ? 'Expecting L Found L EXPECTING SP3' 5.619  
+8  1 ILE A 225 ? 'Expecting L Found L OUTSIDE RANGE' 22.341 
+9  1 LEU A 238 ? 'Expecting L Found L OUTSIDE RANGE' 24.869 
+10 1 SER A 279 ? 'Expecting L Found L OUTSIDE RANGE' 17.403 
+11 1 ILE A 306 ? 'Expecting L Found L OUTSIDE RANGE' 23.565 
+12 1 VAL A 318 ? 'Expecting L Found L OUTSIDE RANGE' 16.354 
+13 1 ILE A 320 ? 'Expecting L Found L OUTSIDE RANGE' 21.228 
+14 1 ASN B 60  ? 'Expecting L Found L OUTSIDE RANGE' 23.622 
+15 1 TRP B 63  ? 'Expecting L Found L OUTSIDE RANGE' 24.205 
+16 1 VAL B 318 ? 'Expecting L Found L OUTSIDE RANGE' 24.842 
+17 1 ILE B 325 ? 'Expecting L Found L OUTSIDE RANGE' 23.087 
+18 1 ARG B 326 ? 'Expecting L Found L OUTSIDE RANGE' 20.667 
+19 1 ASN B 327 ? 'Expecting L Found L OUTSIDE RANGE' 21.736 
+# 
+_pdbx_entity_nonpoly.entity_id   4 
+_pdbx_entity_nonpoly.name        water 
+_pdbx_entity_nonpoly.comp_id     HOH 
+# 

--- a/moldesign/_tests/data/1KBU.pdb
+++ b/moldesign/_tests/data/1KBU.pdb
@@ -1,0 +1,7487 @@
+HEADER    HYDROLASE, LIGASE/DNA                   06-NOV-01   1KBU              
+TITLE     CRE RECOMBINASE BOUND TO A LOXP HOLLIDAY JUNCTION                     
+COMPND    MOL_ID: 1;                                                            
+COMPND   2 MOLECULE: LOXP;                                                      
+COMPND   3 CHAIN: C;                                                            
+COMPND   4 ENGINEERED: YES;                                                     
+COMPND   5 OTHER_DETAILS: PART OF HOLLIDAY JUNCTION;                            
+COMPND   6 MOL_ID: 2;                                                           
+COMPND   7 MOLECULE: LOXP;                                                      
+COMPND   8 CHAIN: D;                                                            
+COMPND   9 ENGINEERED: YES;                                                     
+COMPND  10 OTHER_DETAILS: PART OF HOLLIDAY JUNCTION;                            
+COMPND  11 MOL_ID: 3;                                                           
+COMPND  12 MOLECULE: CRE RECOMBINASE;                                           
+COMPND  13 CHAIN: A, B;                                                         
+COMPND  14 SYNONYM: CRE SITE-SPECIFIC RECOMBINASE;                              
+COMPND  15 ENGINEERED: YES;                                                     
+COMPND  16 OTHER_DETAILS: LYS86 AND LYS201 INTERACTIONS WITH THE                
+COMPND  17 SCISSILE BASE SUGGEST HOW STRAND EXCHANGE ORDER IS                   
+COMPND  18 DETERMINED                                                           
+SOURCE    MOL_ID: 1;                                                            
+SOURCE   2 SYNTHETIC: YES;                                                      
+SOURCE   3 MOL_ID: 2;                                                           
+SOURCE   4 SYNTHETIC: YES;                                                      
+SOURCE   5 MOL_ID: 3;                                                           
+SOURCE   6 ORGANISM_SCIENTIFIC: ENTEROBACTERIA PHAGE P1;                        
+SOURCE   7 ORGANISM_TAXID: 10678;                                               
+SOURCE   8 GENE: CRE;                                                           
+SOURCE   9 EXPRESSION_SYSTEM: ESCHERICHIA COLI BL21(DE3);                       
+SOURCE  10 EXPRESSION_SYSTEM_TAXID: 469008;                                     
+SOURCE  11 EXPRESSION_SYSTEM_STRAIN: BL21(DE3);                                 
+SOURCE  12 EXPRESSION_SYSTEM_VECTOR_TYPE: PLASMID;                              
+SOURCE  13 EXPRESSION_SYSTEM_PLASMID: PET28B(+)                                 
+KEYWDS    SITE-SPECIFIC RECOMBINASE, HOLLIDAY JUNCTION COMPLEX, DNA-            
+KEYWDS   2 PROTEIN CO-CRYSTAL, INT RECOMBINASE MECHANISM, HYDROLASE,            
+KEYWDS   3 LIGASE/DNA COMPLEX                                                   
+EXPDTA    X-RAY DIFFRACTION                                                     
+AUTHOR    S.S.MARTIN,E.PULIDO,V.C.CHU,T.LECHNER,E.P.BALDWIN                     
+REVDAT   2   24-FEB-09 1KBU    1       VERSN                                    
+REVDAT   1   07-JUN-02 1KBU    0                                                
+JRNL        AUTH   S.S.MARTIN,E.PULIDO,V.C.CHU,T.S.LECHNER,E.P.BALDWIN          
+JRNL        TITL   THE ORDER OF STRAND EXCHANGES IN CRE-LOXP                    
+JRNL        TITL 2 RECOMBINATION AND ITS BASIS SUGGESTED BY THE                 
+JRNL        TITL 3 CRYSTAL STRUCTURE OF A CRE-LOXP HOLLIDAY JUNCTION            
+JRNL        TITL 4 COMPLEX                                                      
+JRNL        REF    J.MOL.BIOL.                   V. 319   107 2002              
+JRNL        REFN                   ISSN 0022-2836                               
+JRNL        PMID   12051940                                                     
+JRNL        DOI    10.1016/S0022-2836(02)00246-2                                
+REMARK   1                                                                      
+REMARK   1 REFERENCE 1                                                          
+REMARK   1  AUTH   D.N.GOPAUL,F.GUO,G.D.VAN DUYNE                               
+REMARK   1  TITL   STRUCTURE OF THE HOLLIDAY JUNCTION INTERMEDIATE IN           
+REMARK   1  TITL 2 CRE-LOXP SITE-SPECIFIC RECOMBINATION                         
+REMARK   1  REF    EMBO J.                       V.  17  4175 1998              
+REMARK   1  REFN                   ISSN 0261-4189                               
+REMARK   1  DOI    10.1093/EMBOJ/17.14.4175                                     
+REMARK   1 REFERENCE 2                                                          
+REMARK   1  AUTH   K.C.WOODS,S.S.MARTIN,V.C.CHU,E.P.BALDWIN                     
+REMARK   1  TITL   QUASI-EQUIVALENCE IN SITE-SPECIFIC RECOMBINASE               
+REMARK   1  TITL 2 STRUCTURE AND FUNCTION: CRYSTAL STRUCTURE AND                
+REMARK   1  TITL 3 ACTIVITY OF TRIMERIC CRE RECOMBINASE BOUND TO A              
+REMARK   1  TITL 4 THREE-WAY LOX DNA JUNCTION                                   
+REMARK   1  REF    J.MOL.BIOL.                   V. 313    49 2001              
+REMARK   1  REFN                   ISSN 0022-2836                               
+REMARK   1  DOI    10.1006/JMBI.2001.5012                                       
+REMARK   2                                                                      
+REMARK   2 RESOLUTION.    2.20 ANGSTROMS.                                       
+REMARK   3                                                                      
+REMARK   3 REFINEMENT.                                                          
+REMARK   3   PROGRAM     : TNT                                                  
+REMARK   3   AUTHORS     : TRONRUD,TEN EYCK,MATTHEWS                            
+REMARK   3                                                                      
+REMARK   3  DATA USED IN REFINEMENT.                                            
+REMARK   3   RESOLUTION RANGE HIGH (ANGSTROMS) : 2.20                           
+REMARK   3   RESOLUTION RANGE LOW  (ANGSTROMS) : 5.00                           
+REMARK   3   DATA CUTOFF            (SIGMA(F)) : 0.000                          
+REMARK   3   COMPLETENESS FOR RANGE        (%) : 89.0                           
+REMARK   3   NUMBER OF REFLECTIONS             : 53233                          
+REMARK   3                                                                      
+REMARK   3  USING DATA ABOVE SIGMA CUTOFF.                                      
+REMARK   3   CROSS-VALIDATION METHOD          : THROUGHOUT                      
+REMARK   3   FREE R VALUE TEST SET SELECTION  : RANDOM                          
+REMARK   3   R VALUE     (WORKING + TEST SET) : 0.231                           
+REMARK   3   R VALUE            (WORKING SET) : 0.231                           
+REMARK   3   FREE R VALUE                     : 0.279                           
+REMARK   3   FREE R VALUE TEST SET SIZE   (%) : NULL                            
+REMARK   3   FREE R VALUE TEST SET COUNT      : 2682                            
+REMARK   3                                                                      
+REMARK   3  USING ALL DATA, NO SIGMA CUTOFF.                                    
+REMARK   3   R VALUE   (WORKING + TEST SET, NO CUTOFF) : 0.2310                 
+REMARK   3   R VALUE          (WORKING SET, NO CUTOFF) : NULL                   
+REMARK   3   FREE R VALUE                  (NO CUTOFF) : NULL                   
+REMARK   3   FREE R VALUE TEST SET SIZE (%, NO CUTOFF) : NULL                   
+REMARK   3   FREE R VALUE TEST SET COUNT   (NO CUTOFF) : NULL                   
+REMARK   3   TOTAL NUMBER OF REFLECTIONS   (NO CUTOFF) : 53233                  
+REMARK   3                                                                      
+REMARK   3  NUMBER OF NON-HYDROGEN ATOMS USED IN REFINEMENT.                    
+REMARK   3   PROTEIN ATOMS            : 5089                                    
+REMARK   3   NUCLEIC ACID ATOMS       : 1511                                    
+REMARK   3   HETEROGEN ATOMS          : 0                                       
+REMARK   3   SOLVENT ATOMS            : 237                                     
+REMARK   3                                                                      
+REMARK   3  WILSON B VALUE (FROM FCALC, A**2) : 47.000                          
+REMARK   3                                                                      
+REMARK   3  RMS DEVIATIONS FROM IDEAL VALUES.    RMS    WEIGHT  COUNT           
+REMARK   3   BOND LENGTHS                 (A) : 0.006 ; NULL  ; NULL            
+REMARK   3   BOND ANGLES            (DEGREES) : 1.580 ; NULL  ; NULL            
+REMARK   3   TORSION ANGLES         (DEGREES) : NULL  ; NULL  ; NULL            
+REMARK   3   PSEUDOROTATION ANGLES  (DEGREES) : NULL  ; NULL  ; NULL            
+REMARK   3   TRIGONAL CARBON PLANES       (A) : NULL  ; NULL  ; NULL            
+REMARK   3   GENERAL PLANES               (A) : NULL  ; NULL  ; NULL            
+REMARK   3   ISOTROPIC THERMAL FACTORS (A**2) : NULL  ; NULL  ; NULL            
+REMARK   3   NON-BONDED CONTACTS          (A) : NULL  ; NULL  ; NULL            
+REMARK   3                                                                      
+REMARK   3  INCORRECT CHIRAL-CENTERS (COUNT) : NULL                             
+REMARK   3                                                                      
+REMARK   3  BULK SOLVENT MODELING.                                              
+REMARK   3   METHOD USED : NONE                                                 
+REMARK   3   KSOL        : NULL                                                 
+REMARK   3   BSOL        : NULL                                                 
+REMARK   3                                                                      
+REMARK   3  RESTRAINT LIBRARIES.                                                
+REMARK   3   STEREOCHEMISTRY : ENGH & HUBER                                     
+REMARK   3   ISOTROPIC THERMAL FACTOR RESTRAINTS : ISOTROPIC                    
+REMARK   3                                                                      
+REMARK   3  OTHER REFINEMENT REMARKS: NULL                                      
+REMARK   4                                                                      
+REMARK   4 1KBU COMPLIES WITH FORMAT V. 3.15, 01-DEC-08                         
+REMARK 100                                                                      
+REMARK 100 THIS ENTRY HAS BEEN PROCESSED BY RCSB ON 13-NOV-01.                  
+REMARK 100 THE RCSB ID CODE IS RCSB014787.                                      
+REMARK 200                                                                      
+REMARK 200 EXPERIMENTAL DETAILS                                                 
+REMARK 200  EXPERIMENT TYPE                : X-RAY DIFFRACTION                  
+REMARK 200  DATE OF DATA COLLECTION        : 27-FEB-00                          
+REMARK 200  TEMPERATURE           (KELVIN) : 100                                
+REMARK 200  PH                             : 5.00                               
+REMARK 200  NUMBER OF CRYSTALS USED        : 1                                  
+REMARK 200                                                                      
+REMARK 200  SYNCHROTRON              (Y/N) : Y                                  
+REMARK 200  RADIATION SOURCE               : SSRL                               
+REMARK 200  BEAMLINE                       : BL9-2                              
+REMARK 200  X-RAY GENERATOR MODEL          : NULL                               
+REMARK 200  MONOCHROMATIC OR LAUE    (M/L) : M                                  
+REMARK 200  WAVELENGTH OR RANGE        (A) : 1.0                                
+REMARK 200  MONOCHROMATOR                  : DOUBLE CRYSTAL                     
+REMARK 200  OPTICS                         : NULL                               
+REMARK 200                                                                      
+REMARK 200  DETECTOR TYPE                  : CCD                                
+REMARK 200  DETECTOR MANUFACTURER          : ADSC QUANTUM 4                     
+REMARK 200  INTENSITY-INTEGRATION SOFTWARE : MOSFLM                             
+REMARK 200  DATA SCALING SOFTWARE          : CCP4 (SCALA)                       
+REMARK 200                                                                      
+REMARK 200  NUMBER OF UNIQUE REFLECTIONS   : 53320                              
+REMARK 200  RESOLUTION RANGE HIGH      (A) : 2.200                              
+REMARK 200  RESOLUTION RANGE LOW       (A) : 24.500                             
+REMARK 200  REJECTION CRITERIA  (SIGMA(I)) : -3.000                             
+REMARK 200                                                                      
+REMARK 200 OVERALL.                                                             
+REMARK 200  COMPLETENESS FOR RANGE     (%) : 89.0                               
+REMARK 200  DATA REDUNDANCY                : 3.600                              
+REMARK 200  R MERGE                    (I) : 0.04800                            
+REMARK 200  R SYM                      (I) : 0.03700                            
+REMARK 200  <I/SIGMA(I)> FOR THE DATA SET  : 9.6000                             
+REMARK 200                                                                      
+REMARK 200 IN THE HIGHEST RESOLUTION SHELL.                                     
+REMARK 200  HIGHEST RESOLUTION SHELL, RANGE HIGH (A) : 2.20                     
+REMARK 200  HIGHEST RESOLUTION SHELL, RANGE LOW  (A) : 2.32                     
+REMARK 200  COMPLETENESS FOR SHELL     (%) : 89.8                               
+REMARK 200  DATA REDUNDANCY IN SHELL       : 2.90                               
+REMARK 200  R MERGE FOR SHELL          (I) : 0.40600                            
+REMARK 200  R SYM FOR SHELL            (I) : 0.28700                            
+REMARK 200  <I/SIGMA(I)> FOR SHELL         : 2.400                              
+REMARK 200                                                                      
+REMARK 200 DIFFRACTION PROTOCOL: SINGLE WAVELENGTH                              
+REMARK 200 METHOD USED TO DETERMINE THE STRUCTURE: ISOMORPHOUS MOLECULAR        
+REMARK 200  REPLACEMENT                                                         
+REMARK 200 SOFTWARE USED: TNT                                                   
+REMARK 200 STARTING MODEL: COMBINATION OF 1CRX AND 4CRX (SEE PUBLICATION        
+REMARK 200  FOR DETAILS)                                                        
+REMARK 200                                                                      
+REMARK 200 REMARK: NULL                                                         
+REMARK 280                                                                      
+REMARK 280 CRYSTAL                                                              
+REMARK 280 SOLVENT CONTENT, VS   (%): 57.69                                     
+REMARK 280 MATTHEWS COEFFICIENT, VM (ANGSTROMS**3/DA): 2.91                     
+REMARK 280                                                                      
+REMARK 280 CRYSTALLIZATION CONDITIONS: MPD, SODIUM ACETATE, CALCIUM             
+REMARK 280  CHLORIDE, PH 5.00, VAPOR DIFFUSION, HANGING DROP, TEMPERATURE       
+REMARK 280  294K                                                                
+REMARK 290                                                                      
+REMARK 290 CRYSTALLOGRAPHIC SYMMETRY                                            
+REMARK 290 SYMMETRY OPERATORS FOR SPACE GROUP: C 2 2 21                         
+REMARK 290                                                                      
+REMARK 290      SYMOP   SYMMETRY                                                
+REMARK 290     NNNMMM   OPERATOR                                                
+REMARK 290       1555   X,Y,Z                                                   
+REMARK 290       2555   -X,-Y,Z+1/2                                             
+REMARK 290       3555   -X,Y,-Z+1/2                                             
+REMARK 290       4555   X,-Y,-Z                                                 
+REMARK 290       5555   X+1/2,Y+1/2,Z                                           
+REMARK 290       6555   -X+1/2,-Y+1/2,Z+1/2                                     
+REMARK 290       7555   -X+1/2,Y+1/2,-Z+1/2                                     
+REMARK 290       8555   X+1/2,-Y+1/2,-Z                                         
+REMARK 290                                                                      
+REMARK 290     WHERE NNN -> OPERATOR NUMBER                                     
+REMARK 290           MMM -> TRANSLATION VECTOR                                  
+REMARK 290                                                                      
+REMARK 290 CRYSTALLOGRAPHIC SYMMETRY TRANSFORMATIONS                            
+REMARK 290 THE FOLLOWING TRANSFORMATIONS OPERATE ON THE ATOM/HETATM             
+REMARK 290 RECORDS IN THIS ENTRY TO PRODUCE CRYSTALLOGRAPHICALLY                
+REMARK 290 RELATED MOLECULES.                                                   
+REMARK 290   SMTRY1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 290   SMTRY1   2 -1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   2  0.000000 -1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   2  0.000000  0.000000  1.000000       89.65500            
+REMARK 290   SMTRY1   3 -1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   3  0.000000  1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   3  0.000000  0.000000 -1.000000       89.65500            
+REMARK 290   SMTRY1   4  1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   4  0.000000 -1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   4  0.000000  0.000000 -1.000000        0.00000            
+REMARK 290   SMTRY1   5  1.000000  0.000000  0.000000       53.58500            
+REMARK 290   SMTRY2   5  0.000000  1.000000  0.000000       60.80000            
+REMARK 290   SMTRY3   5  0.000000  0.000000  1.000000        0.00000            
+REMARK 290   SMTRY1   6 -1.000000  0.000000  0.000000       53.58500            
+REMARK 290   SMTRY2   6  0.000000 -1.000000  0.000000       60.80000            
+REMARK 290   SMTRY3   6  0.000000  0.000000  1.000000       89.65500            
+REMARK 290   SMTRY1   7 -1.000000  0.000000  0.000000       53.58500            
+REMARK 290   SMTRY2   7  0.000000  1.000000  0.000000       60.80000            
+REMARK 290   SMTRY3   7  0.000000  0.000000 -1.000000       89.65500            
+REMARK 290   SMTRY1   8  1.000000  0.000000  0.000000       53.58500            
+REMARK 290   SMTRY2   8  0.000000 -1.000000  0.000000       60.80000            
+REMARK 290   SMTRY3   8  0.000000  0.000000 -1.000000        0.00000            
+REMARK 290                                                                      
+REMARK 290 REMARK: NULL                                                         
+REMARK 300                                                                      
+REMARK 300 BIOMOLECULE: 1                                                       
+REMARK 300 SEE REMARK 350 FOR THE AUTHOR PROVIDED AND/OR PROGRAM                
+REMARK 300 GENERATED ASSEMBLY INFORMATION FOR THE STRUCTURE IN                  
+REMARK 300 THIS ENTRY. THE REMARK MAY ALSO PROVIDE INFORMATION ON               
+REMARK 300 BURIED SURFACE AREA.                                                 
+REMARK 300 REMARK: THE BIOLOGICAL ASSEMBLY IS A CRE TETRAMER BOUND TO TWO       
+REMARK 300 LOXP SITES, GENERATED FROM THE ASYMMETRIC UNIT BY THE                
+REMARK 300 CRYSTALLOGRAPHIC TWO-FOLD AXIS PLUS TRANSLATIONS: X, -Y+1, -Z+1      
+REMARK 350                                                                      
+REMARK 350 COORDINATES FOR A COMPLETE MULTIMER REPRESENTING THE KNOWN           
+REMARK 350 BIOLOGICALLY SIGNIFICANT OLIGOMERIZATION STATE OF THE                
+REMARK 350 MOLECULE CAN BE GENERATED BY APPLYING BIOMT TRANSFORMATIONS          
+REMARK 350 GIVEN BELOW.  BOTH NON-CRYSTALLOGRAPHIC AND                          
+REMARK 350 CRYSTALLOGRAPHIC OPERATIONS ARE GIVEN.                               
+REMARK 350                                                                      
+REMARK 350 BIOMOLECULE: 1                                                       
+REMARK 350 AUTHOR DETERMINED BIOLOGICAL UNIT: OCTAMERIC                         
+REMARK 350 APPLY THE FOLLOWING TO CHAINS: C, D, A, B                            
+REMARK 350   BIOMT1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 350   BIOMT2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 350   BIOMT3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 350   BIOMT1   2  1.000000  0.000000  0.000000        0.00000            
+REMARK 350   BIOMT2   2  0.000000 -1.000000  0.000000      121.60000            
+REMARK 350   BIOMT3   2  0.000000  0.000000 -1.000000      179.31000            
+REMARK 465                                                                      
+REMARK 465 MISSING RESIDUES                                                     
+REMARK 465 THE FOLLOWING RESIDUES WERE NOT LOCATED IN THE                       
+REMARK 465 EXPERIMENT. (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN               
+REMARK 465 IDENTIFIER; SSSEQ=SEQUENCE NUMBER; I=INSERTION CODE.)                
+REMARK 465                                                                      
+REMARK 465   M RES C SSSEQI                                                     
+REMARK 465     MET A    -5                                                      
+REMARK 465     HIS A    -4                                                      
+REMARK 465     HIS A    -3                                                      
+REMARK 465     HIS A    -2                                                      
+REMARK 465     HIS A    -1                                                      
+REMARK 465     HIS A     0                                                      
+REMARK 465     HIS A     1                                                      
+REMARK 465     SER A     2                                                      
+REMARK 465     ASN A     3                                                      
+REMARK 465     LEU A     4                                                      
+REMARK 465     LEU A     5                                                      
+REMARK 465     THR A     6                                                      
+REMARK 465     VAL A     7                                                      
+REMARK 465     HIS A     8                                                      
+REMARK 465     GLN A     9                                                      
+REMARK 465     ASN A    10                                                      
+REMARK 465     LEU A    11                                                      
+REMARK 465     PRO A    12                                                      
+REMARK 465     ALA A    13                                                      
+REMARK 465     LEU A    14                                                      
+REMARK 465     PRO A    15                                                      
+REMARK 465     VAL A    16                                                      
+REMARK 465     ASP A    17                                                      
+REMARK 465     GLY A   342                                                      
+REMARK 465     ASP A   343                                                      
+REMARK 465     MET B    -5                                                      
+REMARK 465     HIS B    -4                                                      
+REMARK 465     HIS B    -3                                                      
+REMARK 465     HIS B    -2                                                      
+REMARK 465     HIS B    -1                                                      
+REMARK 465     HIS B     0                                                      
+REMARK 465     HIS B     1                                                      
+REMARK 465     SER B     2                                                      
+REMARK 465     ASN B     3                                                      
+REMARK 465     LEU B     4                                                      
+REMARK 465     LEU B     5                                                      
+REMARK 465     THR B     6                                                      
+REMARK 465     VAL B     7                                                      
+REMARK 465     HIS B     8                                                      
+REMARK 465     GLN B     9                                                      
+REMARK 465     ASN B    10                                                      
+REMARK 465     LEU B    11                                                      
+REMARK 465     PRO B    12                                                      
+REMARK 465     ALA B    13                                                      
+REMARK 465     LEU B    14                                                      
+REMARK 465     PRO B    15                                                      
+REMARK 465     VAL B    16                                                      
+REMARK 465     ASP B    17                                                      
+REMARK 465     ALA B    18                                                      
+REMARK 465     ASP B   329                                                      
+REMARK 465     SER B   330                                                      
+REMARK 465     GLU B   331                                                      
+REMARK 465     THR B   332                                                      
+REMARK 465     GLY B   342                                                      
+REMARK 465     ASP B   343                                                      
+REMARK 475                                                                      
+REMARK 475 ZERO OCCUPANCY RESIDUES                                              
+REMARK 475 THE FOLLOWING RESIDUES WERE MODELED WITH ZERO OCCUPANCY.             
+REMARK 475 THE LOCATION AND PROPERTIES OF THESE RESIDUES MAY NOT                
+REMARK 475 BE RELIABLE. (M=MODEL NUMBER; RES=RESIDUE NAME;                      
+REMARK 475 C=CHAIN IDENTIFIER; SSEQ=SEQUENCE NUMBER; I=INSERTION CODE)          
+REMARK 475   M RES C SSEQI                                                      
+REMARK 475     GLY A  191                                                       
+REMARK 475     LEU A  215                                                       
+REMARK 475     ALA A  312                                                       
+REMARK 475     THR A  316                                                       
+REMARK 480                                                                      
+REMARK 480 ZERO OCCUPANCY ATOM                                                  
+REMARK 480 THE FOLLOWING RESIDUES HAVE ATOMS MODELED WITH ZERO                  
+REMARK 480 OCCUPANCY. THE LOCATION AND PROPERTIES OF THESE ATOMS                
+REMARK 480 MAY NOT BE RELIABLE. (M=MODEL NUMBER; RES=RESIDUE NAME;              
+REMARK 480 C=CHAIN IDENTIFIER; SSEQ=SEQUENCE NUMBER; I=INSERTION CODE):         
+REMARK 480   M RES C SSEQI ATOMS                                                
+REMARK 480     VAL A  182   CB    CG1   CG2                                     
+REMARK 480     VAL A  221   CB    CG1   CG2                                     
+REMARK 480     GLU A  222   CB    CG    CD    OE1   OE2                         
+REMARK 480     PRO A  234   CB    CG    CD                                      
+REMARK 480     ALA A  302   CB                                                  
+REMARK 480     PRO A  307   CB    CG    CD                                      
+REMARK 480     GLN A  311   CB    CG    CD    OE1   NE2                         
+REMARK 480     ASN A  317   CB    CG    OD1   ND2                               
+REMARK 480     ASN A  323   CG    OD1   ND2                                     
+REMARK 480     GLU B   22   CG    CD    OE1   OE2                               
+REMARK 480     MET B   28   CB    CG    SD    CE                                
+REMARK 480     ASN B  317   CB    CG    OD1   ND2                               
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: CLOSE CONTACTS IN SAME ASYMMETRIC UNIT                     
+REMARK 500                                                                      
+REMARK 500 THE FOLLOWING ATOMS ARE IN CLOSE CONTACT.                            
+REMARK 500                                                                      
+REMARK 500  ATM1  RES C  SSEQI   ATM2  RES C  SSEQI           DISTANCE          
+REMARK 500   O    HOH B   396     O    HOH B   450              2.11            
+REMARK 500   NH2  ARG A   301     O    HOH A   388              2.15            
+REMARK 500   O    HOH D    53     O    HOH D    66              2.16            
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: COVALENT BOND ANGLES                                       
+REMARK 500                                                                      
+REMARK 500 THE STEREOCHEMICAL PARAMETERS OF THE FOLLOWING RESIDUES              
+REMARK 500 HAVE VALUES WHICH DEVIATE FROM EXPECTED VALUES BY MORE               
+REMARK 500 THAN 6*RMSD (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN               
+REMARK 500 IDENTIFIER; SSEQ=SEQUENCE NUMBER; I=INSERTION CODE).                 
+REMARK 500                                                                      
+REMARK 500 STANDARD TABLE:                                                      
+REMARK 500 FORMAT: (10X,I3,1X,A3,1X,A1,I4,A1,3(1X,A4,2X),12X,F5.1)              
+REMARK 500                                                                      
+REMARK 500 EXPECTED VALUES PROTEIN: ENGH AND HUBER, 1999                        
+REMARK 500 EXPECTED VALUES NUCLEIC ACID: CLOWNEY ET AL 1996                     
+REMARK 500                                                                      
+REMARK 500  M RES CSSEQI ATM1   ATM2   ATM3                                     
+REMARK 500     DT C   2   O4' -  C1' -  N1  ANGL. DEV. =   2.4 DEGREES          
+REMARK 500     DA C   3   O4' -  C1' -  N9  ANGL. DEV. =  -4.6 DEGREES          
+REMARK 500     DA C   4   O4' -  C1' -  N9  ANGL. DEV. =   5.8 DEGREES          
+REMARK 500     DG C   5   C3' -  O3' -  P   ANGL. DEV. =  -7.3 DEGREES          
+REMARK 500     DC C   8   C3' -  C2' -  C1' ANGL. DEV. =  -4.8 DEGREES          
+REMARK 500     DC C   8   O4' -  C1' -  N1  ANGL. DEV. =   4.2 DEGREES          
+REMARK 500     DT C  12   O4' -  C1' -  N1  ANGL. DEV. =   2.7 DEGREES          
+REMARK 500     DA C  14   C3' -  C2' -  C1' ANGL. DEV. =  -6.3 DEGREES          
+REMARK 500     DT C  15   C3' -  O3' -  P   ANGL. DEV. =   7.3 DEGREES          
+REMARK 500     DT C  17   O4' -  C1' -  N1  ANGL. DEV. =   4.0 DEGREES          
+REMARK 500     DG C  16   C3' -  O3' -  P   ANGL. DEV. =  17.9 DEGREES          
+REMARK 500     DA C  18   O4' -  C1' -  N9  ANGL. DEV. =   4.7 DEGREES          
+REMARK 500     DA C  18   C3' -  O3' -  P   ANGL. DEV. =  10.1 DEGREES          
+REMARK 500     DG C  20   C3' -  C2' -  C1' ANGL. DEV. =  -5.7 DEGREES          
+REMARK 500     DG C  20   C8  -  N9  -  C1' ANGL. DEV. =  10.9 DEGREES          
+REMARK 500     DG C  20   C4  -  N9  -  C1' ANGL. DEV. = -12.4 DEGREES          
+REMARK 500     DT C  22   C3' -  C2' -  C1' ANGL. DEV. =  -5.1 DEGREES          
+REMARK 500     DT C  22   O4' -  C1' -  N1  ANGL. DEV. =   3.0 DEGREES          
+REMARK 500     DA C  28   O4' -  C1' -  N9  ANGL. DEV. =   3.9 DEGREES          
+REMARK 500     DT C  32   P   -  O5' -  C5' ANGL. DEV. = -11.1 DEGREES          
+REMARK 500     DT C  34   O4' -  C1' -  N1  ANGL. DEV. =   1.8 DEGREES          
+REMARK 500     DA D   4   O4' -  C1' -  N9  ANGL. DEV. =   5.2 DEGREES          
+REMARK 500     DC D   8   P   -  O5' -  C5' ANGL. DEV. = -11.3 DEGREES          
+REMARK 500     DC D   8   O4' -  C1' -  N1  ANGL. DEV. =  -4.7 DEGREES          
+REMARK 500     DT D  10   C3' -  C2' -  C1' ANGL. DEV. =  -5.8 DEGREES          
+REMARK 500     DA D  16   O4' -  C1' -  N9  ANGL. DEV. =   2.0 DEGREES          
+REMARK 500     DT D  17   O4' -  C4' -  C3' ANGL. DEV. =  -3.5 DEGREES          
+REMARK 500     DT D  17   C4' -  C3' -  C2' ANGL. DEV. =  -5.1 DEGREES          
+REMARK 500     DT D  17   O4' -  C1' -  N1  ANGL. DEV. =   3.9 DEGREES          
+REMARK 500     DA D  18   O4' -  C4' -  C3' ANGL. DEV. =  -2.8 DEGREES          
+REMARK 500     DA D  18   O4' -  C1' -  N9  ANGL. DEV. =   2.7 DEGREES          
+REMARK 500     DT D  21   P   -  O5' -  C5' ANGL. DEV. = -10.5 DEGREES          
+REMARK 500     DT D  21   C1' -  O4' -  C4' ANGL. DEV. =  -9.7 DEGREES          
+REMARK 500     DT D  21   N3  -  C4  -  O4  ANGL. DEV. =  -4.3 DEGREES          
+REMARK 500     DT D  24   C4  -  C5  -  C7  ANGL. DEV. =   6.8 DEGREES          
+REMARK 500     DT D  24   C6  -  C5  -  C7  ANGL. DEV. =  -7.0 DEGREES          
+REMARK 500     DA D  25   O4' -  C1' -  N9  ANGL. DEV. =  -4.6 DEGREES          
+REMARK 500     DT D  24   C3' -  O3' -  P   ANGL. DEV. =   7.5 DEGREES          
+REMARK 500     DA D  28   O4' -  C1' -  N9  ANGL. DEV. =   2.9 DEGREES          
+REMARK 500    VAL A 217   N   -  CA  -  C   ANGL. DEV. =  17.5 DEGREES          
+REMARK 500    SER A 279   N   -  CA  -  C   ANGL. DEV. =  25.8 DEGREES          
+REMARK 500    MET A 299   CG  -  SD  -  CE  ANGL. DEV. = -13.3 DEGREES          
+REMARK 500    ARG A 301   NE  -  CZ  -  NH1 ANGL. DEV. =   4.9 DEGREES          
+REMARK 500    ARG A 301   NE  -  CZ  -  NH2 ANGL. DEV. = -10.9 DEGREES          
+REMARK 500    PRO A 307   C   -  N   -  CD  ANGL. DEV. = -17.2 DEGREES          
+REMARK 500    VAL A 318   N   -  CA  -  C   ANGL. DEV. =  19.7 DEGREES          
+REMARK 500    ARG B 326   N   -  CA  -  C   ANGL. DEV. =  20.1 DEGREES          
+REMARK 500    LEU B 328   CB  -  CG  -  CD1 ANGL. DEV. =  12.2 DEGREES          
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: TORSION ANGLES                                             
+REMARK 500                                                                      
+REMARK 500 TORSION ANGLES OUTSIDE THE EXPECTED RAMACHANDRAN REGIONS:            
+REMARK 500 (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN IDENTIFIER;               
+REMARK 500 SSEQ=SEQUENCE NUMBER; I=INSERTION CODE).                             
+REMARK 500                                                                      
+REMARK 500 STANDARD TABLE:                                                      
+REMARK 500 FORMAT:(10X,I3,1X,A3,1X,A1,I4,A1,4X,F7.2,3X,F7.2)                    
+REMARK 500                                                                      
+REMARK 500 EXPECTED VALUES: GJ KLEYWEGT AND TA JONES (1996). PHI/PSI-           
+REMARK 500 CHOLOGY: RAMACHANDRAN REVISITED. STRUCTURE 4, 1395 - 1400            
+REMARK 500                                                                      
+REMARK 500  M RES CSSEQI        PSI       PHI                                   
+REMARK 500    THR A  19      117.74     56.19                                   
+REMARK 500    ASP A  33       51.80   -114.94                                   
+REMARK 500    GLN A  35       11.53    -68.67                                   
+REMARK 500    GLU A 129      109.82    -44.58                                   
+REMARK 500    MET A 149      -36.14   -133.42                                   
+REMARK 500    GLU A 150      -15.59    -48.44                                   
+REMARK 500    SER A 186     -163.93   -121.48                                   
+REMARK 500    THR A 188      145.43     -2.33                                   
+REMARK 500    ASP A 189       15.69     35.20                                   
+REMARK 500    ARG A 192     -122.69    -68.38                                   
+REMARK 500    MET A 193      140.37    159.24                                   
+REMARK 500    ILE A 197     -130.80   -102.86                                   
+REMARK 500    LYS A 201       37.14   -148.51                                   
+REMARK 500    VAL A 204       57.17    -96.39                                   
+REMARK 500    SER A 205     -106.47   -126.51                                   
+REMARK 500    SER A 214     -158.98    -92.17                                   
+REMARK 500    VAL A 221        6.28    -65.79                                   
+REMARK 500    ASN A 236      171.88    -31.80                                   
+REMARK 500    PRO A 250      175.11    -57.34                                   
+REMARK 500    SER A 251      127.24   -175.34                                   
+REMARK 500    ALA A 275      134.01    -37.07                                   
+REMARK 500    LYS A 276      134.14    -35.98                                   
+REMARK 500    ASP A 277     -120.48    -94.79                                   
+REMARK 500    ASP A 278       61.83    -49.17                                   
+REMARK 500    SER A 279      -48.25    104.76                                   
+REMARK 500    ALA A 285     -145.37   -117.60                                   
+REMARK 500    SER A 305      142.55    -15.05                                   
+REMARK 500    ILE A 306       10.25    -57.94                                   
+REMARK 500    PRO A 307      -96.52    -75.70                                   
+REMARK 500    GLU A 308       27.91    -54.64                                   
+REMARK 500    ILE A 309      -79.20   -124.23                                   
+REMARK 500    MET A 310       24.56    -75.33                                   
+REMARK 500    GLN A 311      -53.57   -140.18                                   
+REMARK 500    ALA A 312      -32.44    -36.72                                   
+REMARK 500    ASN A 317       62.78    173.81                                   
+REMARK 500    VAL A 318      157.73    -40.34                                   
+REMARK 500    ASN A 319      -30.86    122.47                                   
+REMARK 500    SER B  20      -55.80     12.79                                   
+REMARK 500    ASP B  33       54.89    -98.70                                   
+REMARK 500    ASP B 126       11.26    -63.63                                   
+REMARK 500    GLU B 129      121.60      1.41                                   
+REMARK 500    ASP B 189      -43.51    121.91                                   
+REMARK 500    ALA B 207      -87.50    -78.04                                   
+REMARK 500    ALA B 231       -1.12    -58.55                                   
+REMARK 500    ALA B 249       70.07   -150.64                                   
+REMARK 500    ASP B 277      177.64    -33.94                                   
+REMARK 500    TYR B 283       30.56     72.13                                   
+REMARK 500    ARG B 297      -74.21    -52.92                                   
+REMARK 500    ASP B 298      -37.62    -31.56                                   
+REMARK 500    ARG B 326     -179.29    -51.07                                   
+REMARK 500    ARG B 337      -35.73   -134.64                                   
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 900                                                                      
+REMARK 900 RELATED ENTRIES                                                      
+REMARK 900 RELATED ID: 3CRX   RELATED DB: PDB                                   
+REMARK 900 3CRX IS CRE RECOMBINASE-HOLLIDAY JUNCTION COMPLEX.                   
+REMARK 900 RELATED ID: 2CRX   RELATED DB: PDB                                   
+REMARK 900 2CRX IS CRE RECOMBINASE-HOLLIDAY JUNCTION COMPLEX.                   
+REMARK 900 RELATED ID: 4CRX   RELATED DB: PDB                                   
+REMARK 900 4CRX IS CRE/LOX PRECLEAVAGE COMPLEX.                                 
+REMARK 900 RELATED ID: 1CRX   RELATED DB: PDB                                   
+REMARK 900 1CRX IS CRE/LOX COVALENT INTERMEDIATE.                               
+REMARK 900 RELATED ID: 1F44   RELATED DB: PDB                                   
+REMARK 900 1F44 IS CRE TRIMER/LOX Y-JUNCTION COMPLEX.                           
+REMARK 900 RELATED ID: 1DRG   RELATED DB: PDB                                   
+REMARK 900 1DRG IS CRE TRIMER/LOX Y-JUNCTION COMPLEX.                           
+DBREF  1KBU A   -5   343  UNP    P06956   RECR_BPP1        1    343             
+DBREF  1KBU B   -5   343  UNP    P06956   RECR_BPP1        1    343             
+DBREF  1KBU D    1    34  GB     215626   M10494          14     47             
+DBREF  1KBU C    1    34  PDB    1KBU     1KBU             1     34             
+SEQADV 1KBU HIS A   -4  UNP  P06956              EXPRESSION TAG                 
+SEQADV 1KBU HIS A   -3  UNP  P06956              EXPRESSION TAG                 
+SEQADV 1KBU HIS A   -2  UNP  P06956              EXPRESSION TAG                 
+SEQADV 1KBU HIS A   -1  UNP  P06956              EXPRESSION TAG                 
+SEQADV 1KBU HIS A    0  UNP  P06956              EXPRESSION TAG                 
+SEQADV 1KBU HIS A    1  UNP  P06956              EXPRESSION TAG                 
+SEQADV 1KBU HIS B   -4  UNP  P06956              EXPRESSION TAG                 
+SEQADV 1KBU HIS B   -3  UNP  P06956              EXPRESSION TAG                 
+SEQADV 1KBU HIS B   -2  UNP  P06956              EXPRESSION TAG                 
+SEQADV 1KBU HIS B   -1  UNP  P06956              EXPRESSION TAG                 
+SEQADV 1KBU HIS B    0  UNP  P06956              EXPRESSION TAG                 
+SEQADV 1KBU HIS B    1  UNP  P06956              EXPRESSION TAG                 
+SEQADV 1KBU  DC D   30  GB   215626      G    43 SEE REMARK 999                 
+SEQRES   1 C   34   DA  DT  DA  DA  DG  DT  DT  DC  DG  DT  DA  DT  DA          
+SEQRES   2 C   34   DA  DT  DG  DT  DA  DT  DG  DC  DT  DA  DT  DA  DC          
+SEQRES   3 C   34   DG  DA  DA  DG  DT  DT  DA  DT                              
+SEQRES   1 D   34   DA  DT  DA  DA  DC  DT  DT  DC  DG  DT  DA  DT  DA          
+SEQRES   2 D   34   DG  DC  DA  DT  DA  DC  DA  DT  DT  DA  DT  DA  DC          
+SEQRES   3 D   34   DG  DA  DA  DC  DT  DT  DA  DT                              
+SEQRES   1 A  349  MET HIS HIS HIS HIS HIS HIS SER ASN LEU LEU THR VAL          
+SEQRES   2 A  349  HIS GLN ASN LEU PRO ALA LEU PRO VAL ASP ALA THR SER          
+SEQRES   3 A  349  ASP GLU VAL ARG LYS ASN LEU MET ASP MET PHE ARG ASP          
+SEQRES   4 A  349  ARG GLN ALA PHE SER GLU HIS THR TRP LYS MET LEU LEU          
+SEQRES   5 A  349  SER VAL CYS ARG SER TRP ALA ALA TRP CYS LYS LEU ASN          
+SEQRES   6 A  349  ASN ARG LYS TRP PHE PRO ALA GLU PRO GLU ASP VAL ARG          
+SEQRES   7 A  349  ASP TYR LEU LEU TYR LEU GLN ALA ARG GLY LEU ALA VAL          
+SEQRES   8 A  349  LYS THR ILE GLN GLN HIS LEU GLY GLN LEU ASN MET LEU          
+SEQRES   9 A  349  HIS ARG ARG SER GLY LEU PRO ARG PRO SER ASP SER ASN          
+SEQRES  10 A  349  ALA VAL SER LEU VAL MET ARG ARG ILE ARG LYS GLU ASN          
+SEQRES  11 A  349  VAL ASP ALA GLY GLU ARG ALA LYS GLN ALA LEU ALA PHE          
+SEQRES  12 A  349  GLU ARG THR ASP PHE ASP GLN VAL ARG SER LEU MET GLU          
+SEQRES  13 A  349  ASN SER ASP ARG CYS GLN ASP ILE ARG ASN LEU ALA PHE          
+SEQRES  14 A  349  LEU GLY ILE ALA TYR ASN THR LEU LEU ARG ILE ALA GLU          
+SEQRES  15 A  349  ILE ALA ARG ILE ARG VAL LYS ASP ILE SER ARG THR ASP          
+SEQRES  16 A  349  GLY GLY ARG MET LEU ILE HIS ILE GLY ARG THR LYS THR          
+SEQRES  17 A  349  LEU VAL SER THR ALA GLY VAL GLU LYS ALA LEU SER LEU          
+SEQRES  18 A  349  GLY VAL THR LYS LEU VAL GLU ARG TRP ILE SER VAL SER          
+SEQRES  19 A  349  GLY VAL ALA ASP ASP PRO ASN ASN TYR LEU PHE CYS ARG          
+SEQRES  20 A  349  VAL ARG LYS ASN GLY VAL ALA ALA PRO SER ALA THR SER          
+SEQRES  21 A  349  GLN LEU SER THR ARG ALA LEU GLU GLY ILE PHE GLU ALA          
+SEQRES  22 A  349  THR HIS ARG LEU ILE TYR GLY ALA LYS ASP ASP SER GLY          
+SEQRES  23 A  349  GLN ARG TYR LEU ALA TRP SER GLY HIS SER ALA ARG VAL          
+SEQRES  24 A  349  GLY ALA ALA ARG ASP MET ALA ARG ALA GLY VAL SER ILE          
+SEQRES  25 A  349  PRO GLU ILE MET GLN ALA GLY GLY TRP THR ASN VAL ASN          
+SEQRES  26 A  349  ILE VAL MET ASN TYR ILE ARG ASN LEU ASP SER GLU THR          
+SEQRES  27 A  349  GLY ALA MET VAL ARG LEU LEU GLU ASP GLY ASP                  
+SEQRES   1 B  349  MET HIS HIS HIS HIS HIS HIS SER ASN LEU LEU THR VAL          
+SEQRES   2 B  349  HIS GLN ASN LEU PRO ALA LEU PRO VAL ASP ALA THR SER          
+SEQRES   3 B  349  ASP GLU VAL ARG LYS ASN LEU MET ASP MET PHE ARG ASP          
+SEQRES   4 B  349  ARG GLN ALA PHE SER GLU HIS THR TRP LYS MET LEU LEU          
+SEQRES   5 B  349  SER VAL CYS ARG SER TRP ALA ALA TRP CYS LYS LEU ASN          
+SEQRES   6 B  349  ASN ARG LYS TRP PHE PRO ALA GLU PRO GLU ASP VAL ARG          
+SEQRES   7 B  349  ASP TYR LEU LEU TYR LEU GLN ALA ARG GLY LEU ALA VAL          
+SEQRES   8 B  349  LYS THR ILE GLN GLN HIS LEU GLY GLN LEU ASN MET LEU          
+SEQRES   9 B  349  HIS ARG ARG SER GLY LEU PRO ARG PRO SER ASP SER ASN          
+SEQRES  10 B  349  ALA VAL SER LEU VAL MET ARG ARG ILE ARG LYS GLU ASN          
+SEQRES  11 B  349  VAL ASP ALA GLY GLU ARG ALA LYS GLN ALA LEU ALA PHE          
+SEQRES  12 B  349  GLU ARG THR ASP PHE ASP GLN VAL ARG SER LEU MET GLU          
+SEQRES  13 B  349  ASN SER ASP ARG CYS GLN ASP ILE ARG ASN LEU ALA PHE          
+SEQRES  14 B  349  LEU GLY ILE ALA TYR ASN THR LEU LEU ARG ILE ALA GLU          
+SEQRES  15 B  349  ILE ALA ARG ILE ARG VAL LYS ASP ILE SER ARG THR ASP          
+SEQRES  16 B  349  GLY GLY ARG MET LEU ILE HIS ILE GLY ARG THR LYS THR          
+SEQRES  17 B  349  LEU VAL SER THR ALA GLY VAL GLU LYS ALA LEU SER LEU          
+SEQRES  18 B  349  GLY VAL THR LYS LEU VAL GLU ARG TRP ILE SER VAL SER          
+SEQRES  19 B  349  GLY VAL ALA ASP ASP PRO ASN ASN TYR LEU PHE CYS ARG          
+SEQRES  20 B  349  VAL ARG LYS ASN GLY VAL ALA ALA PRO SER ALA THR SER          
+SEQRES  21 B  349  GLN LEU SER THR ARG ALA LEU GLU GLY ILE PHE GLU ALA          
+SEQRES  22 B  349  THR HIS ARG LEU ILE TYR GLY ALA LYS ASP ASP SER GLY          
+SEQRES  23 B  349  GLN ARG TYR LEU ALA TRP SER GLY HIS SER ALA ARG VAL          
+SEQRES  24 B  349  GLY ALA ALA ARG ASP MET ALA ARG ALA GLY VAL SER ILE          
+SEQRES  25 B  349  PRO GLU ILE MET GLN ALA GLY GLY TRP THR ASN VAL ASN          
+SEQRES  26 B  349  ILE VAL MET ASN TYR ILE ARG ASN LEU ASP SER GLU THR          
+SEQRES  27 B  349  GLY ALA MET VAL ARG LEU LEU GLU ASP GLY ASP                  
+FORMUL   5  HOH   *237(H2 O)                                                    
+HELIX    1   1 THR A   19  ASP A   33  1                                  15    
+HELIX    2   2 ARG A   34  PHE A   37  5                                   4    
+HELIX    3   3 SER A   38  ASN A   60  1                                  23    
+HELIX    4   4 GLU A   67  ARG A   81  1                                  15    
+HELIX    5   5 ALA A   84  ARG A  101  1                                  18    
+HELIX    6   6 ARG A  106  ASP A  109  5                                   4    
+HELIX    7   7 SER A  110  ASP A  126  1                                  17    
+HELIX    8   8 GLU A  138  GLU A  150  1                                  13    
+HELIX    9   9 ARG A  154  ASN A  169  1                                  16    
+HELIX   10  10 ARG A  173  ILE A  180  1                                   8    
+HELIX   11  11 ARG A  181  ILE A  185  5                                   5    
+HELIX   12  12 ARG A  187  ARG A  192  1                                   6    
+HELIX   13  13 GLY A  216  GLY A  229  1                                  14    
+HELIX   14  14 VAL A  230  ASP A  233  5                                   4    
+HELIX   15  15 SER A  257  GLY A  274  1                                  18    
+HELIX   16  16 HIS A  289  ALA A  302  1                                  14    
+HELIX   17  17 ILE A  306  GLN A  311  1                                   6    
+HELIX   18  18 ASN A  319  ILE A  325  1                                   7    
+HELIX   19  19 GLY A  333  GLU A  340  1                                   8    
+HELIX   20  20 SER B   20  ASP B   33  1                                  14    
+HELIX   21  21 ARG B   34  PHE B   37  5                                   4    
+HELIX   22  22 SER B   38  LEU B   58  1                                  21    
+HELIX   23  23 GLU B   67  ARG B   81  1                                  15    
+HELIX   24  24 ALA B   84  ARG B  101  1                                  18    
+HELIX   25  25 ARG B  106  ASP B  109  5                                   4    
+HELIX   26  26 SER B  110  ASP B  126  1                                  17    
+HELIX   27  27 GLU B  138  GLU B  150  1                                  13    
+HELIX   28  28 ARG B  154  LEU B  171  1                                  18    
+HELIX   29  29 ARG B  173  ARG B  179  1                                   7    
+HELIX   30  30 ARG B  181  LYS B  183  5                                   3    
+HELIX   31  31 SER B  214  GLY B  229  1                                  16    
+HELIX   32  32 SER B  257  GLY B  274  1                                  18    
+HELIX   33  33 HIS B  289  GLY B  303  1                                  15    
+HELIX   34  34 SER B  305  GLY B  314  1                                  10    
+HELIX   35  35 VAL B  318  TYR B  324  1                                   7    
+HELIX   36  36 ALA B  334  LEU B  339  1                                   6    
+SHEET    1   A 2 LEU A 194  HIS A 196  0                                        
+SHEET    2   A 2 GLU A 210  ALA A 212 -1  O  LYS A 211   N  ILE A 195           
+SHEET    1   B 3 ILE B 185  ARG B 187  0                                        
+SHEET    2   B 3 MET B 193  ILE B 197 -1  O  LEU B 194   N  SER B 186           
+SHEET    3   B 3 VAL B 209  ALA B 212 -1  O  LYS B 211   N  ILE B 195           
+CISPEP   1 PHE A   64    PRO A   65          0         1.71                     
+CISPEP   2 PHE B   64    PRO B   65          0        -0.99                     
+CRYST1  107.170  121.600  179.310  90.00  90.00  90.00 C 2 2 21     16          
+ORIGX1      1.000000  0.000000  0.000000        0.00000                         
+ORIGX2      0.000000  1.000000  0.000000        0.00000                         
+ORIGX3      0.000000  0.000000  1.000000        0.00000                         
+SCALE1      0.009331  0.000000  0.000000        0.00000                         
+SCALE2      0.000000  0.008224  0.000000        0.00000                         
+SCALE3      0.000000  0.000000  0.005577        0.00000                         
+ATOM      1  O5'  DA C   1      72.298   6.925  60.408  1.00 71.81           O  
+ATOM      2  C5'  DA C   1      73.381   6.379  59.662  1.00100.00           C  
+ATOM      3  C4'  DA C   1      74.716   6.942  60.118  1.00100.00           C  
+ATOM      4  O4'  DA C   1      75.099   8.026  59.239  1.00100.00           O  
+ATOM      5  C3'  DA C   1      74.737   7.586  61.495  1.00100.00           C  
+ATOM      6  O3'  DA C   1      76.088   7.618  61.937  1.00100.00           O  
+ATOM      7  C2'  DA C   1      74.193   8.986  61.212  1.00 51.34           C  
+ATOM      8  C1'  DA C   1      74.609   9.244  59.763  1.00 68.08           C  
+ATOM      9  N9   DA C   1      73.522   9.710  58.901  1.00 60.54           N  
+ATOM     10  C8   DA C   1      72.265   9.189  58.766  1.00 56.64           C  
+ATOM     11  N7   DA C   1      71.511   9.825  57.901  1.00 55.25           N  
+ATOM     12  C5   DA C   1      72.332  10.831  57.425  1.00 56.97           C  
+ATOM     13  C6   DA C   1      72.114  11.857  56.487  1.00 55.94           C  
+ATOM     14  N6   DA C   1      70.949  12.019  55.851  1.00 55.87           N  
+ATOM     15  N1   DA C   1      73.131  12.706  56.232  1.00 56.80           N  
+ATOM     16  C2   DA C   1      74.286  12.529  56.887  1.00 58.49           C  
+ATOM     17  N3   DA C   1      74.612  11.604  57.792  1.00 58.64           N  
+ATOM     18  C4   DA C   1      73.577  10.776  58.027  1.00 59.27           C  
+ATOM     19  P    DT C   2      76.500   8.326  63.309  1.00100.00           P  
+ATOM     20  OP1  DT C   2      77.942   8.063  63.523  1.00100.00           O  
+ATOM     21  OP2  DT C   2      75.503   7.957  64.340  1.00 98.80           O  
+ATOM     22  O5'  DT C   2      76.347   9.881  62.969  1.00100.00           O  
+ATOM     23  C5'  DT C   2      77.223  10.472  62.017  1.00 97.35           C  
+ATOM     24  C4'  DT C   2      77.128  11.987  62.046  1.00 92.23           C  
+ATOM     25  O4'  DT C   2      76.220  12.447  61.010  1.00 88.41           O  
+ATOM     26  C3'  DT C   2      76.629  12.597  63.354  1.00 81.16           C  
+ATOM     27  O3'  DT C   2      77.355  13.789  63.631  1.00 74.78           O  
+ATOM     28  C2'  DT C   2      75.185  12.941  63.005  1.00 66.87           C  
+ATOM     29  C1'  DT C   2      75.392  13.435  61.580  1.00 55.22           C  
+ATOM     30  N1   DT C   2      74.134  13.587  60.793  1.00 52.86           N  
+ATOM     31  C2   DT C   2      74.077  14.676  59.948  1.00 51.77           C  
+ATOM     32  O2   DT C   2      75.016  15.433  59.788  1.00 51.85           O  
+ATOM     33  N3   DT C   2      72.905  14.835  59.262  1.00 49.02           N  
+ATOM     34  C4   DT C   2      71.795  14.027  59.371  1.00 53.60           C  
+ATOM     35  O4   DT C   2      70.804  14.298  58.705  1.00 53.31           O  
+ATOM     36  C5   DT C   2      71.912  12.914  60.278  1.00 48.61           C  
+ATOM     37  C7   DT C   2      70.763  11.968  60.469  1.00 48.39           C  
+ATOM     38  C6   DT C   2      73.055  12.744  60.953  1.00 48.29           C  
+ATOM     39  P    DA C   3      78.032  14.066  65.054  1.00 73.86           P  
+ATOM     40  OP1  DA C   3      79.165  13.128  65.231  1.00 81.58           O  
+ATOM     41  OP2  DA C   3      76.965  14.161  66.075  1.00 89.58           O  
+ATOM     42  O5'  DA C   3      78.651  15.520  64.824  1.00 69.16           O  
+ATOM     43  C5'  DA C   3      79.498  15.653  63.690  1.00 59.49           C  
+ATOM     44  C4'  DA C   3      79.457  17.051  63.106  1.00 50.07           C  
+ATOM     45  O4'  DA C   3      78.185  17.264  62.448  1.00 52.26           O  
+ATOM     46  C3'  DA C   3      79.561  18.186  64.114  1.00 47.65           C  
+ATOM     47  O3'  DA C   3      79.980  19.349  63.417  1.00 48.09           O  
+ATOM     48  C2'  DA C   3      78.106  18.305  64.551  1.00 59.16           C  
+ATOM     49  C1'  DA C   3      77.389  18.150  63.213  1.00 53.62           C  
+ATOM     50  N9   DA C   3      76.123  17.445  63.335  1.00 41.75           N  
+ATOM     51  C8   DA C   3      75.774  16.465  64.198  1.00 42.27           C  
+ATOM     52  N7   DA C   3      74.561  15.990  64.014  1.00 42.14           N  
+ATOM     53  C5   DA C   3      74.089  16.683  62.938  1.00 37.08           C  
+ATOM     54  C6   DA C   3      72.874  16.662  62.232  1.00 36.16           C  
+ATOM     55  N6   DA C   3      71.909  15.816  62.601  1.00 40.19           N  
+ATOM     56  N1   DA C   3      72.705  17.490  61.186  1.00 34.77           N  
+ATOM     57  C2   DA C   3      73.733  18.301  60.909  1.00 35.04           C  
+ATOM     58  N3   DA C   3      74.901  18.467  61.481  1.00 34.63           N  
+ATOM     59  C4   DA C   3      75.043  17.583  62.505  1.00 34.46           C  
+ATOM     60  P    DA C   4      80.528  20.655  64.148  1.00 45.88           P  
+ATOM     61  OP1  DA C   4      81.512  21.277  63.233  1.00 40.50           O  
+ATOM     62  OP2  DA C   4      80.853  20.300  65.547  1.00 49.05           O  
+ATOM     63  O5'  DA C   4      79.228  21.559  64.121  1.00 54.20           O  
+ATOM     64  C5'  DA C   4      78.958  22.269  62.937  1.00 45.88           C  
+ATOM     65  C4'  DA C   4      77.531  22.766  63.002  1.00 36.21           C  
+ATOM     66  O4'  DA C   4      76.651  21.622  63.159  1.00 33.89           O  
+ATOM     67  C3'  DA C   4      77.291  23.637  64.232  1.00 37.41           C  
+ATOM     68  O3'  DA C   4      76.653  24.841  63.853  1.00 32.21           O  
+ATOM     69  C2'  DA C   4      76.402  22.802  65.146  1.00 36.47           C  
+ATOM     70  C1'  DA C   4      75.661  22.004  64.087  1.00 28.03           C  
+ATOM     71  N9   DA C   4      74.852  20.897  64.586  1.00 27.98           N  
+ATOM     72  C8   DA C   4      74.992  20.089  65.678  1.00 27.58           C  
+ATOM     73  N7   DA C   4      73.987  19.253  65.827  1.00 30.83           N  
+ATOM     74  C5   DA C   4      73.114  19.563  64.789  1.00 33.15           C  
+ATOM     75  C6   DA C   4      71.858  19.048  64.392  1.00 27.60           C  
+ATOM     76  N6   DA C   4      71.209  18.051  65.008  1.00 26.33           N  
+ATOM     77  N1   DA C   4      71.276  19.595  63.311  1.00 28.52           N  
+ATOM     78  C2   DA C   4      71.901  20.592  62.673  1.00 32.94           C  
+ATOM     79  N3   DA C   4      73.070  21.163  62.947  1.00 33.73           N  
+ATOM     80  C4   DA C   4      73.633  20.594  64.025  1.00 32.94           C  
+ATOM     81  P    DG C   5      77.056  26.188  64.613  1.00 36.64           P  
+ATOM     82  OP1  DG C   5      77.190  27.290  63.637  1.00 32.28           O  
+ATOM     83  OP2  DG C   5      78.181  25.858  65.511  1.00 53.61           O  
+ATOM     84  O5'  DG C   5      75.755  26.496  65.486  1.00 44.34           O  
+ATOM     85  C5'  DG C   5      74.739  25.531  65.663  1.00 35.78           C  
+ATOM     86  C4'  DG C   5      73.696  25.680  64.572  1.00 34.96           C  
+ATOM     87  O4'  DG C   5      73.211  24.343  64.299  1.00 36.37           O  
+ATOM     88  C3'  DG C   5      72.487  26.528  64.953  1.00 49.50           C  
+ATOM     89  O3'  DG C   5      72.046  27.451  63.974  1.00 46.00           O  
+ATOM     90  C2'  DG C   5      71.367  25.531  65.211  1.00 66.00           C  
+ATOM     91  C1'  DG C   5      71.833  24.231  64.564  1.00 40.84           C  
+ATOM     92  N9   DG C   5      71.731  23.149  65.524  1.00 29.75           N  
+ATOM     93  C8   DG C   5      72.581  22.784  66.534  1.00 30.09           C  
+ATOM     94  N7   DG C   5      72.120  21.798  67.252  1.00 31.60           N  
+ATOM     95  C5   DG C   5      70.885  21.515  66.691  1.00 29.75           C  
+ATOM     96  C6   DG C   5      69.929  20.538  67.043  1.00 38.97           C  
+ATOM     97  O6   DG C   5      69.998  19.704  67.950  1.00 44.57           O  
+ATOM     98  N1   DG C   5      68.802  20.583  66.230  1.00 34.25           N  
+ATOM     99  C2   DG C   5      68.632  21.476  65.205  1.00 38.67           C  
+ATOM    100  N2   DG C   5      67.475  21.377  64.534  1.00 41.73           N  
+ATOM    101  N3   DG C   5      69.524  22.397  64.855  1.00 35.73           N  
+ATOM    102  C4   DG C   5      70.624  22.352  65.638  1.00 32.82           C  
+ATOM    103  P    DT C   6      71.013  28.523  64.566  1.00 45.47           P  
+ATOM    104  OP1  DT C   6      71.010  29.707  63.673  1.00 32.85           O  
+ATOM    105  OP2  DT C   6      71.311  28.677  66.014  1.00 50.94           O  
+ATOM    106  O5'  DT C   6      69.603  27.777  64.470  1.00 47.62           O  
+ATOM    107  C5'  DT C   6      69.094  27.299  63.242  1.00 44.05           C  
+ATOM    108  C4'  DT C   6      67.626  26.953  63.404  1.00 46.56           C  
+ATOM    109  O4'  DT C   6      67.471  25.755  64.202  1.00 49.48           O  
+ATOM    110  C3'  DT C   6      66.763  28.000  64.094  1.00 45.90           C  
+ATOM    111  O3'  DT C   6      65.489  27.972  63.500  1.00 58.58           O  
+ATOM    112  C2'  DT C   6      66.665  27.516  65.536  1.00 32.96           C  
+ATOM    113  C1'  DT C   6      66.717  26.004  65.372  1.00 30.57           C  
+ATOM    114  N1   DT C   6      67.449  25.284  66.443  1.00 32.09           N  
+ATOM    115  C2   DT C   6      66.840  24.122  66.839  1.00 35.30           C  
+ATOM    116  O2   DT C   6      65.751  23.793  66.408  1.00 37.36           O  
+ATOM    117  N3   DT C   6      67.525  23.373  67.764  1.00 37.82           N  
+ATOM    118  C4   DT C   6      68.754  23.672  68.323  1.00 37.40           C  
+ATOM    119  O4   DT C   6      69.261  22.928  69.160  1.00 36.62           O  
+ATOM    120  C5   DT C   6      69.346  24.895  67.851  1.00 32.95           C  
+ATOM    121  C7   DT C   6      70.684  25.319  68.380  1.00 31.72           C  
+ATOM    122  C6   DT C   6      68.693  25.617  66.930  1.00 33.78           C  
+ATOM    123  P    DT C   7      64.438  29.138  63.793  1.00 64.26           P  
+ATOM    124  OP1  DT C   7      63.863  29.508  62.478  1.00 87.31           O  
+ATOM    125  OP2  DT C   7      65.077  30.174  64.633  1.00 44.73           O  
+ATOM    126  O5'  DT C   7      63.322  28.385  64.657  1.00 51.85           O  
+ATOM    127  C5'  DT C   7      63.077  26.998  64.449  1.00 39.81           C  
+ATOM    128  C4'  DT C   7      62.245  26.417  65.577  1.00 54.44           C  
+ATOM    129  O4'  DT C   7      63.089  25.758  66.557  1.00 59.94           O  
+ATOM    130  C3'  DT C   7      61.393  27.414  66.349  1.00 57.66           C  
+ATOM    131  O3'  DT C   7      60.120  26.798  66.559  1.00 62.29           O  
+ATOM    132  C2'  DT C   7      62.192  27.596  67.640  1.00 49.24           C  
+ATOM    133  C1'  DT C   7      62.764  26.199  67.861  1.00 40.70           C  
+ATOM    134  N1   DT C   7      64.018  26.111  68.693  1.00 38.80           N  
+ATOM    135  C2   DT C   7      64.164  24.935  69.397  1.00 39.41           C  
+ATOM    136  O2   DT C   7      63.308  24.072  69.392  1.00 40.57           O  
+ATOM    137  N3   DT C   7      65.321  24.811  70.130  1.00 38.52           N  
+ATOM    138  C4   DT C   7      66.353  25.731  70.210  1.00 38.88           C  
+ATOM    139  O4   DT C   7      67.338  25.494  70.910  1.00 37.86           O  
+ATOM    140  C5   DT C   7      66.144  26.941  69.450  1.00 41.04           C  
+ATOM    141  C7   DT C   7      67.212  28.000  69.456  1.00 39.46           C  
+ATOM    142  C6   DT C   7      65.017  27.068  68.728  1.00 38.86           C  
+ATOM    143  P    DC C   8      58.804  27.520  67.113  1.00 57.96           P  
+ATOM    144  OP1  DC C   8      57.659  26.870  66.437  1.00 68.57           O  
+ATOM    145  OP2  DC C   8      58.962  28.993  67.087  1.00 39.10           O  
+ATOM    146  O5'  DC C   8      58.810  27.035  68.633  1.00 43.87           O  
+ATOM    147  C5'  DC C   8      58.860  25.633  68.846  1.00 45.30           C  
+ATOM    148  C4'  DC C   8      58.748  25.359  70.331  1.00 55.46           C  
+ATOM    149  O4'  DC C   8      60.070  25.099  70.872  1.00 56.17           O  
+ATOM    150  C3'  DC C   8      58.209  26.546  71.121  1.00 57.52           C  
+ATOM    151  O3'  DC C   8      57.539  26.047  72.264  1.00 72.00           O  
+ATOM    152  C2'  DC C   8      59.492  27.248  71.547  1.00 33.09           C  
+ATOM    153  C1'  DC C   8      60.281  26.006  71.935  1.00 39.82           C  
+ATOM    154  N1   DC C   8      61.718  26.307  72.147  1.00 32.56           N  
+ATOM    155  C2   DC C   8      62.474  25.455  72.955  1.00 31.20           C  
+ATOM    156  O2   DC C   8      61.946  24.434  73.435  1.00 26.02           O  
+ATOM    157  N3   DC C   8      63.774  25.788  73.169  1.00 32.43           N  
+ATOM    158  C4   DC C   8      64.288  26.890  72.606  1.00 30.96           C  
+ATOM    159  N4   DC C   8      65.570  27.189  72.833  1.00 31.43           N  
+ATOM    160  C5   DC C   8      63.522  27.764  71.790  1.00 24.22           C  
+ATOM    161  C6   DC C   8      62.241  27.444  71.602  1.00 23.71           C  
+ATOM    162  P    DG C   9      56.009  26.419  72.519  1.00 67.03           P  
+ATOM    163  OP1  DG C   9      55.224  25.544  71.621  1.00 60.52           O  
+ATOM    164  OP2  DG C   9      55.881  27.893  72.450  1.00 58.45           O  
+ATOM    165  O5'  DG C   9      55.817  25.958  74.039  1.00 51.12           O  
+ATOM    166  C5'  DG C   9      56.192  24.629  74.380  1.00 52.25           C  
+ATOM    167  C4'  DG C   9      56.869  24.556  75.738  1.00 54.72           C  
+ATOM    168  O4'  DG C   9      58.305  24.655  75.570  1.00 48.77           O  
+ATOM    169  C3'  DG C   9      56.443  25.617  76.751  1.00 61.89           C  
+ATOM    170  O3'  DG C   9      55.838  25.054  77.915  1.00 53.68           O  
+ATOM    171  C2'  DG C   9      57.734  26.321  77.146  1.00 55.62           C  
+ATOM    172  C1'  DG C   9      58.847  25.421  76.620  1.00 41.57           C  
+ATOM    173  N9   DG C   9      59.881  26.299  76.096  1.00 36.63           N  
+ATOM    174  C8   DG C   9      59.780  27.392  75.267  1.00 37.04           C  
+ATOM    175  N7   DG C   9      60.908  28.020  75.097  1.00 35.09           N  
+ATOM    176  C5   DG C   9      61.796  27.312  75.899  1.00 35.14           C  
+ATOM    177  C6   DG C   9      63.171  27.513  76.119  1.00 29.55           C  
+ATOM    178  O6   DG C   9      63.906  28.385  75.638  1.00 32.01           O  
+ATOM    179  N1   DG C   9      63.679  26.586  77.020  1.00 27.64           N  
+ATOM    180  C2   DG C   9      62.976  25.572  77.616  1.00 26.85           C  
+ATOM    181  N2   DG C   9      63.693  24.793  78.445  1.00 30.40           N  
+ATOM    182  N3   DG C   9      61.691  25.344  77.398  1.00 31.14           N  
+ATOM    183  C4   DG C   9      61.177  26.261  76.539  1.00 31.84           C  
+ATOM    184  P    DT C  10      55.180  25.989  79.038  1.00 44.64           P  
+ATOM    185  OP1  DT C  10      53.869  25.404  79.390  1.00 60.17           O  
+ATOM    186  OP2  DT C  10      55.256  27.411  78.624  1.00 26.98           O  
+ATOM    187  O5'  DT C  10      56.188  25.754  80.256  1.00 46.10           O  
+ATOM    188  C5'  DT C  10      56.546  24.435  80.661  1.00 42.32           C  
+ATOM    189  C4'  DT C  10      57.801  24.502  81.511  1.00 46.74           C  
+ATOM    190  O4'  DT C  10      58.842  25.086  80.690  1.00 49.67           O  
+ATOM    191  C3'  DT C  10      57.683  25.395  82.739  1.00 40.42           C  
+ATOM    192  O3'  DT C  10      58.219  24.761  83.890  1.00 49.09           O  
+ATOM    193  C2'  DT C  10      58.465  26.648  82.363  1.00 28.17           C  
+ATOM    194  C1'  DT C  10      59.512  26.099  81.402  1.00 35.63           C  
+ATOM    195  N1   DT C  10      59.924  27.134  80.423  1.00 36.19           N  
+ATOM    196  C2   DT C  10      61.271  27.429  80.332  1.00 36.03           C  
+ATOM    197  O2   DT C  10      62.117  26.850  80.990  1.00 35.16           O  
+ATOM    198  N3   DT C  10      61.590  28.422  79.435  1.00 29.67           N  
+ATOM    199  C4   DT C  10      60.695  29.164  78.678  1.00 32.08           C  
+ATOM    200  O4   DT C  10      61.101  30.074  77.953  1.00 30.55           O  
+ATOM    201  C5   DT C  10      59.306  28.785  78.824  1.00 38.10           C  
+ATOM    202  C7   DT C  10      58.262  29.501  78.016  1.00 36.43           C  
+ATOM    203  C6   DT C  10      58.977  27.809  79.686  1.00 35.92           C  
+ATOM    204  P    DA C  11      58.213  25.446  85.340  1.00 53.43           P  
+ATOM    205  OP1  DA C  11      58.177  24.330  86.313  1.00 32.61           O  
+ATOM    206  OP2  DA C  11      57.201  26.528  85.397  1.00 51.43           O  
+ATOM    207  O5'  DA C  11      59.652  26.143  85.438  1.00 55.28           O  
+ATOM    208  C5'  DA C  11      60.867  25.408  85.589  1.00 37.06           C  
+ATOM    209  C4'  DA C  11      62.033  26.374  85.595  1.00 19.69           C  
+ATOM    210  O4'  DA C  11      61.963  27.149  84.375  1.00 24.02           O  
+ATOM    211  C3'  DA C  11      61.944  27.411  86.705  1.00 23.80           C  
+ATOM    212  O3'  DA C  11      63.092  27.254  87.512  1.00 40.74           O  
+ATOM    213  C2'  DA C  11      61.954  28.767  86.003  1.00 24.27           C  
+ATOM    214  C1'  DA C  11      62.529  28.407  84.641  1.00 23.61           C  
+ATOM    215  N9   DA C  11      62.169  29.347  83.578  1.00 28.89           N  
+ATOM    216  C8   DA C  11      60.932  29.614  83.050  1.00 24.71           C  
+ATOM    217  N7   DA C  11      60.957  30.540  82.121  1.00 29.70           N  
+ATOM    218  C5   DA C  11      62.297  30.894  82.017  1.00 30.60           C  
+ATOM    219  C6   DA C  11      62.972  31.826  81.208  1.00 26.27           C  
+ATOM    220  N6   DA C  11      62.343  32.595  80.306  1.00 25.34           N  
+ATOM    221  N1   DA C  11      64.308  31.946  81.356  1.00 26.92           N  
+ATOM    222  C2   DA C  11      64.926  31.163  82.251  1.00 27.85           C  
+ATOM    223  N3   DA C  11      64.402  30.251  83.064  1.00 29.21           N  
+ATOM    224  C4   DA C  11      63.065  30.168  82.913  1.00 30.86           C  
+ATOM    225  P    DT C  12      63.280  28.006  88.910  1.00 37.50           P  
+ATOM    226  OP1  DT C  12      64.245  27.228  89.717  1.00 40.31           O  
+ATOM    227  OP2  DT C  12      61.964  28.286  89.518  1.00 36.10           O  
+ATOM    228  O5'  DT C  12      63.977  29.370  88.451  1.00 39.85           O  
+ATOM    229  C5'  DT C  12      65.278  29.333  87.886  1.00 36.00           C  
+ATOM    230  C4'  DT C  12      65.721  30.711  87.439  1.00 25.81           C  
+ATOM    231  O4'  DT C  12      64.950  31.122  86.284  1.00 31.74           O  
+ATOM    232  C3'  DT C  12      65.577  31.831  88.459  1.00 30.75           C  
+ATOM    233  O3'  DT C  12      66.840  32.429  88.538  1.00 40.73           O  
+ATOM    234  C2'  DT C  12      64.627  32.828  87.800  1.00 40.12           C  
+ATOM    235  C1'  DT C  12      64.813  32.526  86.317  1.00 36.04           C  
+ATOM    236  N1   DT C  12      63.672  32.976  85.449  1.00 35.79           N  
+ATOM    237  C2   DT C  12      63.982  33.961  84.535  1.00 38.09           C  
+ATOM    238  O2   DT C  12      65.109  34.401  84.385  1.00 39.07           O  
+ATOM    239  N3   DT C  12      62.943  34.412  83.765  1.00 33.61           N  
+ATOM    240  C4   DT C  12      61.637  33.981  83.813  1.00 32.29           C  
+ATOM    241  O4   DT C  12      60.829  34.488  83.045  1.00 31.80           O  
+ATOM    242  C5   DT C  12      61.365  32.961  84.788  1.00 28.30           C  
+ATOM    243  C7   DT C  12      59.976  32.417  84.930  1.00 28.69           C  
+ATOM    244  C6   DT C  12      62.374  32.511  85.547  1.00 29.19           C  
+ATOM    245  P    DA C  13      67.337  33.353  89.733  1.00 39.21           P  
+ATOM    246  OP1  DA C  13      68.284  32.519  90.503  1.00 42.84           O  
+ATOM    247  OP2  DA C  13      66.205  34.030  90.402  1.00 56.13           O  
+ATOM    248  O5'  DA C  13      68.153  34.450  88.915  1.00 55.27           O  
+ATOM    249  C5'  DA C  13      69.222  34.055  88.076  1.00 43.50           C  
+ATOM    250  C4'  DA C  13      69.455  35.146  87.050  1.00 31.37           C  
+ATOM    251  O4'  DA C  13      68.287  35.301  86.202  1.00 36.38           O  
+ATOM    252  C3'  DA C  13      69.733  36.528  87.626  1.00 31.19           C  
+ATOM    253  O3'  DA C  13      70.728  37.102  86.799  1.00 34.00           O  
+ATOM    254  C2'  DA C  13      68.413  37.263  87.422  1.00 31.68           C  
+ATOM    255  C1'  DA C  13      67.966  36.672  86.092  1.00 28.31           C  
+ATOM    256  N9   DA C  13      66.527  36.770  85.916  1.00 30.83           N  
+ATOM    257  C8   DA C  13      65.565  36.070  86.585  1.00 32.03           C  
+ATOM    258  N7   DA C  13      64.346  36.388  86.226  1.00 36.18           N  
+ATOM    259  C5   DA C  13      64.523  37.371  85.270  1.00 31.40           C  
+ATOM    260  C6   DA C  13      63.599  38.112  84.510  1.00 38.49           C  
+ATOM    261  N6   DA C  13      62.284  37.921  84.637  1.00 37.24           N  
+ATOM    262  N1   DA C  13      64.095  39.012  83.629  1.00 36.94           N  
+ATOM    263  C2   DA C  13      65.428  39.148  83.543  1.00 36.55           C  
+ATOM    264  N3   DA C  13      66.391  38.506  84.211  1.00 34.88           N  
+ATOM    265  C4   DA C  13      65.864  37.621  85.067  1.00 30.84           C  
+ATOM    266  P    DA C  14      71.526  38.422  87.199  1.00 35.51           P  
+ATOM    267  OP1  DA C  14      72.893  38.287  86.653  1.00 54.99           O  
+ATOM    268  OP2  DA C  14      71.308  38.659  88.645  1.00 47.54           O  
+ATOM    269  O5'  DA C  14      70.813  39.565  86.346  1.00 34.76           O  
+ATOM    270  C5'  DA C  14      70.737  39.366  84.950  1.00 31.24           C  
+ATOM    271  C4'  DA C  14      70.200  40.610  84.265  1.00 54.40           C  
+ATOM    272  O4'  DA C  14      68.753  40.667  84.347  1.00 54.43           O  
+ATOM    273  C3'  DA C  14      70.634  41.967  84.803  1.00 59.43           C  
+ATOM    274  O3'  DA C  14      70.323  42.885  83.766  1.00 60.90           O  
+ATOM    275  C2'  DA C  14      69.603  42.151  85.912  1.00 51.67           C  
+ATOM    276  C1'  DA C  14      68.383  41.841  85.052  1.00 48.29           C  
+ATOM    277  N9   DA C  14      67.165  41.477  85.760  1.00 41.20           N  
+ATOM    278  C8   DA C  14      67.010  40.690  86.866  1.00 39.63           C  
+ATOM    279  N7   DA C  14      65.756  40.509  87.206  1.00 40.87           N  
+ATOM    280  C5   DA C  14      65.054  41.200  86.231  1.00 40.59           C  
+ATOM    281  C6   DA C  14      63.680  41.377  86.011  1.00 39.66           C  
+ATOM    282  N6   DA C  14      62.771  40.832  86.825  1.00 41.14           N  
+ATOM    283  N1   DA C  14      63.298  42.117  84.952  1.00 39.44           N  
+ATOM    284  C2   DA C  14      64.244  42.643  84.163  1.00 40.59           C  
+ATOM    285  N3   DA C  14      65.567  42.537  84.261  1.00 40.96           N  
+ATOM    286  C4   DA C  14      65.904  41.792  85.323  1.00 39.90           C  
+ATOM    287  P    DT C  15      71.421  43.615  82.867  1.00 57.67           P  
+ATOM    288  OP1  DT C  15      71.513  42.879  81.591  1.00 62.11           O  
+ATOM    289  OP2  DT C  15      72.618  43.840  83.703  1.00 95.76           O  
+ATOM    290  O5'  DT C  15      70.699  45.016  82.591  1.00 55.49           O  
+ATOM    291  C5'  DT C  15      70.329  45.741  83.757  1.00 62.53           C  
+ATOM    292  C4'  DT C  15      69.104  46.614  83.551  1.00 80.79           C  
+ATOM    293  O4'  DT C  15      67.910  45.874  83.922  1.00 85.33           O  
+ATOM    294  C3'  DT C  15      69.124  47.862  84.424  1.00 80.16           C  
+ATOM    295  O3'  DT C  15      68.892  49.015  83.640  1.00 84.19           O  
+ATOM    296  C2'  DT C  15      68.025  47.639  85.456  1.00 68.77           C  
+ATOM    297  C1'  DT C  15      67.085  46.680  84.734  1.00 58.02           C  
+ATOM    298  N1   DT C  15      66.334  45.824  85.692  1.00 56.68           N  
+ATOM    299  C2   DT C  15      64.959  45.821  85.613  1.00 54.84           C  
+ATOM    300  O2   DT C  15      64.342  46.427  84.755  1.00 53.44           O  
+ATOM    301  N3   DT C  15      64.339  45.046  86.561  1.00 51.23           N  
+ATOM    302  C4   DT C  15      64.939  44.319  87.574  1.00 52.14           C  
+ATOM    303  O4   DT C  15      64.253  43.669  88.360  1.00 53.55           O  
+ATOM    304  C5   DT C  15      66.374  44.400  87.610  1.00 53.08           C  
+ATOM    305  C7   DT C  15      67.127  43.640  88.660  1.00 54.39           C  
+ATOM    306  C6   DT C  15      66.999  45.145  86.691  1.00 50.68           C  
+ATOM    307  P  A DG C  16      69.777  50.319  83.902  0.73 86.77           P  
+ATOM    308  P  B DG C  16      69.625  50.425  83.768  0.27 82.03           P  
+ATOM    309  OP1A DG C  16      70.948  50.246  83.003  0.73 78.96           O  
+ATOM    310  OP1B DG C  16      70.757  50.554  82.825  0.27 79.67           O  
+ATOM    311  OP2A DG C  16      69.981  50.456  85.362  0.73 72.52           O  
+ATOM    312  OP2B DG C  16      69.864  50.547  85.225  0.27 82.04           O  
+ATOM    313  O5'A DG C  16      68.795  51.456  83.350  0.73 67.43           O  
+ATOM    314  O5'B DG C  16      68.481  51.456  83.316  0.27 86.45           O  
+ATOM    315  C5'A DG C  16      68.235  51.226  82.058  0.73 38.17           C  
+ATOM    316  C5'B DG C  16      68.146  51.652  81.936  0.27 91.79           C  
+ATOM    317  C4'A DG C  16      66.888  51.898  81.858  0.73 87.29           C  
+ATOM    318  C4'B DG C  16      66.741  52.203  81.742  0.27 96.42           C  
+ATOM    319  O4'A DG C  16      65.821  51.083  82.404  0.73 86.93           O  
+ATOM    320  O4'B DG C  16      65.782  51.275  82.316  0.27 97.17           O  
+ATOM    321  C3'A DG C  16      66.739  53.297  82.436  0.73100.00           C  
+ATOM    322  C3'B DG C  16      66.515  53.571  82.380  0.27 98.64           C  
+ATOM    323  O3'A DG C  16      66.259  54.180  81.435  0.73100.00           O  
+ATOM    324  O3'B DG C  16      66.621  54.732  81.493  0.27100.00           O  
+ATOM    325  C2'A DG C  16      65.748  53.150  83.588  0.73100.00           C  
+ATOM    326  C2'B DG C  16      65.285  53.409  83.276  0.27 99.47           C  
+ATOM    327  C1'A DG C  16      65.084  51.790  83.381  0.73 99.55           C  
+ATOM    328  C1'B DG C  16      64.971  51.908  83.285  0.27 99.58           C  
+ATOM    329  N9 A DG C  16      65.083  50.975  84.591  0.73 98.06           N  
+ATOM    330  N9 B DG C  16      65.061  51.151  84.540  0.27 99.50           N  
+ATOM    331  C8 A DG C  16      66.174  50.616  85.348  0.73 97.81           C  
+ATOM    332  C8 B DG C  16      66.169  50.809  85.281  0.27 99.47           C  
+ATOM    333  N7 A DG C  16      65.883  49.874  86.379  0.73 96.46           N  
+ATOM    334  N7 B DG C  16      65.901  50.076  86.328  0.27 99.34           N  
+ATOM    335  C5 A DG C  16      64.503  49.725  86.303  0.73 95.15           C  
+ATOM    336  C5 B DG C  16      64.525  49.889  86.270  0.27100.00           C  
+ATOM    337  C6 A DG C  16      63.625  49.016  87.156  0.73 90.08           C  
+ATOM    338  C6 B DG C  16      63.663  49.174  87.139  0.27 98.34           C  
+ATOM    339  O6 A DG C  16      63.905  48.362  88.173  0.73 87.06           O  
+ATOM    340  O6 B DG C  16      63.956  48.543  88.165  0.27 96.36           O  
+ATOM    341  N1 A DG C  16      62.303  49.115  86.729  0.73 88.78           N  
+ATOM    342  N1 B DG C  16      62.336  49.236  86.719  0.27 98.01           N  
+ATOM    343  C2 A DG C  16      61.887  49.815  85.622  0.73 90.55           C  
+ATOM    344  C2 B DG C  16      61.901  49.906  85.601  0.27 98.11           C  
+ATOM    345  N2 A DG C  16      60.571  49.794  85.370  0.73 95.02           N  
+ATOM    346  N2 B DG C  16      60.584  49.853  85.353  0.27 99.02           N  
+ATOM    347  N3 A DG C  16      62.701  50.482  84.813  0.73 92.31           N  
+ATOM    348  N3 B DG C  16      62.699  50.578  84.779  0.27 98.63           N  
+ATOM    349  C4 A DG C  16      63.994  50.396  85.211  0.73 94.74           C  
+ATOM    350  C4 B DG C  16      63.997  50.531  85.169  0.27 99.47           C  
+ATOM    351  P  B DT C  17      65.674  55.535  80.459  0.27100.00           P  
+ATOM    352  OP1B DT C  17      65.738  54.854  79.145  0.27100.00           O  
+ATOM    353  OP2B DT C  17      66.011  56.979  80.543  0.27100.00           O  
+ATOM    354  O5'B DT C  17      64.195  55.350  81.038  0.27 96.30           O  
+ATOM    355  C5'B DT C  17      63.966  55.923  82.316  0.27 90.54           C  
+ATOM    356  C4'B DT C  17      62.529  55.762  82.774  0.27 87.70           C  
+ATOM    357  O4'B DT C  17      62.449  54.582  83.619  0.27 85.85           O  
+ATOM    358  C3'B DT C  17      62.082  56.919  83.658  0.27 87.75           C  
+ATOM    359  O3'B DT C  17      60.682  57.116  83.642  0.27 87.60           O  
+ATOM    360  C2'B DT C  17      62.482  56.420  85.034  0.27 85.76           C  
+ATOM    361  C1'B DT C  17      62.004  54.983  84.900  0.27 85.27           C  
+ATOM    362  N1 B DT C  17      62.606  54.172  85.983  0.27 85.68           N  
+ATOM    363  C2 B DT C  17      61.829  53.247  86.646  0.27 84.89           C  
+ATOM    364  O2 B DT C  17      60.704  52.936  86.300  0.27 83.81           O  
+ATOM    365  N3 B DT C  17      62.468  52.638  87.696  0.27 84.36           N  
+ATOM    366  C4 B DT C  17      63.738  52.913  88.169  0.27 85.15           C  
+ATOM    367  O4 B DT C  17      64.176  52.281  89.124  0.27 84.13           O  
+ATOM    368  C5 B DT C  17      64.457  53.943  87.464  0.27 87.12           C  
+ATOM    369  C7 B DT C  17      65.848  54.313  87.884  0.27 86.84           C  
+ATOM    370  C6 B DT C  17      63.855  54.542  86.433  0.27 87.07           C  
+ATOM    371  P  B DA C  18      60.227  58.509  84.276  0.27 87.15           P  
+ATOM    372  OP1B DA C  18      61.263  58.935  85.245  0.27 82.68           O  
+ATOM    373  OP2B DA C  18      58.813  58.385  84.691  0.27 88.34           O  
+ATOM    374  O5'B DA C  18      60.323  59.440  82.982  0.27 88.46           O  
+ATOM    375  C5'B DA C  18      60.264  58.748  81.742  0.27 87.59           C  
+ATOM    376  C4'B DA C  18      59.492  59.559  80.723  0.27 86.66           C  
+ATOM    377  O4'B DA C  18      60.192  60.823  80.576  0.27 83.05           O  
+ATOM    378  C3'B DA C  18      59.453  58.931  79.332  0.27 91.52           C  
+ATOM    379  O3'B DA C  18      58.250  59.165  78.591  0.27 98.75           O  
+ATOM    380  C2'B DA C  18      60.641  59.585  78.649  0.27 82.13           C  
+ATOM    381  C1'B DA C  18      60.482  60.991  79.206  0.27 77.55           C  
+ATOM    382  N9 B DA C  18      61.695  61.755  78.971  0.27 74.49           N  
+ATOM    383  C8 B DA C  18      62.750  61.290  78.241  0.27 73.85           C  
+ATOM    384  N7 B DA C  18      63.741  62.133  78.118  0.27 73.98           N  
+ATOM    385  C5 B DA C  18      63.295  63.245  78.806  0.27 77.26           C  
+ATOM    386  C6 B DA C  18      63.892  64.496  79.046  0.27 76.98           C  
+ATOM    387  N6 B DA C  18      65.105  64.826  78.594  0.27 74.67           N  
+ATOM    388  N1 B DA C  18      63.192  65.396  79.765  0.27 77.17           N  
+ATOM    389  C2 B DA C  18      61.976  65.056  80.210  0.27 78.15           C  
+ATOM    390  N3 B DA C  18      61.312  63.911  80.050  0.27 77.79           N  
+ATOM    391  C4 B DA C  18      62.034  63.039  79.330  0.27 76.62           C  
+ATOM    392  P  A DT C  19      57.429  60.603  78.119  0.73100.00           P  
+ATOM    393  P  B DT C  19      57.298  60.457  78.558  0.27100.00           P  
+ATOM    394  OP1A DT C  19      57.835  59.545  79.072  0.73100.00           O  
+ATOM    395  OP1B DT C  19      57.532  61.289  79.759  0.27 95.12           O  
+ATOM    396  OP2A DT C  19      56.186  61.370  78.357  0.73100.00           O  
+ATOM    397  OP2B DT C  19      55.934  59.942  78.306  0.27 97.64           O  
+ATOM    398  O5'A DT C  19      58.652  61.623  77.943  0.73100.00           O  
+ATOM    399  O5'B DT C  19      57.737  61.321  77.275  0.27100.00           O  
+ATOM    400  C5'A DT C  19      58.623  62.612  76.924  0.73 97.11           C  
+ATOM    401  C5'B DT C  19      58.699  62.391  77.251  0.27 98.33           C  
+ATOM    402  C4'A DT C  19      58.106  63.928  77.470  0.73 95.06           C  
+ATOM    403  C4'B DT C  19      58.151  63.771  77.598  0.27 95.98           C  
+ATOM    404  O4'A DT C  19      59.243  64.777  77.766  0.73 95.00           O  
+ATOM    405  O4'B DT C  19      59.255  64.681  77.851  0.27 94.99           O  
+ATOM    406  C3'A DT C  19      57.350  64.720  76.421  0.73 96.22           C  
+ATOM    407  C3'B DT C  19      57.347  64.508  76.534  0.27 95.97           C  
+ATOM    408  O3'A DT C  19      56.727  65.825  77.069  0.73100.00           O  
+ATOM    409  O3'B DT C  19      56.652  65.577  77.174  0.27100.00           O  
+ATOM    410  C2'A DT C  19      58.525  65.169  75.558  0.73 80.10           C  
+ATOM    411  C2'B DT C  19      58.471  65.063  75.665  0.27 87.03           C  
+ATOM    412  C1'A DT C  19      59.516  65.589  76.639  0.73 75.27           C  
+ATOM    413  C1'B DT C  19      59.458  65.527  76.733  0.27 84.69           C  
+ATOM    414  N1 A DT C  19      60.944  65.438  76.258  0.73 73.67           N  
+ATOM    415  N1 B DT C  19      60.894  65.420  76.330  0.27 83.97           N  
+ATOM    416  C2 A DT C  19      61.785  66.495  76.549  0.73 70.55           C  
+ATOM    417  C2 B DT C  19      61.749  66.448  76.677  0.27 82.32           C  
+ATOM    418  O2 A DT C  19      61.429  67.520  77.108  0.73 67.29           O  
+ATOM    419  O2 B DT C  19      61.389  67.452  77.268  0.27 80.67           O  
+ATOM    420  N3 A DT C  19      63.087  66.299  76.165  0.73 71.91           N  
+ATOM    421  N3 B DT C  19      63.056  66.263  76.296  0.27 82.14           N  
+ATOM    422  C4 A DT C  19      63.611  65.183  75.531  0.73 72.72           C  
+ATOM    423  C4 B DT C  19      63.587  65.175  75.626  0.27 82.60           C  
+ATOM    424  O4 A DT C  19      64.804  65.155  75.244  0.73 71.72           O  
+ATOM    425  O4 B DT C  19      64.783  65.155  75.346  0.27 81.62           O  
+ATOM    426  C5 A DT C  19      62.670  64.123  75.260  0.73 75.36           C  
+ATOM    427  C5 B DT C  19      62.638  64.138  75.306  0.27 83.55           C  
+ATOM    428  C7 A DT C  19      63.122  62.870  74.565  0.73 75.15           C  
+ATOM    429  C7 B DT C  19      63.088  62.906  74.576  0.27 82.88           C  
+ATOM    430  C6 A DT C  19      61.395  64.295  75.630  0.73 74.40           C  
+ATOM    431  C6 B DT C  19      61.359  64.301  75.672  0.27 83.70           C  
+ATOM    432  P    DG C  20      55.344  66.400  76.523  1.00 95.03           P  
+ATOM    433  OP1  DG C  20      54.457  66.677  77.677  1.00 95.76           O  
+ATOM    434  OP2  DG C  20      54.902  65.486  75.440  1.00 90.27           O  
+ATOM    435  O5'  DG C  20      55.784  67.796  75.891  1.00 66.58           O  
+ATOM    436  C5'  DG C  20      56.112  68.881  76.750  1.00 58.47           C  
+ATOM    437  C4'  DG C  20      56.852  69.928  75.941  1.00 73.27           C  
+ATOM    438  O4'  DG C  20      58.186  69.444  75.637  1.00 68.14           O  
+ATOM    439  C3'  DG C  20      56.241  70.238  74.580  1.00 88.72           C  
+ATOM    440  O3'  DG C  20      56.641  71.549  74.216  1.00 85.15           O  
+ATOM    441  C2'  DG C  20      56.943  69.215  73.687  1.00 68.95           C  
+ATOM    442  C1'  DG C  20      58.343  69.428  74.238  1.00 57.98           C  
+ATOM    443  N9   DG C  20      59.377  68.467  73.883  1.00 53.02           N  
+ATOM    444  C8   DG C  20      59.453  67.178  73.415  1.00 58.69           C  
+ATOM    445  N7   DG C  20      60.697  66.801  73.246  1.00 53.76           N  
+ATOM    446  C5   DG C  20      61.463  67.905  73.627  1.00 51.83           C  
+ATOM    447  C6   DG C  20      62.865  68.093  73.672  1.00 51.24           C  
+ATOM    448  O6   DG C  20      63.749  67.285  73.363  1.00 50.67           O  
+ATOM    449  N1   DG C  20      63.197  69.373  74.136  1.00 47.72           N  
+ATOM    450  C2   DG C  20      62.293  70.337  74.510  1.00 53.70           C  
+ATOM    451  N2   DG C  20      62.806  71.507  74.925  1.00 52.59           N  
+ATOM    452  N3   DG C  20      60.978  70.173  74.480  1.00 56.02           N  
+ATOM    453  C4   DG C  20      60.652  68.939  74.029  1.00 53.47           C  
+ATOM    454  P    DC C  21      55.566  72.721  74.322  1.00 72.97           P  
+ATOM    455  OP1  DC C  21      55.256  72.919  75.760  1.00 65.47           O  
+ATOM    456  OP2  DC C  21      54.517  72.361  73.345  1.00 66.49           O  
+ATOM    457  O5'  DC C  21      56.376  73.996  73.797  1.00 61.53           O  
+ATOM    458  C5'  DC C  21      57.188  74.761  74.678  1.00 49.32           C  
+ATOM    459  C4'  DC C  21      58.574  74.887  74.080  1.00 41.91           C  
+ATOM    460  O4'  DC C  21      59.024  73.585  73.641  1.00 51.05           O  
+ATOM    461  C3'  DC C  21      58.647  75.742  72.828  1.00 31.36           C  
+ATOM    462  O3'  DC C  21      59.360  76.886  73.211  1.00 36.41           O  
+ATOM    463  C2'  DC C  21      59.451  74.923  71.814  1.00 38.35           C  
+ATOM    464  C1'  DC C  21      60.008  73.771  72.647  1.00 41.61           C  
+ATOM    465  N1   DC C  21      60.225  72.452  71.952  1.00 38.27           N  
+ATOM    466  C2   DC C  21      61.534  72.027  71.652  1.00 33.43           C  
+ATOM    467  O2   DC C  21      62.494  72.764  71.925  1.00 38.82           O  
+ATOM    468  N3   DC C  21      61.734  70.823  71.057  1.00 29.49           N  
+ATOM    469  C4   DC C  21      60.685  70.048  70.777  1.00 31.65           C  
+ATOM    470  N4   DC C  21      60.914  68.869  70.182  1.00 28.89           N  
+ATOM    471  C5   DC C  21      59.351  70.448  71.098  1.00 31.51           C  
+ATOM    472  C6   DC C  21      59.164  71.638  71.680  1.00 32.55           C  
+ATOM    473  P    DT C  22      59.749  77.831  72.001  1.00 41.67           P  
+ATOM    474  OP1  DT C  22      60.081  79.165  72.539  1.00 32.30           O  
+ATOM    475  OP2  DT C  22      58.673  77.628  71.011  1.00 50.13           O  
+ATOM    476  O5'  DT C  22      61.111  77.167  71.493  1.00 59.79           O  
+ATOM    477  C5'  DT C  22      62.359  77.792  71.774  1.00 52.30           C  
+ATOM    478  C4'  DT C  22      63.444  77.275  70.846  1.00 54.83           C  
+ATOM    479  O4'  DT C  22      63.295  75.856  70.567  1.00 53.09           O  
+ATOM    480  C3'  DT C  22      63.510  77.958  69.487  1.00 51.02           C  
+ATOM    481  O3'  DT C  22      64.876  78.123  69.151  1.00 56.30           O  
+ATOM    482  C2'  DT C  22      62.840  76.944  68.567  1.00 38.86           C  
+ATOM    483  C1'  DT C  22      63.460  75.693  69.172  1.00 37.99           C  
+ATOM    484  N1   DT C  22      62.882  74.408  68.707  1.00 36.58           N  
+ATOM    485  C2   DT C  22      63.786  73.413  68.391  1.00 35.76           C  
+ATOM    486  O2   DT C  22      64.992  73.536  68.524  1.00 37.87           O  
+ATOM    487  N3   DT C  22      63.218  72.241  67.973  1.00 27.02           N  
+ATOM    488  C4   DT C  22      61.867  71.986  67.799  1.00 28.48           C  
+ATOM    489  O4   DT C  22      61.512  70.882  67.393  1.00 27.81           O  
+ATOM    490  C5   DT C  22      60.982  73.074  68.141  1.00 27.76           C  
+ATOM    491  C7   DT C  22      59.492  72.903  68.008  1.00 27.38           C  
+ATOM    492  C6   DT C  22      61.522  74.227  68.555  1.00 29.78           C  
+ATOM    493  P    DA C  23      65.187  79.312  68.135  1.00 60.43           P  
+ATOM    494  OP1  DA C  23      65.852  80.389  68.905  1.00 72.50           O  
+ATOM    495  OP2  DA C  23      63.934  79.564  67.396  1.00 66.48           O  
+ATOM    496  O5'  DA C  23      66.278  78.669  67.169  1.00 65.82           O  
+ATOM    497  C5'  DA C  23      67.518  78.386  67.800  1.00 65.54           C  
+ATOM    498  C4'  DA C  23      68.102  77.120  67.213  1.00 59.28           C  
+ATOM    499  O4'  DA C  23      67.072  76.107  67.254  1.00 57.88           O  
+ATOM    500  C3'  DA C  23      68.447  77.279  65.740  1.00 57.79           C  
+ATOM    501  O3'  DA C  23      69.838  77.493  65.586  1.00 56.92           O  
+ATOM    502  C2'  DA C  23      68.016  75.973  65.081  1.00 51.38           C  
+ATOM    503  C1'  DA C  23      67.243  75.226  66.164  1.00 46.39           C  
+ATOM    504  N9   DA C  23      65.908  74.829  65.729  1.00 35.41           N  
+ATOM    505  C8   DA C  23      64.736  75.528  65.819  1.00 36.41           C  
+ATOM    506  N7   DA C  23      63.689  74.895  65.340  1.00 37.32           N  
+ATOM    507  C5   DA C  23      64.213  73.696  64.894  1.00 34.03           C  
+ATOM    508  C6   DA C  23      63.630  72.584  64.268  1.00 32.58           C  
+ATOM    509  N6   DA C  23      62.330  72.490  63.981  1.00 33.05           N  
+ATOM    510  N1   DA C  23      64.433  71.549  63.955  1.00 33.12           N  
+ATOM    511  C2   DA C  23      65.733  71.637  64.250  1.00 33.75           C  
+ATOM    512  N3   DA C  23      66.403  72.633  64.825  1.00 34.08           N  
+ATOM    513  C4   DA C  23      65.574  73.641  65.126  1.00 34.85           C  
+ATOM    514  P    DT C  24      70.393  77.819  64.126  1.00 47.83           P  
+ATOM    515  OP1  DT C  24      71.779  78.306  64.274  1.00 53.45           O  
+ATOM    516  OP2  DT C  24      69.411  78.676  63.428  1.00 51.42           O  
+ATOM    517  O5'  DT C  24      70.401  76.368  63.454  1.00 45.55           O  
+ATOM    518  C5'  DT C  24      71.336  75.408  63.921  1.00 47.71           C  
+ATOM    519  C4'  DT C  24      71.197  74.097  63.169  1.00 49.74           C  
+ATOM    520  O4'  DT C  24      69.813  73.665  63.160  1.00 44.94           O  
+ATOM    521  C3'  DT C  24      71.652  74.116  61.714  1.00 54.27           C  
+ATOM    522  O3'  DT C  24      72.442  72.949  61.501  1.00 50.03           O  
+ATOM    523  C2'  DT C  24      70.337  74.117  60.934  1.00 44.75           C  
+ATOM    524  C1'  DT C  24      69.438  73.292  61.850  1.00 40.16           C  
+ATOM    525  N1   DT C  24      67.983  73.568  61.729  1.00 36.61           N  
+ATOM    526  C2   DT C  24      67.160  72.558  61.279  1.00 35.49           C  
+ATOM    527  O2   DT C  24      67.543  71.460  60.916  1.00 34.24           O  
+ATOM    528  N3   DT C  24      65.831  72.887  61.248  1.00 37.90           N  
+ATOM    529  C4   DT C  24      65.257  74.085  61.641  1.00 41.54           C  
+ATOM    530  O4   DT C  24      64.041  74.228  61.539  1.00 40.92           O  
+ATOM    531  C5   DT C  24      66.178  75.084  62.114  1.00 37.19           C  
+ATOM    532  C7   DT C  24      65.633  76.414  62.559  1.00 33.35           C  
+ATOM    533  C6   DT C  24      67.483  74.783  62.154  1.00 37.76           C  
+ATOM    534  P    DA C  25      72.921  72.392  60.081  1.00 48.12           P  
+ATOM    535  OP1  DA C  25      74.352  72.049  60.231  1.00 81.53           O  
+ATOM    536  OP2  DA C  25      72.492  73.336  59.027  1.00 47.07           O  
+ATOM    537  O5'  DA C  25      72.100  71.032  59.923  1.00 41.61           O  
+ATOM    538  C5'  DA C  25      70.854  71.132  59.262  1.00 35.27           C  
+ATOM    539  C4'  DA C  25      70.670  69.971  58.309  1.00 46.41           C  
+ATOM    540  O4'  DA C  25      69.257  69.863  58.025  1.00 49.92           O  
+ATOM    541  C3'  DA C  25      71.278  70.197  56.935  1.00 63.33           C  
+ATOM    542  O3'  DA C  25      71.440  68.941  56.296  1.00 63.41           O  
+ATOM    543  C2'  DA C  25      70.242  71.078  56.240  1.00 49.50           C  
+ATOM    544  C1'  DA C  25      68.937  70.692  56.927  1.00 49.89           C  
+ATOM    545  N9   DA C  25      68.167  71.830  57.419  1.00 44.06           N  
+ATOM    546  C8   DA C  25      68.570  72.942  58.104  1.00 44.99           C  
+ATOM    547  N7   DA C  25      67.589  73.778  58.357  1.00 44.72           N  
+ATOM    548  C5   DA C  25      66.475  73.163  57.806  1.00 37.72           C  
+ATOM    549  C6   DA C  25      65.119  73.535  57.741  1.00 43.66           C  
+ATOM    550  N6   DA C  25      64.646  74.674  58.260  1.00 45.09           N  
+ATOM    551  N1   DA C  25      64.271  72.700  57.110  1.00 42.39           N  
+ATOM    552  C2   DA C  25      64.756  71.569  56.584  1.00 40.22           C  
+ATOM    553  N3   DA C  25      66.004  71.107  56.584  1.00 38.36           N  
+ATOM    554  C4   DA C  25      66.815  71.963  57.220  1.00 37.25           C  
+ATOM    555  P    DC C  26      72.328  68.842  54.972  1.00 57.40           P  
+ATOM    556  OP1  DC C  26      72.679  67.409  54.803  1.00 56.45           O  
+ATOM    557  OP2  DC C  26      73.385  69.877  55.039  1.00 66.81           O  
+ATOM    558  O5'  DC C  26      71.303  69.291  53.833  1.00 40.53           O  
+ATOM    559  C5'  DC C  26      70.282  68.399  53.445  1.00 45.54           C  
+ATOM    560  C4'  DC C  26      69.320  69.100  52.506  1.00 54.46           C  
+ATOM    561  O4'  DC C  26      68.537  70.061  53.259  1.00 59.55           O  
+ATOM    562  C3'  DC C  26      69.930  69.883  51.348  1.00 55.14           C  
+ATOM    563  O3'  DC C  26      69.196  69.574  50.175  1.00 67.47           O  
+ATOM    564  C2'  DC C  26      69.665  71.337  51.729  1.00 52.33           C  
+ATOM    565  C1'  DC C  26      68.315  71.166  52.413  1.00 53.43           C  
+ATOM    566  N1   DC C  26      67.875  72.325  53.238  1.00 50.89           N  
+ATOM    567  C2   DC C  26      66.497  72.554  53.363  1.00 44.30           C  
+ATOM    568  O2   DC C  26      65.696  71.795  52.797  1.00 42.89           O  
+ATOM    569  N3   DC C  26      66.082  73.607  54.113  1.00 41.49           N  
+ATOM    570  C4   DC C  26      66.972  74.398  54.718  1.00 41.48           C  
+ATOM    571  N4   DC C  26      66.503  75.415  55.453  1.00 30.66           N  
+ATOM    572  C5   DC C  26      68.380  74.178  54.605  1.00 44.39           C  
+ATOM    573  C6   DC C  26      68.779  73.136  53.866  1.00 48.92           C  
+ATOM    574  P    DG C  27      69.993  69.336  48.812  1.00 68.07           P  
+ATOM    575  OP1  DG C  27      70.642  68.016  48.969  1.00 69.82           O  
+ATOM    576  OP2  DG C  27      70.789  70.549  48.520  1.00 67.36           O  
+ATOM    577  O5'  DG C  27      68.839  69.231  47.715  1.00 59.91           O  
+ATOM    578  C5'  DG C  27      67.776  68.331  47.951  1.00 55.31           C  
+ATOM    579  C4'  DG C  27      66.465  69.036  47.664  1.00 63.69           C  
+ATOM    580  O4'  DG C  27      66.226  70.043  48.678  1.00 66.75           O  
+ATOM    581  C3'  DG C  27      66.440  69.770  46.331  1.00 59.33           C  
+ATOM    582  O3'  DG C  27      65.204  69.538  45.678  1.00 73.15           O  
+ATOM    583  C2'  DG C  27      66.567  71.237  46.722  1.00 47.49           C  
+ATOM    584  C1'  DG C  27      65.852  71.258  48.065  1.00 46.91           C  
+ATOM    585  N9   DG C  27      66.308  72.336  48.936  1.00 57.21           N  
+ATOM    586  C8   DG C  27      67.589  72.681  49.302  1.00 56.91           C  
+ATOM    587  N7   DG C  27      67.647  73.694  50.119  1.00 55.25           N  
+ATOM    588  C5   DG C  27      66.314  74.033  50.323  1.00 53.88           C  
+ATOM    589  C6   DG C  27      65.749  75.059  51.118  1.00 44.85           C  
+ATOM    590  O6   DG C  27      66.324  75.901  51.823  1.00 42.02           O  
+ATOM    591  N1   DG C  27      64.360  75.053  51.038  1.00 43.59           N  
+ATOM    592  C2   DG C  27      63.607  74.175  50.297  1.00 48.54           C  
+ATOM    593  N2   DG C  27      62.278  74.326  50.345  1.00 46.90           N  
+ATOM    594  N3   DG C  27      64.125  73.217  49.548  1.00 51.61           N  
+ATOM    595  C4   DG C  27      65.477  73.207  49.605  1.00 56.55           C  
+ATOM    596  P    DA C  28      65.037  69.974  44.148  1.00 81.39           P  
+ATOM    597  OP1  DA C  28      64.210  68.946  43.478  1.00 89.20           O  
+ATOM    598  OP2  DA C  28      66.371  70.314  43.608  1.00100.00           O  
+ATOM    599  O5'  DA C  28      64.182  71.323  44.234  1.00 71.43           O  
+ATOM    600  C5'  DA C  28      62.888  71.290  44.812  1.00 69.97           C  
+ATOM    601  C4'  DA C  28      62.500  72.692  45.232  1.00 72.50           C  
+ATOM    602  O4'  DA C  28      63.464  73.155  46.213  1.00 74.52           O  
+ATOM    603  C3'  DA C  28      62.527  73.716  44.102  1.00 71.67           C  
+ATOM    604  O3'  DA C  28      61.273  74.384  44.009  1.00 75.49           O  
+ATOM    605  C2'  DA C  28      63.660  74.655  44.506  1.00 65.07           C  
+ATOM    606  C1'  DA C  28      63.574  74.547  46.022  1.00 61.87           C  
+ATOM    607  N9   DA C  28      64.692  75.122  46.770  1.00 54.64           N  
+ATOM    608  C8   DA C  28      66.023  74.812  46.751  1.00 55.81           C  
+ATOM    609  N7   DA C  28      66.753  75.564  47.545  1.00 59.11           N  
+ATOM    610  C5   DA C  28      65.842  76.434  48.121  1.00 55.16           C  
+ATOM    611  C6   DA C  28      65.972  77.480  49.054  1.00 50.74           C  
+ATOM    612  N6   DA C  28      67.135  77.851  49.599  1.00 53.53           N  
+ATOM    613  N1   DA C  28      64.853  78.143  49.415  1.00 49.34           N  
+ATOM    614  C2   DA C  28      63.684  77.784  48.871  1.00 50.04           C  
+ATOM    615  N3   DA C  28      63.439  76.817  47.991  1.00 50.78           N  
+ATOM    616  C4   DA C  28      64.568  76.174  47.650  1.00 52.78           C  
+ATOM    617  P    DA C  29      60.687  74.637  42.542  1.00 73.64           P  
+ATOM    618  OP1  DA C  29      60.154  73.348  42.050  1.00 78.18           O  
+ATOM    619  OP2  DA C  29      61.718  75.371  41.775  1.00 69.84           O  
+ATOM    620  O5'  DA C  29      59.440  75.611  42.763  1.00 68.82           O  
+ATOM    621  C5'  DA C  29      58.910  75.756  44.069  1.00 76.74           C  
+ATOM    622  C4'  DA C  29      59.166  77.169  44.546  1.00 70.50           C  
+ATOM    623  O4'  DA C  29      60.507  77.249  45.086  1.00 65.49           O  
+ATOM    624  C3'  DA C  29      59.118  78.192  43.417  1.00 77.88           C  
+ATOM    625  O3'  DA C  29      58.345  79.296  43.847  1.00 90.89           O  
+ATOM    626  C2'  DA C  29      60.581  78.588  43.225  1.00 74.96           C  
+ATOM    627  C1'  DA C  29      61.023  78.495  44.677  1.00 64.16           C  
+ATOM    628  N9   DA C  29      62.456  78.472  44.933  1.00 59.81           N  
+ATOM    629  C8   DA C  29      63.392  77.610  44.447  1.00 57.93           C  
+ATOM    630  N7   DA C  29      64.603  77.822  44.901  1.00 56.95           N  
+ATOM    631  C5   DA C  29      64.445  78.912  45.739  1.00 56.42           C  
+ATOM    632  C6   DA C  29      65.359  79.636  46.519  1.00 54.81           C  
+ATOM    633  N6   DA C  29      66.656  79.331  46.560  1.00 56.90           N  
+ATOM    634  N1   DA C  29      64.896  80.674  47.245  1.00 54.73           N  
+ATOM    635  C2   DA C  29      63.589  80.952  47.186  1.00 56.92           C  
+ATOM    636  N3   DA C  29      62.631  80.345  46.484  1.00 57.27           N  
+ATOM    637  C4   DA C  29      63.129  79.321  45.777  1.00 57.04           C  
+ATOM    638  P    DG C  30      57.871  80.382  42.775  1.00 90.74           P  
+ATOM    639  OP1  DG C  30      56.391  80.386  42.750  1.00100.00           O  
+ATOM    640  OP2  DG C  30      58.628  80.172  41.520  1.00 97.55           O  
+ATOM    641  O5'  DG C  30      58.366  81.757  43.414  1.00 70.80           O  
+ATOM    642  C5'  DG C  30      58.092  82.063  44.766  1.00 64.36           C  
+ATOM    643  C4'  DG C  30      59.045  83.153  45.208  1.00 70.87           C  
+ATOM    644  O4'  DG C  30      60.383  82.603  45.264  1.00 77.14           O  
+ATOM    645  C3'  DG C  30      59.123  84.338  44.255  1.00 54.47           C  
+ATOM    646  O3'  DG C  30      59.209  85.519  45.008  1.00 66.12           O  
+ATOM    647  C2'  DG C  30      60.426  84.121  43.494  1.00 61.52           C  
+ATOM    648  C1'  DG C  30      61.272  83.451  44.566  1.00 66.51           C  
+ATOM    649  N9   DG C  30      62.358  82.606  44.079  1.00 60.85           N  
+ATOM    650  C8   DG C  30      62.354  81.491  43.277  1.00 58.34           C  
+ATOM    651  N7   DG C  30      63.545  80.988  43.095  1.00 54.74           N  
+ATOM    652  C5   DG C  30      64.376  81.806  43.848  1.00 50.00           C  
+ATOM    653  C6   DG C  30      65.771  81.745  44.046  1.00 55.46           C  
+ATOM    654  O6   DG C  30      66.558  80.920  43.564  1.00 57.53           O  
+ATOM    655  N1   DG C  30      66.227  82.758  44.888  1.00 52.07           N  
+ATOM    656  C2   DG C  30      65.421  83.722  45.445  1.00 51.61           C  
+ATOM    657  N2   DG C  30      66.026  84.633  46.224  1.00 44.90           N  
+ATOM    658  N3   DG C  30      64.108  83.795  45.269  1.00 49.51           N  
+ATOM    659  C4   DG C  30      63.661  82.807  44.461  1.00 47.28           C  
+ATOM    660  P    DT C  31      58.954  86.872  44.206  1.00 76.43           P  
+ATOM    661  OP1  DT C  31      57.905  87.642  44.905  1.00 70.50           O  
+ATOM    662  OP2  DT C  31      58.839  86.541  42.768  1.00 92.11           O  
+ATOM    663  O5'  DT C  31      60.309  87.670  44.442  1.00 83.11           O  
+ATOM    664  C5'  DT C  31      60.822  87.774  45.752  1.00 75.47           C  
+ATOM    665  C4'  DT C  31      62.194  88.401  45.620  1.00 72.96           C  
+ATOM    666  O4'  DT C  31      63.170  87.438  45.150  1.00 68.71           O  
+ATOM    667  C3'  DT C  31      62.237  89.549  44.621  1.00 67.94           C  
+ATOM    668  O3'  DT C  31      62.807  90.645  45.306  1.00 67.86           O  
+ATOM    669  C2'  DT C  31      63.111  89.057  43.464  1.00 49.43           C  
+ATOM    670  C1'  DT C  31      64.005  88.063  44.193  1.00 44.13           C  
+ATOM    671  N1   DT C  31      64.623  86.978  43.389  1.00 43.17           N  
+ATOM    672  C2   DT C  31      65.969  86.782  43.593  1.00 45.31           C  
+ATOM    673  O2   DT C  31      66.636  87.516  44.306  1.00 47.23           O  
+ATOM    674  N3   DT C  31      66.513  85.722  42.918  1.00 36.39           N  
+ATOM    675  C4   DT C  31      65.837  84.826  42.115  1.00 41.10           C  
+ATOM    676  O4   DT C  31      66.439  83.909  41.559  1.00 41.10           O  
+ATOM    677  C5   DT C  31      64.431  85.074  41.970  1.00 36.32           C  
+ATOM    678  C7   DT C  31      63.610  84.167  41.109  1.00 36.69           C  
+ATOM    679  C6   DT C  31      63.891  86.121  42.598  1.00 37.86           C  
+ATOM    680  P    DT C  32      62.537  92.118  44.759  1.00 74.26           P  
+ATOM    681  OP1  DT C  32      61.662  92.852  45.697  1.00 82.37           O  
+ATOM    682  OP2  DT C  32      62.179  92.009  43.329  1.00 77.28           O  
+ATOM    683  O5'  DT C  32      64.001  92.724  44.881  1.00 74.79           O  
+ATOM    684  C5'  DT C  32      64.936  91.811  44.371  1.00 70.46           C  
+ATOM    685  C4'  DT C  32      66.343  92.340  44.531  1.00 69.59           C  
+ATOM    686  O4'  DT C  32      67.215  91.221  44.236  1.00 70.32           O  
+ATOM    687  C3'  DT C  32      66.709  93.451  43.557  1.00 67.36           C  
+ATOM    688  O3'  DT C  32      67.617  94.380  44.137  1.00 81.03           O  
+ATOM    689  C2'  DT C  32      67.347  92.700  42.394  1.00 52.41           C  
+ATOM    690  C1'  DT C  32      67.915  91.431  43.025  1.00 49.03           C  
+ATOM    691  N1   DT C  32      67.799  90.211  42.160  1.00 49.26           N  
+ATOM    692  C2   DT C  32      68.881  89.359  42.041  1.00 51.69           C  
+ATOM    693  O2   DT C  32      69.957  89.545  42.573  1.00 55.73           O  
+ATOM    694  N3   DT C  32      68.676  88.249  41.266  1.00 40.11           N  
+ATOM    695  C4   DT C  32      67.510  87.912  40.604  1.00 45.05           C  
+ATOM    696  O4   DT C  32      67.444  86.881  39.941  1.00 44.60           O  
+ATOM    697  C5   DT C  32      66.421  88.835  40.781  1.00 46.07           C  
+ATOM    698  C7   DT C  32      65.096  88.574  40.137  1.00 45.71           C  
+ATOM    699  C6   DT C  32      66.607  89.924  41.533  1.00 48.78           C  
+ATOM    700  P    DA C  33      67.823  95.776  43.383  1.00 79.07           P  
+ATOM    701  OP1  DA C  33      67.821  96.879  44.371  1.00 75.40           O  
+ATOM    702  OP2  DA C  33      66.896  95.806  42.230  1.00 84.63           O  
+ATOM    703  O5'  DA C  33      69.309  95.643  42.819  1.00 77.00           O  
+ATOM    704  C5'  DA C  33      70.278  95.022  43.639  1.00 76.29           C  
+ATOM    705  C4'  DA C  33      71.334  94.435  42.733  1.00 68.24           C  
+ATOM    706  O4'  DA C  33      70.783  93.309  42.014  1.00 68.34           O  
+ATOM    707  C3'  DA C  33      71.872  95.393  41.684  1.00 62.77           C  
+ATOM    708  O3'  DA C  33      73.273  95.378  41.893  1.00 71.39           O  
+ATOM    709  C2'  DA C  33      71.402  94.807  40.350  1.00 51.59           C  
+ATOM    710  C1'  DA C  33      71.239  93.325  40.679  1.00 47.28           C  
+ATOM    711  N9   DA C  33      70.216  92.595  39.941  1.00 32.37           N  
+ATOM    712  C8   DA C  33      68.922  92.976  39.744  1.00 32.50           C  
+ATOM    713  N7   DA C  33      68.213  92.088  39.094  1.00 38.16           N  
+ATOM    714  C5   DA C  33      69.083  91.038  38.859  1.00 27.11           C  
+ATOM    715  C6   DA C  33      68.929  89.800  38.208  1.00 40.36           C  
+ATOM    716  N6   DA C  33      67.775  89.403  37.646  1.00 39.34           N  
+ATOM    717  N1   DA C  33      70.011  88.994  38.139  1.00 40.54           N  
+ATOM    718  C2   DA C  33      71.147  89.404  38.714  1.00 37.64           C  
+ATOM    719  N3   DA C  33      71.400  90.543  39.353  1.00 34.93           N  
+ATOM    720  C4   DA C  33      70.319  91.333  39.393  1.00 29.42           C  
+ATOM    721  P    DT C  34      74.329  96.116  40.954  1.00 76.00           P  
+ATOM    722  OP1  DT C  34      74.873  97.278  41.694  1.00 54.21           O  
+ATOM    723  OP2  DT C  34      73.706  96.309  39.623  1.00100.00           O  
+ATOM    724  O5'  DT C  34      75.444  94.973  40.852  1.00 53.10           O  
+ATOM    725  C5'  DT C  34      76.218  94.880  39.660  1.00100.00           C  
+ATOM    726  C4'  DT C  34      76.268  93.450  39.151  1.00100.00           C  
+ATOM    727  O4'  DT C  34      74.917  92.980  38.910  1.00 79.60           O  
+ATOM    728  C3'  DT C  34      77.023  93.236  37.842  1.00 54.07           C  
+ATOM    729  O3'  DT C  34      77.681  91.974  37.877  1.00 58.45           O  
+ATOM    730  C2'  DT C  34      75.896  93.235  36.813  1.00 83.46           C  
+ATOM    731  C1'  DT C  34      74.849  92.457  37.600  1.00 50.52           C  
+ATOM    732  N1   DT C  34      73.447  92.554  37.078  1.00 49.57           N  
+ATOM    733  C2   DT C  34      72.938  91.416  36.485  1.00 49.35           C  
+ATOM    734  O2   DT C  34      73.570  90.375  36.393  1.00 50.04           O  
+ATOM    735  N3   DT C  34      71.656  91.522  36.011  1.00 36.88           N  
+ATOM    736  C4   DT C  34      70.847  92.633  36.097  1.00 39.15           C  
+ATOM    737  O4   DT C  34      69.716  92.592  35.625  1.00 39.11           O  
+ATOM    738  C5   DT C  34      71.439  93.787  36.716  1.00 37.06           C  
+ATOM    739  C7   DT C  34      70.627  95.041  36.818  1.00 37.10           C  
+ATOM    740  C6   DT C  34      72.691  93.705  37.185  1.00 41.73           C  
+TER     741       DT C  34                                                      
+ATOM    742  O5'  DA D   1      69.061  40.209 150.308  1.00100.00           O  
+ATOM    743  C5'  DA D   1      68.754  38.940 149.730  1.00 42.68           C  
+ATOM    744  C4'  DA D   1      69.947  38.421 148.953  1.00100.00           C  
+ATOM    745  O4'  DA D   1      69.818  37.010 148.666  1.00 82.60           O  
+ATOM    746  C3'  DA D   1      70.144  39.096 147.605  1.00 49.21           C  
+ATOM    747  O3'  DA D   1      71.133  40.088 147.751  1.00 74.01           O  
+ATOM    748  C2'  DA D   1      70.596  37.997 146.648  1.00100.00           C  
+ATOM    749  C1'  DA D   1      70.496  36.712 147.464  1.00 54.13           C  
+ATOM    750  N9   DA D   1      69.710  35.655 146.834  1.00 53.30           N  
+ATOM    751  C8   DA D   1      68.353  35.483 146.877  1.00 53.95           C  
+ATOM    752  N7   DA D   1      67.925  34.415 146.242  1.00 49.20           N  
+ATOM    753  C5   DA D   1      69.089  33.849 145.760  1.00 47.45           C  
+ATOM    754  C6   DA D   1      69.303  32.684 144.997  1.00 48.49           C  
+ATOM    755  N6   DA D   1      68.292  31.904 144.604  1.00 47.96           N  
+ATOM    756  N1   DA D   1      70.574  32.371 144.673  1.00 47.86           N  
+ATOM    757  C2   DA D   1      71.547  33.189 145.092  1.00 49.78           C  
+ATOM    758  N3   DA D   1      71.477  34.315 145.809  1.00 49.67           N  
+ATOM    759  C4   DA D   1      70.199  34.591 146.113  1.00 49.19           C  
+ATOM    760  P    DT D   2      71.222  41.118 146.540  1.00 82.28           P  
+ATOM    761  OP1  DT D   2      72.070  42.248 146.982  1.00 72.84           O  
+ATOM    762  OP2  DT D   2      69.855  41.309 146.009  1.00 58.43           O  
+ATOM    763  O5'  DT D   2      72.018  40.258 145.463  1.00 84.02           O  
+ATOM    764  C5'  DT D   2      73.314  39.813 145.789  1.00 73.35           C  
+ATOM    765  C4'  DT D   2      73.898  39.164 144.553  1.00 58.55           C  
+ATOM    766  O4'  DT D   2      73.221  37.903 144.316  1.00 52.33           O  
+ATOM    767  C3'  DT D   2      73.763  39.967 143.265  1.00 57.31           C  
+ATOM    768  O3'  DT D   2      74.986  39.813 142.566  1.00 58.20           O  
+ATOM    769  C2'  DT D   2      72.625  39.251 142.540  1.00 55.48           C  
+ATOM    770  C1'  DT D   2      72.848  37.801 142.959  1.00 43.95           C  
+ATOM    771  N1   DT D   2      71.612  36.963 142.889  1.00 41.85           N  
+ATOM    772  C2   DT D   2      71.719  35.687 142.384  1.00 44.19           C  
+ATOM    773  O2   DT D   2      72.763  35.201 141.980  1.00 48.12           O  
+ATOM    774  N3   DT D   2      70.553  34.971 142.337  1.00 35.16           N  
+ATOM    775  C4   DT D   2      69.309  35.414 142.742  1.00 40.09           C  
+ATOM    776  O4   DT D   2      68.332  34.681 142.645  1.00 40.00           O  
+ATOM    777  C5   DT D   2      69.268  36.750 143.264  1.00 32.36           C  
+ATOM    778  C7   DT D   2      67.928  37.260 143.721  1.00 31.26           C  
+ATOM    779  C6   DT D   2      70.401  37.461 143.323  1.00 33.97           C  
+ATOM    780  P    DA D   3      75.590  40.820 141.484  1.00 54.25           P  
+ATOM    781  OP1  DA D   3      76.761  41.489 142.089  1.00 61.14           O  
+ATOM    782  OP2  DA D   3      74.519  41.654 140.898  1.00 76.46           O  
+ATOM    783  O5'  DA D   3      76.104  39.735 140.429  1.00 56.57           O  
+ATOM    784  C5'  DA D   3      76.860  38.655 140.963  1.00 35.40           C  
+ATOM    785  C4'  DA D   3      76.986  37.531 139.956  1.00 44.89           C  
+ATOM    786  O4'  DA D   3      75.709  36.850 139.879  1.00 54.11           O  
+ATOM    787  C3'  DA D   3      77.287  37.988 138.534  1.00 48.73           C  
+ATOM    788  O3'  DA D   3      77.993  36.959 137.825  1.00 59.39           O  
+ATOM    789  C2'  DA D   3      75.878  38.248 137.997  1.00 44.00           C  
+ATOM    790  C1'  DA D   3      75.110  37.084 138.617  1.00 48.86           C  
+ATOM    791  N9   DA D   3      73.683  37.289 138.873  1.00 36.39           N  
+ATOM    792  C8   DA D   3      73.021  38.371 139.377  1.00 34.72           C  
+ATOM    793  N7   DA D   3      71.736  38.162 139.559  1.00 32.55           N  
+ATOM    794  C5   DA D   3      71.542  36.851 139.164  1.00 25.54           C  
+ATOM    795  C6   DA D   3      70.388  36.047 139.102  1.00 37.12           C  
+ATOM    796  N6   DA D   3      69.179  36.487 139.472  1.00 44.16           N  
+ATOM    797  N1   DA D   3      70.541  34.796 138.629  1.00 34.54           N  
+ATOM    798  C2   DA D   3      71.770  34.388 138.274  1.00 32.58           C  
+ATOM    799  N3   DA D   3      72.926  35.054 138.286  1.00 29.97           N  
+ATOM    800  C4   DA D   3      72.736  36.299 138.738  1.00 26.82           C  
+ATOM    801  P    DA D   4      78.869  37.222 136.509  1.00 58.19           P  
+ATOM    802  OP1  DA D   4      79.883  36.152 136.414  1.00 55.47           O  
+ATOM    803  OP2  DA D   4      79.298  38.635 136.467  1.00 52.95           O  
+ATOM    804  O5'  DA D   4      77.797  36.952 135.353  1.00 70.51           O  
+ATOM    805  C5'  DA D   4      77.433  35.596 135.113  1.00 63.76           C  
+ATOM    806  C4'  DA D   4      76.178  35.493 134.266  1.00 60.32           C  
+ATOM    807  O4'  DA D   4      75.000  35.757 135.073  1.00 53.53           O  
+ATOM    808  C3'  DA D   4      76.111  36.428 133.058  1.00 52.93           C  
+ATOM    809  O3'  DA D   4      75.743  35.694 131.877  1.00 64.22           O  
+ATOM    810  C2'  DA D   4      75.001  37.391 133.465  1.00 32.88           C  
+ATOM    811  C1'  DA D   4      74.094  36.447 134.245  1.00 32.67           C  
+ATOM    812  N9   DA D   4      73.061  37.164 134.984  1.00 27.89           N  
+ATOM    813  C8   DA D   4      73.101  38.460 135.415  1.00 27.51           C  
+ATOM    814  N7   DA D   4      71.999  38.877 135.990  1.00 26.98           N  
+ATOM    815  C5   DA D   4      71.159  37.786 135.900  1.00 22.49           C  
+ATOM    816  C6   DA D   4      69.835  37.595 136.323  1.00 26.44           C  
+ATOM    817  N6   DA D   4      69.137  38.550 136.943  1.00 27.71           N  
+ATOM    818  N1   DA D   4      69.276  36.388 136.110  1.00 27.17           N  
+ATOM    819  C2   DA D   4      70.013  35.452 135.500  1.00 29.42           C  
+ATOM    820  N3   DA D   4      71.265  35.524 135.043  1.00 28.58           N  
+ATOM    821  C4   DA D   4      71.790  36.731 135.278  1.00 24.05           C  
+ATOM    822  P    DC D   5      76.228  36.036 130.381  1.00 58.58           P  
+ATOM    823  OP1  DC D   5      76.817  34.822 129.773  1.00 52.00           O  
+ATOM    824  OP2  DC D   5      77.051  37.262 130.450  1.00 45.72           O  
+ATOM    825  O5'  DC D   5      74.874  36.312 129.569  1.00 53.27           O  
+ATOM    826  C5'  DC D   5      73.753  36.957 130.153  1.00 40.96           C  
+ATOM    827  C4'  DC D   5      72.618  35.990 130.422  1.00 41.71           C  
+ATOM    828  O4'  DC D   5      72.057  36.339 131.702  1.00 36.03           O  
+ATOM    829  C3'  DC D   5      71.481  36.115 129.428  1.00 58.10           C  
+ATOM    830  O3'  DC D   5      71.551  34.978 128.602  1.00 65.76           O  
+ATOM    831  C2'  DC D   5      70.191  36.133 130.245  1.00 53.20           C  
+ATOM    832  C1'  DC D   5      70.649  36.381 131.676  1.00 31.69           C  
+ATOM    833  N1   DC D   5      70.319  37.694 132.295  1.00 31.39           N  
+ATOM    834  C2   DC D   5      69.041  37.845 132.831  1.00 35.30           C  
+ATOM    835  O2   DC D   5      68.277  36.885 132.708  1.00 40.57           O  
+ATOM    836  N3   DC D   5      68.681  39.000 133.447  1.00 32.94           N  
+ATOM    837  C4   DC D   5      69.581  39.978 133.541  1.00 39.98           C  
+ATOM    838  N4   DC D   5      69.211  41.106 134.155  1.00 44.02           N  
+ATOM    839  C5   DC D   5      70.902  39.842 133.019  1.00 35.60           C  
+ATOM    840  C6   DC D   5      71.234  38.695 132.415  1.00 32.82           C  
+ATOM    841  P    DT D   6      70.897  35.127 127.160  1.00 58.45           P  
+ATOM    842  OP1  DT D   6      71.080  33.843 126.448  1.00 44.84           O  
+ATOM    843  OP2  DT D   6      71.405  36.386 126.569  1.00 47.23           O  
+ATOM    844  O5'  DT D   6      69.344  35.289 127.527  1.00 49.32           O  
+ATOM    845  C5'  DT D   6      68.596  34.178 128.038  1.00 48.28           C  
+ATOM    846  C4'  DT D   6      67.107  34.456 128.165  1.00 52.20           C  
+ATOM    847  O4'  DT D   6      66.793  35.410 129.213  1.00 60.10           O  
+ATOM    848  C3'  DT D   6      66.426  35.004 126.929  1.00 50.43           C  
+ATOM    849  O3'  DT D   6      65.113  34.510 126.987  1.00 55.62           O  
+ATOM    850  C2'  DT D   6      66.448  36.504 127.192  1.00 48.29           C  
+ATOM    851  C1'  DT D   6      66.140  36.547 128.679  1.00 37.42           C  
+ATOM    852  N1   DT D   6      66.746  37.749 129.294  1.00 35.95           N  
+ATOM    853  C2   DT D   6      65.970  38.533 130.114  1.00 37.41           C  
+ATOM    854  O2   DT D   6      64.814  38.270 130.389  1.00 37.69           O  
+ATOM    855  N3   DT D   6      66.618  39.637 130.607  1.00 36.76           N  
+ATOM    856  C4   DT D   6      67.924  40.024 130.346  1.00 36.23           C  
+ATOM    857  O4   DT D   6      68.357  41.079 130.814  1.00 35.33           O  
+ATOM    858  C5   DT D   6      68.664  39.144 129.474  1.00 33.58           C  
+ATOM    859  C7   DT D   6      70.079  39.441 129.072  1.00 34.38           C  
+ATOM    860  C6   DT D   6      68.046  38.070 128.974  1.00 34.11           C  
+ATOM    861  P    DT D   7      64.236  34.541 125.660  1.00 64.20           P  
+ATOM    862  OP1  DT D   7      63.620  33.202 125.509  1.00 64.70           O  
+ATOM    863  OP2  DT D   7      65.033  35.131 124.560  1.00 78.81           O  
+ATOM    864  O5'  DT D   7      63.114  35.591 126.081  1.00 58.95           O  
+ATOM    865  C5'  DT D   7      62.329  35.289 127.216  1.00 46.57           C  
+ATOM    866  C4'  DT D   7      61.581  36.542 127.619  1.00 40.27           C  
+ATOM    867  O4'  DT D   7      62.534  37.553 128.023  1.00 43.99           O  
+ATOM    868  C3'  DT D   7      60.764  37.174 126.502  1.00 39.73           C  
+ATOM    869  O3'  DT D   7      59.484  37.444 127.043  1.00 53.93           O  
+ATOM    870  C2'  DT D   7      61.535  38.453 126.174  1.00 36.76           C  
+ATOM    871  C1'  DT D   7      62.108  38.808 127.540  1.00 36.68           C  
+ATOM    872  N1   DT D   7      63.336  39.643 127.542  1.00 38.85           N  
+ATOM    873  C2   DT D   7      63.364  40.715 128.402  1.00 42.34           C  
+ATOM    874  O2   DT D   7      62.400  41.054 129.072  1.00 42.45           O  
+ATOM    875  N3   DT D   7      64.546  41.420 128.392  1.00 40.68           N  
+ATOM    876  C4   DT D   7      65.688  41.134 127.661  1.00 44.94           C  
+ATOM    877  O4   DT D   7      66.683  41.843 127.769  1.00 45.04           O  
+ATOM    878  C5   DT D   7      65.595  39.980 126.812  1.00 39.96           C  
+ATOM    879  C7   DT D   7      66.777  39.598 125.973  1.00 37.73           C  
+ATOM    880  C6   DT D   7      64.451  39.286 126.808  1.00 42.61           C  
+ATOM    881  P    DC D   8      58.218  37.662 126.092  1.00 63.37           P  
+ATOM    882  OP1  DC D   8      57.163  36.709 126.501  1.00 92.72           O  
+ATOM    883  OP2  DC D   8      58.696  37.710 124.692  1.00 69.50           O  
+ATOM    884  O5'  DC D   8      57.751  39.118 126.526  1.00 53.54           O  
+ATOM    885  C5'  DC D   8      58.875  39.937 126.710  1.00 57.54           C  
+ATOM    886  C4'  DC D   8      58.425  41.232 127.331  1.00 47.53           C  
+ATOM    887  O4'  DC D   8      59.640  41.904 127.720  1.00 43.07           O  
+ATOM    888  C3'  DC D   8      57.686  42.126 126.347  1.00 44.91           C  
+ATOM    889  O3'  DC D   8      56.557  42.711 126.977  1.00 57.98           O  
+ATOM    890  C2'  DC D   8      58.735  43.152 125.927  1.00 48.53           C  
+ATOM    891  C1'  DC D   8      59.717  43.162 127.094  1.00 41.32           C  
+ATOM    892  N1   DC D   8      61.131  43.249 126.682  1.00 37.48           N  
+ATOM    893  C2   DC D   8      61.814  44.372 127.126  1.00 34.98           C  
+ATOM    894  O2   DC D   8      61.198  45.199 127.816  1.00 39.55           O  
+ATOM    895  N3   DC D   8      63.113  44.509 126.780  1.00 35.85           N  
+ATOM    896  C4   DC D   8      63.720  43.563 126.059  1.00 36.41           C  
+ATOM    897  N4   DC D   8      65.011  43.745 125.757  1.00 40.71           N  
+ATOM    898  C5   DC D   8      63.034  42.400 125.602  1.00 32.24           C  
+ATOM    899  C6   DC D   8      61.749  42.285 125.942  1.00 34.75           C  
+ATOM    900  P    DG D   9      55.427  43.439 126.109  1.00 53.34           P  
+ATOM    901  OP1  DG D   9      54.155  43.425 126.863  1.00 64.29           O  
+ATOM    902  OP2  DG D   9      55.484  42.925 124.725  1.00 62.96           O  
+ATOM    903  O5'  DG D   9      55.921  44.953 126.093  1.00 47.12           O  
+ATOM    904  C5'  DG D   9      55.837  45.722 127.277  1.00 42.07           C  
+ATOM    905  C4'  DG D   9      56.476  47.054 126.954  1.00 46.97           C  
+ATOM    906  O4'  DG D   9      57.880  46.829 126.689  1.00 47.41           O  
+ATOM    907  C3'  DG D   9      55.916  47.699 125.695  1.00 56.01           C  
+ATOM    908  O3'  DG D   9      55.318  48.915 126.088  1.00 56.55           O  
+ATOM    909  C2'  DG D   9      57.106  47.909 124.758  1.00 55.40           C  
+ATOM    910  C1'  DG D   9      58.323  47.669 125.645  1.00 49.64           C  
+ATOM    911  N9   DG D   9      59.421  46.948 125.005  1.00 38.49           N  
+ATOM    912  C8   DG D   9      59.420  45.778 124.281  1.00 28.48           C  
+ATOM    913  N7   DG D   9      60.614  45.421 123.894  1.00 28.12           N  
+ATOM    914  C5   DG D   9      61.458  46.394 124.426  1.00 35.57           C  
+ATOM    915  C6   DG D   9      62.870  46.533 124.362  1.00 36.56           C  
+ATOM    916  O6   DG D   9      63.705  45.812 123.804  1.00 36.72           O  
+ATOM    917  N1   DG D   9      63.324  47.672 125.026  1.00 36.16           N  
+ATOM    918  C2   DG D   9      62.518  48.561 125.690  1.00 44.81           C  
+ATOM    919  N2   DG D   9      63.147  49.584 126.291  1.00 43.43           N  
+ATOM    920  N3   DG D   9      61.195  48.447 125.765  1.00 43.59           N  
+ATOM    921  C4   DG D   9      60.737  47.343 125.115  1.00 40.34           C  
+ATOM    922  P    DT D  10      54.863  49.941 124.958  1.00 55.53           P  
+ATOM    923  OP1  DT D  10      53.735  50.728 125.500  1.00 67.54           O  
+ATOM    924  OP2  DT D  10      54.718  49.189 123.691  1.00 66.51           O  
+ATOM    925  O5'  DT D  10      56.124  50.913 124.862  1.00 58.49           O  
+ATOM    926  C5'  DT D  10      56.270  51.905 125.860  1.00 58.13           C  
+ATOM    927  C4'  DT D  10      57.582  52.603 125.586  1.00 66.04           C  
+ATOM    928  O4'  DT D  10      58.542  51.599 125.169  1.00 60.65           O  
+ATOM    929  C3'  DT D  10      57.498  53.571 124.414  1.00 72.37           C  
+ATOM    930  O3'  DT D  10      58.486  54.555 124.607  1.00 80.96           O  
+ATOM    931  C2'  DT D  10      57.908  52.676 123.253  1.00 60.22           C  
+ATOM    932  C1'  DT D  10      59.093  52.025 123.944  1.00 51.57           C  
+ATOM    933  N1   DT D  10      59.653  50.866 123.219  1.00 51.65           N  
+ATOM    934  C2   DT D  10      61.026  50.722 123.279  1.00 49.69           C  
+ATOM    935  O2   DT D  10      61.751  51.487 123.901  1.00 48.24           O  
+ATOM    936  N3   DT D  10      61.523  49.643 122.590  1.00 37.80           N  
+ATOM    937  C4   DT D  10      60.795  48.735 121.840  1.00 40.04           C  
+ATOM    938  O4   DT D  10      61.373  47.823 121.257  1.00 39.34           O  
+ATOM    939  C5   DT D  10      59.371  48.954 121.821  1.00 47.91           C  
+ATOM    940  C7   DT D  10      58.529  48.002 121.032  1.00 48.41           C  
+ATOM    941  C6   DT D  10      58.861  49.991 122.503  1.00 50.38           C  
+ATOM    942  P    DA D  11      58.192  56.089 124.290  1.00 82.62           P  
+ATOM    943  OP1  DA D  11      58.319  56.786 125.588  1.00 71.98           O  
+ATOM    944  OP2  DA D  11      56.956  56.192 123.485  1.00 76.09           O  
+ATOM    945  O5'  DA D  11      59.460  56.445 123.386  1.00 81.19           O  
+ATOM    946  C5'  DA D  11      60.684  56.380 124.097  1.00 64.25           C  
+ATOM    947  C4'  DA D  11      61.866  56.133 123.185  1.00 54.53           C  
+ATOM    948  O4'  DA D  11      61.948  54.757 122.745  1.00 55.21           O  
+ATOM    949  C3'  DA D  11      61.900  56.999 121.938  1.00 57.47           C  
+ATOM    950  O3'  DA D  11      62.928  57.952 122.154  1.00 55.33           O  
+ATOM    951  C2'  DA D  11      62.211  56.025 120.799  1.00 59.67           C  
+ATOM    952  C1'  DA D  11      62.625  54.737 121.504  1.00 48.08           C  
+ATOM    953  N9   DA D  11      62.302  53.480 120.821  1.00 42.48           N  
+ATOM    954  C8   DA D  11      61.087  52.866 120.653  1.00 39.62           C  
+ATOM    955  N7   DA D  11      61.151  51.708 120.037  1.00 34.61           N  
+ATOM    956  C5   DA D  11      62.505  51.543 119.789  1.00 34.27           C  
+ATOM    957  C6   DA D  11      63.255  50.516 119.169  1.00 38.11           C  
+ATOM    958  N6   DA D  11      62.728  49.402 118.651  1.00 35.94           N  
+ATOM    959  N1   DA D  11      64.595  50.665 119.105  1.00 38.46           N  
+ATOM    960  C2   DA D  11      65.148  51.777 119.607  1.00 37.19           C  
+ATOM    961  N3   DA D  11      64.551  52.806 120.205  1.00 36.11           N  
+ATOM    962  C4   DA D  11      63.225  52.620 120.277  1.00 35.86           C  
+ATOM    963  P    DT D  12      63.377  59.042 121.078  1.00 52.78           P  
+ATOM    964  OP1  DT D  12      64.423  59.878 121.706  1.00 77.56           O  
+ATOM    965  OP2  DT D  12      62.167  59.688 120.522  1.00 71.01           O  
+ATOM    966  O5'  DT D  12      64.075  58.155 119.952  1.00 44.41           O  
+ATOM    967  C5'  DT D  12      65.485  58.064 120.000  1.00 45.72           C  
+ATOM    968  C4'  DT D  12      65.982  57.089 118.954  1.00 45.49           C  
+ATOM    969  O4'  DT D  12      65.087  55.957 118.832  1.00 42.50           O  
+ATOM    970  C3'  DT D  12      66.173  57.638 117.542  1.00 61.67           C  
+ATOM    971  O3'  DT D  12      67.553  57.556 117.227  1.00 65.91           O  
+ATOM    972  C2'  DT D  12      65.397  56.667 116.651  1.00 61.12           C  
+ATOM    973  C1'  DT D  12      65.314  55.433 117.542  1.00 50.89           C  
+ATOM    974  N1   DT D  12      64.218  54.491 117.186  1.00 50.13           N  
+ATOM    975  C2   DT D  12      64.602  53.344 116.525  1.00 48.44           C  
+ATOM    976  O2   DT D  12      65.759  53.088 116.226  1.00 45.77           O  
+ATOM    977  N3   DT D  12      63.573  52.493 116.215  1.00 47.48           N  
+ATOM    978  C4   DT D  12      62.233  52.685 116.457  1.00 42.61           C  
+ATOM    979  O4   DT D  12      61.459  51.783 116.143  1.00 41.63           O  
+ATOM    980  C5   DT D  12      61.893  53.913 117.146  1.00 39.82           C  
+ATOM    981  C7   DT D  12      60.468  54.182 117.497  1.00 40.29           C  
+ATOM    982  C6   DT D  12      62.888  54.744 117.481  1.00 43.45           C  
+ATOM    983  P    DA D  13      68.307  58.568 116.250  1.00 59.21           P  
+ATOM    984  OP1  DA D  13      69.194  59.368 117.122  1.00 76.31           O  
+ATOM    985  OP2  DA D  13      67.337  59.253 115.368  1.00 51.10           O  
+ATOM    986  O5'  DA D  13      69.180  57.542 115.385  1.00 49.69           O  
+ATOM    987  C5'  DA D  13      69.806  56.507 116.135  1.00 45.59           C  
+ATOM    988  C4'  DA D  13      70.415  55.400 115.294  1.00 48.85           C  
+ATOM    989  O4'  DA D  13      69.457  54.334 115.082  1.00 55.28           O  
+ATOM    990  C3'  DA D  13      70.962  55.745 113.919  1.00 52.35           C  
+ATOM    991  O3'  DA D  13      72.070  54.887 113.680  1.00 56.07           O  
+ATOM    992  C2'  DA D  13      69.793  55.415 112.992  1.00 61.21           C  
+ATOM    993  C1'  DA D  13      69.078  54.278 113.720  1.00 55.79           C  
+ATOM    994  N9   DA D  13      67.615  54.312 113.674  1.00 50.48           N  
+ATOM    995  C8   DA D  13      66.724  55.231 114.162  1.00 49.80           C  
+ATOM    996  N7   DA D  13      65.465  54.901 113.972  1.00 45.40           N  
+ATOM    997  C5   DA D  13      65.538  53.674 113.331  1.00 46.15           C  
+ATOM    998  C6   DA D  13      64.555  52.787 112.847  1.00 42.11           C  
+ATOM    999  N6   DA D  13      63.240  53.015 112.932  1.00 37.68           N  
+ATOM   1000  N1   DA D  13      64.974  51.644 112.269  1.00 44.52           N  
+ATOM   1001  C2   DA D  13      66.289  51.407 112.172  1.00 48.29           C  
+ATOM   1002  N3   DA D  13      67.306  52.166 112.577  1.00 48.82           N  
+ATOM   1003  C4   DA D  13      66.856  53.293 113.152  1.00 47.67           C  
+ATOM   1004  P    DG D  14      72.721  54.817 112.223  1.00 65.99           P  
+ATOM   1005  OP1  DG D  14      74.146  54.438 112.354  1.00 64.08           O  
+ATOM   1006  OP2  DG D  14      72.321  56.038 111.487  1.00 61.69           O  
+ATOM   1007  O5'  DG D  14      71.955  53.563 111.607  1.00 80.76           O  
+ATOM   1008  C5'  DG D  14      72.520  52.278 111.767  1.00 72.19           C  
+ATOM   1009  C4'  DG D  14      71.732  51.334 110.888  1.00 67.66           C  
+ATOM   1010  O4'  DG D  14      70.345  51.745 110.920  1.00 65.87           O  
+ATOM   1011  C3'  DG D  14      72.134  51.358 109.419  1.00 65.75           C  
+ATOM   1012  O3'  DG D  14      72.164  50.019 108.958  1.00 79.43           O  
+ATOM   1013  C2'  DG D  14      71.031  52.173 108.743  1.00 50.86           C  
+ATOM   1014  C1'  DG D  14      69.848  51.736 109.600  1.00 57.35           C  
+ATOM   1015  N9   DG D  14      68.618  52.526 109.577  1.00 47.12           N  
+ATOM   1016  C8   DG D  14      68.412  53.841 109.906  1.00 45.25           C  
+ATOM   1017  N7   DG D  14      67.165  54.211 109.825  1.00 43.95           N  
+ATOM   1018  C5   DG D  14      66.488  53.061 109.439  1.00 45.47           C  
+ATOM   1019  C6   DG D  14      65.104  52.851 109.204  1.00 39.04           C  
+ATOM   1020  O6   DG D  14      64.175  53.667 109.285  1.00 37.96           O  
+ATOM   1021  N1   DG D  14      64.826  51.537 108.832  1.00 35.78           N  
+ATOM   1022  C2   DG D  14      65.783  50.555 108.728  1.00 54.19           C  
+ATOM   1023  N2   DG D  14      65.330  49.345 108.357  1.00 68.50           N  
+ATOM   1024  N3   DG D  14      67.084  50.730 108.943  1.00 52.29           N  
+ATOM   1025  C4   DG D  14      67.369  52.009 109.305  1.00 50.44           C  
+ATOM   1026  P    DC D  15      73.272  49.588 107.895  1.00 87.01           P  
+ATOM   1027  OP1  DC D  15      73.068  48.158 107.572  1.00 96.13           O  
+ATOM   1028  OP2  DC D  15      74.584  50.047 108.402  1.00 99.69           O  
+ATOM   1029  O5'  DC D  15      72.870  50.466 106.619  1.00 89.73           O  
+ATOM   1030  C5'  DC D  15      72.256  49.865 105.484  1.00 93.43           C  
+ATOM   1031  C4'  DC D  15      70.918  49.240 105.839  1.00 82.66           C  
+ATOM   1032  O4'  DC D  15      70.043  50.228 106.434  1.00 76.78           O  
+ATOM   1033  C3'  DC D  15      70.165  48.660 104.651  1.00 77.91           C  
+ATOM   1034  O3'  DC D  15      69.843  47.298 104.901  1.00 79.25           O  
+ATOM   1035  C2'  DC D  15      68.934  49.550 104.494  1.00 80.12           C  
+ATOM   1036  C1'  DC D  15      68.741  50.089 105.905  1.00 66.05           C  
+ATOM   1037  N1   DC D  15      68.067  51.420 106.005  1.00 69.64           N  
+ATOM   1038  C2   DC D  15      66.790  51.605 105.461  1.00 68.56           C  
+ATOM   1039  O2   DC D  15      66.226  50.669 104.881  1.00 68.80           O  
+ATOM   1040  N3   DC D  15      66.197  52.820 105.590  1.00 64.97           N  
+ATOM   1041  C4   DC D  15      66.829  53.812 106.221  1.00 66.98           C  
+ATOM   1042  N4   DC D  15      66.207  54.994 106.317  1.00 63.92           N  
+ATOM   1043  C5   DC D  15      68.125  53.635 106.790  1.00 69.89           C  
+ATOM   1044  C6   DC D  15      68.702  52.436 106.655  1.00 70.64           C  
+ATOM   1045  P  A DA D  16      70.318  46.211 103.825  0.73 90.84           P  
+ATOM   1046  P  B DA D  16      70.290  46.197 103.902  0.27 86.16           P  
+ATOM   1047  OP1A DA D  16      70.494  44.910 104.513  0.73100.00           O  
+ATOM   1048  OP1B DA D  16      70.516  44.933 104.639  0.27 89.93           O  
+ATOM   1049  OP2A DA D  16      71.413  46.793 103.016  0.73 88.69           O  
+ATOM   1050  OP2B DA D  16      71.379  46.801 103.103  0.27 83.87           O  
+ATOM   1051  O5'A DA D  16      69.004  46.112 102.926  0.73 91.41           O  
+ATOM   1052  O5'B DA D  16      69.030  45.984 102.941  0.27 86.15           O  
+ATOM   1053  C5'A DA D  16      67.724  46.090 103.547  0.73 92.80           C  
+ATOM   1054  C5'B DA D  16      67.763  45.430 103.293  0.27 86.01           C  
+ATOM   1055  C4'A DA D  16      66.715  45.604 102.527  0.73 97.79           C  
+ATOM   1056  C4'B DA D  16      66.834  45.452 102.088  0.27 87.56           C  
+ATOM   1057  O4'A DA D  16      65.789  46.674 102.213  0.73 96.39           O  
+ATOM   1058  O4'B DA D  16      66.026  46.659 102.157  0.27 84.74           O  
+ATOM   1059  C3'A DA D  16      67.379  45.238 101.208  0.73100.00           C  
+ATOM   1060  C3'B DA D  16      67.547  45.545 100.739  0.27 87.73           C  
+ATOM   1061  O3'A DA D  16      66.713  44.206 100.471  0.73100.00           O  
+ATOM   1062  O3'B DA D  16      66.676  45.208  99.659  0.27 86.88           O  
+ATOM   1063  C2'A DA D  16      67.405  46.579 100.477  0.73 89.88           C  
+ATOM   1064  C2'B DA D  16      67.775  47.043 100.702  0.27 78.16           C  
+ATOM   1065  C1'A DA D  16      66.208  47.344 101.042  0.73 82.70           C  
+ATOM   1066  C1'B DA D  16      66.365  47.480 101.058  0.27 73.12           C  
+ATOM   1067  N9 A DA D  16      66.531  48.716 101.418  0.73 70.87           N  
+ATOM   1068  N9 B DA D  16      66.517  48.855 101.485  0.27 63.66           N  
+ATOM   1069  C8 A DA D  16      67.769  49.254 101.614  0.73 71.22           C  
+ATOM   1070  C8 B DA D  16      67.732  49.405 101.781  0.27 63.13           C  
+ATOM   1071  N7 A DA D  16      67.749  50.521 101.959  0.73 69.84           N  
+ATOM   1072  N7 B DA D  16      67.687  50.666 102.114  0.27 61.54           N  
+ATOM   1073  C5 A DA D  16      66.402  50.835 101.993  0.73 71.29           C  
+ATOM   1074  C5 B DA D  16      66.341  50.966 102.019  0.27 62.98           C  
+ATOM   1075  C6 A DA D  16      65.717  52.030 102.282  0.73 70.60           C  
+ATOM   1076  C6 B DA D  16      65.632  52.158 102.254  0.27 61.90           C  
+ATOM   1077  N6 A DA D  16      66.339  53.170 102.628  0.73 68.49           N  
+ATOM   1078  N6 B DA D  16      66.214  53.297 102.638  0.27 60.31           N  
+ATOM   1079  N1 A DA D  16      64.369  52.021 102.225  0.73 70.38           N  
+ATOM   1080  N1 B DA D  16      64.295  52.134 102.064  0.27 61.54           N  
+ATOM   1081  C2 A DA D  16      63.767  50.876 101.880  0.73 70.99           C  
+ATOM   1082  C2 B DA D  16      63.718  50.993 101.683  0.27 62.12           C  
+ATOM   1083  N3 A DA D  16      64.300  49.693 101.578  0.73 70.59           N  
+ATOM   1084  N3 B DA D  16      64.274  49.808 101.420  0.27 61.91           N  
+ATOM   1085  C4 A DA D  16      65.638  49.733 101.653  0.73 70.26           C  
+ATOM   1086  C4 B DA D  16      65.601  49.868 101.623  0.27 62.12           C  
+ATOM   1087  P  A DT D  17      65.819  43.020 101.072  0.73100.00           P  
+ATOM   1088  P  B DT D  17      66.793  45.708  98.135  0.27 85.00           P  
+ATOM   1089  OP1A DT D  17      65.999  42.920 102.539  0.73 99.77           O  
+ATOM   1090  OP1B DT D  17      67.034  44.497  97.323  0.27 84.20           O  
+ATOM   1091  OP2A DT D  17      66.027  41.811 100.249  0.73100.00           O  
+ATOM   1092  OP2B DT D  17      67.708  46.858  97.944  0.27 80.44           O  
+ATOM   1093  O5'A DT D  17      64.335  43.514 100.776  0.73 93.58           O  
+ATOM   1094  O5'B DT D  17      65.299  46.189  97.809  0.27 83.29           O  
+ATOM   1095  C5'A DT D  17      63.424  42.478 100.460  0.73 92.55           C  
+ATOM   1096  C5'B DT D  17      64.756  47.370  98.395  0.27 74.19           C  
+ATOM   1097  C4'A DT D  17      62.087  43.150 100.265  0.73 92.78           C  
+ATOM   1098  C4'B DT D  17      63.239  47.449  98.315  0.27 61.65           C  
+ATOM   1099  O4'A DT D  17      62.387  44.568 100.195  0.73 90.86           O  
+ATOM   1100  O4'B DT D  17      62.860  48.714  98.911  0.27 55.07           O  
+ATOM   1101  C3'A DT D  17      61.390  42.835  98.950  0.73 92.55           C  
+ATOM   1102  C3'B DT D  17      62.660  47.601  96.915  0.27 63.71           C  
+ATOM   1103  O3'A DT D  17      60.042  43.228  99.082  0.73 97.47           O  
+ATOM   1104  O3'B DT D  17      61.248  47.780  97.032  0.27 76.31           O  
+ATOM   1105  C2'A DT D  17      62.093  43.789  97.998  0.73 86.25           C  
+ATOM   1106  C2'B DT D  17      63.256  48.967  96.611  0.27 43.90           C  
+ATOM   1107  C1'A DT D  17      62.160  45.031  98.877  0.73 88.62           C  
+ATOM   1108  C1'B DT D  17      62.799  49.682  97.879  0.27 35.12           C  
+ATOM   1109  N1 A DT D  17      63.232  45.956  98.412  0.73 88.56           N  
+ATOM   1110  N1 B DT D  17      63.653  50.843  98.240  0.27 32.02           N  
+ATOM   1111  C2 A DT D  17      62.817  47.211  98.026  0.73 87.28           C  
+ATOM   1112  C2 B DT D  17      63.057  52.083  98.302  0.27 30.80           C  
+ATOM   1113  O2 A DT D  17      61.668  47.597  98.127  0.73 86.40           O  
+ATOM   1114  O2 B DT D  17      61.871  52.270  98.161  0.27 30.71           O  
+ATOM   1115  N3 A DT D  17      63.812  48.029  97.547  0.73 85.36           N  
+ATOM   1116  N3 B DT D  17      63.914  53.107  98.615  0.27 26.41           N  
+ATOM   1117  C4 A DT D  17      65.148  47.714  97.386  0.73 85.64           C  
+ATOM   1118  C4 B DT D  17      65.270  53.015  98.857  0.27 26.27           C  
+ATOM   1119  O4 A DT D  17      65.925  48.554  96.948  0.73 84.65           O  
+ATOM   1120  O4 B DT D  17      65.901  54.029  99.109  0.27 25.54           O  
+ATOM   1121  C5 A DT D  17      65.501  46.368  97.762  0.73 86.38           C  
+ATOM   1122  C5 B DT D  17      65.825  51.686  98.735  0.27 26.49           C  
+ATOM   1123  C7 A DT D  17      66.913  45.889  97.613  0.73 84.44           C  
+ATOM   1124  C7 B DT D  17      67.297  51.489  98.955  0.27 27.15           C  
+ATOM   1125  C6 A DT D  17      64.543  45.561  98.238  0.73 88.00           C  
+ATOM   1126  C6 B DT D  17      65.003  50.684  98.468  0.27 27.18           C  
+ATOM   1127  P  A DA D  18      58.911  42.502  98.224  0.73100.00           P  
+ATOM   1128  P  B DA D  18      60.126  46.793  96.455  0.27 79.31           P  
+ATOM   1129  OP1A DA D  18      58.423  41.350  99.012  0.73100.00           O  
+ATOM   1130  OP1B DA D  18      59.428  46.197  97.616  0.27 78.36           O  
+ATOM   1131  OP2A DA D  18      59.441  42.300  96.854  0.73 98.90           O  
+ATOM   1132  OP2B DA D  18      60.761  45.913  95.448  0.27 82.38           O  
+ATOM   1133  O5'A DA D  18      57.750  43.604  98.176  0.73 97.51           O  
+ATOM   1134  O5'B DA D  18      59.087  47.767  95.721  0.27 81.25           O  
+ATOM   1135  C5'A DA D  18      57.546  44.125  96.875  0.73 90.84           C  
+ATOM   1136  C5'B DA D  18      58.009  48.416  96.402  0.27 79.23           C  
+ATOM   1137  C4'A DA D  18      56.645  45.338  96.761  0.73 82.18           C  
+ATOM   1138  C4'B DA D  18      57.016  49.014  95.418  0.27 76.48           C  
+ATOM   1139  O4'A DA D  18      57.478  46.481  96.451  0.73 80.24           O  
+ATOM   1140  O4'B DA D  18      57.701  50.031  94.636  0.27 72.33           O  
+ATOM   1141  C3'A DA D  18      55.844  45.186  95.481  0.73 83.84           C  
+ATOM   1142  C3'B DA D  18      56.441  47.984  94.451  0.27 81.24           C  
+ATOM   1143  O3'A DA D  18      54.808  46.144  95.338  0.73 96.43           O  
+ATOM   1144  O3'B DA D  18      55.007  47.938  94.427  0.27 96.48           O  
+ATOM   1145  C2'A DA D  18      56.951  45.357  94.444  0.73 76.72           C  
+ATOM   1146  C2'B DA D  18      57.036  48.362  93.100  0.27 63.25           C  
+ATOM   1147  C1'A DA D  18      57.846  46.417  95.084  0.73 77.32           C  
+ATOM   1148  C1'B DA D  18      57.757  49.691  93.266  0.27 60.46           C  
+ATOM   1149  N9 A DA D  18      59.285  46.164  94.989  0.73 73.42           N  
+ATOM   1150  N9 B DA D  18      59.140  49.563  92.815  0.27 54.08           N  
+ATOM   1151  C8 A DA D  18      60.022  45.175  95.582  0.73 73.18           C  
+ATOM   1152  C8 B DA D  18      60.097  48.721  93.312  0.27 54.44           C  
+ATOM   1153  N7 A DA D  18      61.304  45.216  95.316  0.73 74.42           N  
+ATOM   1154  N7 B DA D  18      61.254  48.773  92.692  0.27 52.56           N  
+ATOM   1155  C5 A DA D  18      61.428  46.321  94.492  0.73 74.63           C  
+ATOM   1156  C5 B DA D  18      61.050  49.755  91.725  0.27 48.99           C  
+ATOM   1157  C6 A DA D  18      62.544  46.905  93.863  0.73 72.31           C  
+ATOM   1158  C6 B DA D  18      61.848  50.236  90.689  0.27 39.10           C  
+ATOM   1159  N6 A DA D  18      63.788  46.429  93.992  0.73 70.51           N  
+ATOM   1160  N6 B DA D  18      63.134  49.884  90.559  0.27 32.64           N  
+ATOM   1161  N1 A DA D  18      62.327  47.999  93.104  0.73 71.95           N  
+ATOM   1162  N1 B DA D  18      61.341  51.156  89.864  0.27 40.98           N  
+ATOM   1163  C2 A DA D  18      61.078  48.464  92.993  0.73 72.13           C  
+ATOM   1164  C2 B DA D  18      60.067  51.546  90.020  0.27 44.70           C  
+ATOM   1165  N3 A DA D  18      59.953  48.001  93.536  0.73 71.91           N  
+ATOM   1166  N3 B DA D  18      59.191  51.120  90.936  0.27 46.20           N  
+ATOM   1167  C4 A DA D  18      60.197  46.915  94.283  0.73 72.55           C  
+ATOM   1168  C4 B DA D  18      59.729  50.207  91.751  0.27 48.19           C  
+ATOM   1169  P  A DC D  19      53.799  45.912  94.116  0.73100.00           P  
+ATOM   1170  P  B DC D  19      54.151  46.586  94.269  0.27 99.36           P  
+ATOM   1171  OP1A DC D  19      52.424  46.168  94.601  0.73100.00           O  
+ATOM   1172  OP1B DC D  19      52.775  46.868  94.739  0.27100.00           O  
+ATOM   1173  OP2A DC D  19      54.121  44.600  93.512  0.73100.00           O  
+ATOM   1174  OP2B DC D  19      54.903  45.464  94.876  0.27 94.77           O  
+ATOM   1175  O5'A DC D  19      54.207  47.069  93.083  0.73 95.76           O  
+ATOM   1176  O5'B DC D  19      54.063  46.332  92.690  0.27 94.84           O  
+ATOM   1177  C5'A DC D  19      55.238  46.851  92.124  0.73 93.90           C  
+ATOM   1178  C5'B DC D  19      55.198  46.395  91.839  0.27 87.42           C  
+ATOM   1179  C4'A DC D  19      55.037  47.755  90.922  0.73 93.60           C  
+ATOM   1180  C4'B DC D  19      54.978  47.515  90.841  0.27 80.90           C  
+ATOM   1181  O4'A DC D  19      56.295  48.334  90.495  0.73 99.35           O  
+ATOM   1182  O4'B DC D  19      56.188  48.215  90.455  0.27 82.45           O  
+ATOM   1183  C3'A DC D  19      54.443  47.094  89.690  0.73 78.37           C  
+ATOM   1184  C3'B DC D  19      54.393  47.032  89.531  0.27 70.48           C  
+ATOM   1185  O3'A DC D  19      53.584  48.046  89.074  0.73 58.58           O  
+ATOM   1186  O3'B DC D  19      53.608  48.085  89.003  0.27 57.09           O  
+ATOM   1187  C2'A DC D  19      55.677  46.760  88.853  0.73 79.35           C  
+ATOM   1188  C2'B DC D  19      55.649  46.725  88.717  0.27 71.84           C  
+ATOM   1189  C1'A DC D  19      56.647  47.886  89.201  0.73 78.70           C  
+ATOM   1190  C1'B DC D  19      56.604  47.828  89.162  0.27 71.66           C  
+ATOM   1191  N1 A DC D  19      58.087  47.505  89.279  0.73 77.27           N  
+ATOM   1192  N1 B DC D  19      58.050  47.465  89.269  0.27 71.20           N  
+ATOM   1193  C2 A DC D  19      58.977  48.083  88.369  0.73 77.13           C  
+ATOM   1194  C2 B DC D  19      58.935  48.144  88.425  0.27 70.52           C  
+ATOM   1195  O2 A DC D  19      58.535  48.858  87.512  0.73 74.67           O  
+ATOM   1196  O2 B DC D  19      58.480  48.970  87.624  0.27 68.76           O  
+ATOM   1197  N3 A DC D  19      60.293  47.761  88.450  0.73 78.68           N  
+ATOM   1198  N3 B DC D  19      60.262  47.871  88.495  0.27 71.57           N  
+ATOM   1199  C4 A DC D  19      60.720  46.920  89.393  0.73 78.59           C  
+ATOM   1200  C4 B DC D  19      60.716  46.973  89.371  0.27 71.15           C  
+ATOM   1201  N4 A DC D  19      62.026  46.638  89.433  0.73 81.77           N  
+ATOM   1202  N4 B DC D  19      62.032  46.737  89.403  0.27 71.68           N  
+ATOM   1203  C5 A DC D  19      59.827  46.332  90.338  0.73 73.64           C  
+ATOM   1204  C5 B DC D  19      59.834  46.278  90.250  0.27 68.62           C  
+ATOM   1205  C6 A DC D  19      58.534  46.657  90.249  0.73 73.81           C  
+ATOM   1206  C6 B DC D  19      58.528  46.559  90.172  0.27 69.31           C  
+ATOM   1207  P    DA D  20      52.859  47.753  87.681  1.00 57.03           P  
+ATOM   1208  OP1  DA D  20      51.973  48.897  87.378  1.00 64.18           O  
+ATOM   1209  OP2  DA D  20      52.325  46.374  87.734  1.00 60.56           O  
+ATOM   1210  O5'  DA D  20      54.083  47.789  86.655  1.00 77.11           O  
+ATOM   1211  C5'  DA D  20      54.227  48.772  85.646  1.00 68.39           C  
+ATOM   1212  C4'  DA D  20      55.277  48.261  84.681  1.00 42.40           C  
+ATOM   1213  O4'  DA D  20      56.343  47.649  85.450  1.00 50.30           O  
+ATOM   1214  C3'  DA D  20      54.748  47.155  83.780  1.00 33.58           C  
+ATOM   1215  O3'  DA D  20      54.950  47.483  82.428  1.00 37.70           O  
+ATOM   1216  C2'  DA D  20      55.519  45.901  84.165  1.00 26.84           C  
+ATOM   1217  C1'  DA D  20      56.783  46.499  84.760  1.00 40.17           C  
+ATOM   1218  N9   DA D  20      57.462  45.592  85.684  1.00 40.95           N  
+ATOM   1219  C8   DA D  20      56.923  44.668  86.532  1.00 42.73           C  
+ATOM   1220  N7   DA D  20      57.813  44.001  87.227  1.00 40.61           N  
+ATOM   1221  C5   DA D  20      59.024  44.515  86.797  1.00 42.86           C  
+ATOM   1222  C6   DA D  20      60.358  44.227  87.146  1.00 43.77           C  
+ATOM   1223  N6   DA D  20      60.694  43.310  88.059  1.00 46.90           N  
+ATOM   1224  N1   DA D  20      61.334  44.926  86.529  1.00 40.24           N  
+ATOM   1225  C2   DA D  20      60.990  45.854  85.627  1.00 42.13           C  
+ATOM   1226  N3   DA D  20      59.775  46.209  85.211  1.00 42.99           N  
+ATOM   1227  C4   DA D  20      58.826  45.496  85.845  1.00 42.43           C  
+ATOM   1228  P    DT D  21      54.076  46.593  81.441  1.00 54.72           P  
+ATOM   1229  OP1  DT D  21      53.552  47.491  80.390  1.00 58.54           O  
+ATOM   1230  OP2  DT D  21      53.184  45.748  82.262  1.00 85.71           O  
+ATOM   1231  O5'  DT D  21      55.149  45.629  80.770  1.00 69.67           O  
+ATOM   1232  C5'  DT D  21      56.143  46.379  80.120  1.00 83.05           C  
+ATOM   1233  C4'  DT D  21      57.497  45.798  80.437  1.00 65.88           C  
+ATOM   1234  O4'  DT D  21      57.508  45.063  81.676  1.00 60.56           O  
+ATOM   1235  C3'  DT D  21      57.954  44.786  79.407  1.00 50.22           C  
+ATOM   1236  O3'  DT D  21      58.672  45.578  78.486  1.00 44.55           O  
+ATOM   1237  C2'  DT D  21      58.854  43.864  80.232  1.00 54.50           C  
+ATOM   1238  C1'  DT D  21      58.792  44.495  81.622  1.00 49.09           C  
+ATOM   1239  N1   DT D  21      58.953  43.560  82.752  1.00 48.50           N  
+ATOM   1240  C2   DT D  21      60.231  43.489  83.246  1.00 47.24           C  
+ATOM   1241  O2   DT D  21      61.132  44.160  82.780  1.00 46.09           O  
+ATOM   1242  N3   DT D  21      60.403  42.621  84.294  1.00 46.09           N  
+ATOM   1243  C4   DT D  21      59.428  41.836  84.864  1.00 50.33           C  
+ATOM   1244  O4   DT D  21      59.801  41.105  85.761  1.00 49.47           O  
+ATOM   1245  C5   DT D  21      58.107  41.951  84.297  1.00 52.91           C  
+ATOM   1246  C7   DT D  21      56.951  41.141  84.817  1.00 53.21           C  
+ATOM   1247  C6   DT D  21      57.927  42.814  83.290  1.00 48.39           C  
+ATOM   1248  P    DT D  22      58.861  45.219  76.946  1.00 43.21           P  
+ATOM   1249  OP1  DT D  22      58.694  46.478  76.193  1.00 43.61           O  
+ATOM   1250  OP2  DT D  22      58.034  44.043  76.604  1.00 40.59           O  
+ATOM   1251  O5'  DT D  22      60.409  44.808  76.889  1.00 62.06           O  
+ATOM   1252  C5'  DT D  22      61.316  45.304  77.872  1.00 53.31           C  
+ATOM   1253  C4'  DT D  22      62.586  44.478  77.917  1.00 41.83           C  
+ATOM   1254  O4'  DT D  22      62.650  43.733  79.158  1.00 36.62           O  
+ATOM   1255  C3'  DT D  22      62.743  43.465  76.793  1.00 44.13           C  
+ATOM   1256  O3'  DT D  22      64.120  43.402  76.469  1.00 45.84           O  
+ATOM   1257  C2'  DT D  22      62.270  42.171  77.440  1.00 36.28           C  
+ATOM   1258  C1'  DT D  22      62.820  42.369  78.845  1.00 36.03           C  
+ATOM   1259  N1   DT D  22      62.084  41.602  79.845  1.00 37.39           N  
+ATOM   1260  C2   DT D  22      62.882  41.143  80.851  1.00 36.50           C  
+ATOM   1261  O2   DT D  22      64.066  41.399  80.886  1.00 36.35           O  
+ATOM   1262  N3   DT D  22      62.237  40.404  81.805  1.00 33.16           N  
+ATOM   1263  C4   DT D  22      60.886  40.111  81.840  1.00 34.43           C  
+ATOM   1264  O4   DT D  22      60.447  39.434  82.758  1.00 34.29           O  
+ATOM   1265  C5   DT D  22      60.104  40.615  80.741  1.00 38.11           C  
+ATOM   1266  C7   DT D  22      58.639  40.318  80.687  1.00 36.07           C  
+ATOM   1267  C6   DT D  22      60.734  41.322  79.798  1.00 41.34           C  
+ATOM   1268  P    DA D  23      64.603  42.748  75.092  1.00 43.91           P  
+ATOM   1269  OP1  DA D  23      65.391  43.783  74.387  1.00 57.88           O  
+ATOM   1270  OP2  DA D  23      63.446  42.115  74.421  1.00 49.25           O  
+ATOM   1271  O5'  DA D  23      65.566  41.577  75.600  1.00 44.30           O  
+ATOM   1272  C5'  DA D  23      66.715  41.927  76.338  1.00 42.73           C  
+ATOM   1273  C4'  DA D  23      67.048  40.834  77.335  1.00 47.91           C  
+ATOM   1274  O4'  DA D  23      65.917  40.588  78.196  1.00 50.55           O  
+ATOM   1275  C3'  DA D  23      67.373  39.461  76.769  1.00 51.26           C  
+ATOM   1276  O3'  DA D  23      68.761  39.408  76.521  1.00 47.29           O  
+ATOM   1277  C2'  DA D  23      67.057  38.531  77.938  1.00 69.83           C  
+ATOM   1278  C1'  DA D  23      66.177  39.370  78.861  1.00 58.51           C  
+ATOM   1279  N9   DA D  23      64.892  38.737  79.129  1.00 39.80           N  
+ATOM   1280  C8   DA D  23      63.699  38.884  78.477  1.00 36.51           C  
+ATOM   1281  N7   DA D  23      62.748  38.128  78.972  1.00 40.29           N  
+ATOM   1282  C5   DA D  23      63.364  37.446  80.007  1.00 32.34           C  
+ATOM   1283  C6   DA D  23      62.885  36.507  80.932  1.00 33.52           C  
+ATOM   1284  N6   DA D  23      61.621  36.072  80.959  1.00 36.86           N  
+ATOM   1285  N1   DA D  23      63.778  36.023  81.821  1.00 34.90           N  
+ATOM   1286  C2   DA D  23      65.051  36.450  81.788  1.00 33.73           C  
+ATOM   1287  N3   DA D  23      65.613  37.341  80.978  1.00 31.96           N  
+ATOM   1288  C4   DA D  23      64.695  37.805  80.115  1.00 32.26           C  
+ATOM   1289  P    DT D  24      69.507  38.147  75.885  1.00 40.23           P  
+ATOM   1290  OP1  DT D  24      70.775  38.718  75.385  1.00 48.96           O  
+ATOM   1291  OP2  DT D  24      68.598  37.421  74.971  1.00 38.02           O  
+ATOM   1292  O5'  DT D  24      69.825  37.182  77.120  1.00 42.25           O  
+ATOM   1293  C5'  DT D  24      70.743  37.545  78.136  1.00 28.40           C  
+ATOM   1294  C4'  DT D  24      70.667  36.479  79.210  1.00 32.33           C  
+ATOM   1295  O4'  DT D  24      69.277  36.303  79.592  1.00 39.10           O  
+ATOM   1296  C3'  DT D  24      71.137  35.090  78.793  1.00 34.87           C  
+ATOM   1297  O3'  DT D  24      71.762  34.508  79.926  1.00 29.80           O  
+ATOM   1298  C2'  DT D  24      69.830  34.366  78.486  1.00 32.10           C  
+ATOM   1299  C1'  DT D  24      68.948  34.930  79.591  1.00 31.71           C  
+ATOM   1300  N1   DT D  24      67.490  34.770  79.300  1.00 31.48           N  
+ATOM   1301  C2   DT D  24      66.767  33.896  80.082  1.00 32.50           C  
+ATOM   1302  O2   DT D  24      67.259  33.306  81.026  1.00 33.95           O  
+ATOM   1303  N3   DT D  24      65.452  33.745  79.731  1.00 33.06           N  
+ATOM   1304  C4   DT D  24      64.808  34.383  78.686  1.00 35.36           C  
+ATOM   1305  O4   DT D  24      63.612  34.137  78.530  1.00 34.16           O  
+ATOM   1306  C5   DT D  24      65.641  35.255  77.872  1.00 29.97           C  
+ATOM   1307  C7   DT D  24      65.186  36.030  76.665  1.00 24.29           C  
+ATOM   1308  C6   DT D  24      66.923  35.411  78.217  1.00 28.90           C  
+ATOM   1309  P    DA D  25      72.518  33.099  79.998  1.00 34.37           P  
+ATOM   1310  OP1  DA D  25      73.553  33.268  81.040  1.00 40.50           O  
+ATOM   1311  OP2  DA D  25      72.891  32.613  78.654  1.00 40.45           O  
+ATOM   1312  O5'  DA D  25      71.390  32.108  80.539  1.00 36.01           O  
+ATOM   1313  C5'  DA D  25      71.076  32.116  81.918  1.00 33.43           C  
+ATOM   1314  C4'  DA D  25      70.821  30.696  82.377  1.00 36.12           C  
+ATOM   1315  O4'  DA D  25      69.453  30.337  82.061  1.00 41.08           O  
+ATOM   1316  C3'  DA D  25      71.665  29.639  81.682  1.00 33.90           C  
+ATOM   1317  O3'  DA D  25      71.876  28.538  82.549  1.00 35.36           O  
+ATOM   1318  C2'  DA D  25      70.789  29.239  80.499  1.00 38.73           C  
+ATOM   1319  C1'  DA D  25      69.392  29.295  81.106  1.00 35.35           C  
+ATOM   1320  N9   DA D  25      68.370  29.751  80.172  1.00 27.36           N  
+ATOM   1321  C8   DA D  25      68.507  30.753  79.253  1.00 26.18           C  
+ATOM   1322  N7   DA D  25      67.428  30.988  78.547  1.00 26.25           N  
+ATOM   1323  C5   DA D  25      66.505  30.092  79.065  1.00 29.09           C  
+ATOM   1324  C6   DA D  25      65.149  29.857  78.757  1.00 31.85           C  
+ATOM   1325  N6   DA D  25      64.514  30.554  77.805  1.00 33.97           N  
+ATOM   1326  N1   DA D  25      64.494  28.888  79.437  1.00 28.70           N  
+ATOM   1327  C2   DA D  25      65.156  28.215  80.384  1.00 29.12           C  
+ATOM   1328  N3   DA D  25      66.427  28.360  80.771  1.00 29.93           N  
+ATOM   1329  C4   DA D  25      67.062  29.322  80.069  1.00 29.83           C  
+ATOM   1330  P    DC D  26      72.785  27.359  81.973  1.00 35.58           P  
+ATOM   1331  OP1  DC D  26      73.425  26.661  83.110  1.00 32.78           O  
+ATOM   1332  OP2  DC D  26      73.581  27.925  80.858  1.00 50.69           O  
+ATOM   1333  O5'  DC D  26      71.744  26.325  81.351  1.00 33.79           O  
+ATOM   1334  C5'  DC D  26      71.036  25.549  82.289  1.00 36.37           C  
+ATOM   1335  C4'  DC D  26      70.082  24.669  81.518  1.00 48.58           C  
+ATOM   1336  O4'  DC D  26      69.158  25.503  80.772  1.00 48.05           O  
+ATOM   1337  C3'  DC D  26      70.794  23.794  80.495  1.00 51.38           C  
+ATOM   1338  O3'  DC D  26      70.285  22.470  80.601  1.00 50.15           O  
+ATOM   1339  C2'  DC D  26      70.452  24.473  79.169  1.00 47.71           C  
+ATOM   1340  C1'  DC D  26      69.036  24.950  79.481  1.00 38.83           C  
+ATOM   1341  N1   DC D  26      68.438  25.963  78.557  1.00 31.29           N  
+ATOM   1342  C2   DC D  26      67.058  25.895  78.329  1.00 32.20           C  
+ATOM   1343  O2   DC D  26      66.385  25.013  78.881  1.00 38.40           O  
+ATOM   1344  N3   DC D  26      66.486  26.804  77.500  1.00 28.06           N  
+ATOM   1345  C4   DC D  26      67.218  27.758  76.929  1.00 18.49           C  
+ATOM   1346  N4   DC D  26      66.590  28.621  76.119  1.00 18.84           N  
+ATOM   1347  C5   DC D  26      68.620  27.850  77.153  1.00 16.22           C  
+ATOM   1348  C6   DC D  26      69.177  26.941  77.962  1.00 15.07           C  
+ATOM   1349  P    DG D  27      71.237  21.247  80.220  1.00 50.23           P  
+ATOM   1350  OP1  DG D  27      72.094  20.922  81.381  1.00 56.98           O  
+ATOM   1351  OP2  DG D  27      71.850  21.522  78.903  1.00 51.62           O  
+ATOM   1352  O5'  DG D  27      70.180  20.066  80.049  1.00 53.91           O  
+ATOM   1353  C5'  DG D  27      69.076  20.044  80.927  1.00 42.52           C  
+ATOM   1354  C4'  DG D  27      67.841  19.651  80.148  1.00 43.21           C  
+ATOM   1355  O4'  DG D  27      67.421  20.789  79.361  1.00 50.29           O  
+ATOM   1356  C3'  DG D  27      68.014  18.498  79.168  1.00 48.66           C  
+ATOM   1357  O3'  DG D  27      66.992  17.543  79.433  1.00 75.62           O  
+ATOM   1358  C2'  DG D  27      67.887  19.129  77.778  1.00 31.55           C  
+ATOM   1359  C1'  DG D  27      67.072  20.388  78.053  1.00 35.19           C  
+ATOM   1360  N9   DG D  27      67.378  21.546  77.220  1.00 34.75           N  
+ATOM   1361  C8   DG D  27      68.590  22.173  77.064  1.00 31.83           C  
+ATOM   1362  N7   DG D  27      68.532  23.237  76.315  1.00 35.68           N  
+ATOM   1363  C5   DG D  27      67.190  23.340  75.978  1.00 30.14           C  
+ATOM   1364  C6   DG D  27      66.537  24.293  75.165  1.00 30.65           C  
+ATOM   1365  O6   DG D  27      67.033  25.270  74.586  1.00 33.84           O  
+ATOM   1366  N1   DG D  27      65.174  24.048  75.062  1.00 31.89           N  
+ATOM   1367  C2   DG D  27      64.526  22.996  75.662  1.00 39.46           C  
+ATOM   1368  N2   DG D  27      63.205  22.934  75.443  1.00 42.01           N  
+ATOM   1369  N3   DG D  27      65.125  22.091  76.431  1.00 40.54           N  
+ATOM   1370  C4   DG D  27      66.460  22.318  76.539  1.00 39.41           C  
+ATOM   1371  P    DA D  28      66.916  16.110  78.727  1.00 77.73           P  
+ATOM   1372  OP1  DA D  28      66.123  15.232  79.614  1.00 88.88           O  
+ATOM   1373  OP2  DA D  28      68.279  15.703  78.318  1.00100.00           O  
+ATOM   1374  O5'  DA D  28      66.038  16.397  77.425  1.00 55.11           O  
+ATOM   1375  C5'  DA D  28      64.717  16.861  77.645  1.00 46.47           C  
+ATOM   1376  C4'  DA D  28      64.099  17.260  76.320  1.00 53.87           C  
+ATOM   1377  O4'  DA D  28      64.677  18.520  75.885  1.00 60.29           O  
+ATOM   1378  C3'  DA D  28      64.356  16.281  75.179  1.00 62.07           C  
+ATOM   1379  O3'  DA D  28      63.209  16.223  74.330  1.00 72.95           O  
+ATOM   1380  C2'  DA D  28      65.529  16.941  74.460  1.00 59.03           C  
+ATOM   1381  C1'  DA D  28      65.060  18.387  74.532  1.00 49.96           C  
+ATOM   1382  N9   DA D  28      66.050  19.401  74.160  1.00 41.37           N  
+ATOM   1383  C8   DA D  28      67.395  19.495  74.400  1.00 43.48           C  
+ATOM   1384  N7   DA D  28      67.953  20.569  73.887  1.00 38.43           N  
+ATOM   1385  C5   DA D  28      66.899  21.224  73.270  1.00 29.53           C  
+ATOM   1386  C6   DA D  28      66.823  22.426  72.547  1.00 32.63           C  
+ATOM   1387  N6   DA D  28      67.879  23.218  72.300  1.00 30.29           N  
+ATOM   1388  N1   DA D  28      65.612  22.771  72.058  1.00 33.17           N  
+ATOM   1389  C2   DA D  28      64.558  21.982  72.301  1.00 31.24           C  
+ATOM   1390  N3   DA D  28      64.505  20.831  72.968  1.00 31.38           N  
+ATOM   1391  C4   DA D  28      65.723  20.513  73.424  1.00 32.48           C  
+ATOM   1392  P    DA D  29      62.755  14.844  73.655  1.00 68.06           P  
+ATOM   1393  OP1  DA D  29      62.040  14.057  74.684  1.00 66.52           O  
+ATOM   1394  OP2  DA D  29      63.930  14.278  72.955  1.00 76.05           O  
+ATOM   1395  O5'  DA D  29      61.692  15.257  72.535  1.00 55.54           O  
+ATOM   1396  C5'  DA D  29      60.889  16.414  72.671  1.00 48.61           C  
+ATOM   1397  C4'  DA D  29      60.835  17.137  71.340  1.00 57.71           C  
+ATOM   1398  O4'  DA D  29      61.943  18.069  71.242  1.00 57.91           O  
+ATOM   1399  C3'  DA D  29      60.936  16.247  70.105  1.00 72.03           C  
+ATOM   1400  O3'  DA D  29      60.033  16.742  69.127  1.00 85.02           O  
+ATOM   1401  C2'  DA D  29      62.382  16.441  69.653  1.00 56.96           C  
+ATOM   1402  C1'  DA D  29      62.567  17.918  69.982  1.00 53.62           C  
+ATOM   1403  N9   DA D  29      63.962  18.351  70.077  1.00 41.70           N  
+ATOM   1404  C8   DA D  29      65.021  17.761  70.708  1.00 40.49           C  
+ATOM   1405  N7   DA D  29      66.145  18.434  70.602  1.00 40.55           N  
+ATOM   1406  C5   DA D  29      65.792  19.549  69.861  1.00 36.59           C  
+ATOM   1407  C6   DA D  29      66.523  20.652  69.394  1.00 31.44           C  
+ATOM   1408  N6   DA D  29      67.828  20.801  69.639  1.00 32.90           N  
+ATOM   1409  N1   DA D  29      65.881  21.595  68.675  1.00 32.64           N  
+ATOM   1410  C2   DA D  29      64.578  21.425  68.445  1.00 36.07           C  
+ATOM   1411  N3   DA D  29      63.781  20.424  68.818  1.00 37.26           N  
+ATOM   1412  C4   DA D  29      64.456  19.510  69.529  1.00 35.70           C  
+ATOM   1413  P    DC D  30      59.583  15.903  67.842  1.00 81.38           P  
+ATOM   1414  OP1  DC D  30      58.111  16.026  67.738  1.00 88.42           O  
+ATOM   1415  OP2  DC D  30      60.231  14.572  67.864  1.00 68.08           O  
+ATOM   1416  O5'  DC D  30      60.235  16.750  66.659  1.00 85.76           O  
+ATOM   1417  C5'  DC D  30      59.844  18.107  66.557  1.00 87.82           C  
+ATOM   1418  C4'  DC D  30      60.880  18.878  65.767  1.00 80.45           C  
+ATOM   1419  O4'  DC D  30      62.157  18.824  66.449  1.00 77.22           O  
+ATOM   1420  C3'  DC D  30      61.123  18.352  64.356  1.00 74.83           C  
+ATOM   1421  O3'  DC D  30      60.687  19.331  63.422  1.00 62.36           O  
+ATOM   1422  C2'  DC D  30      62.630  18.093  64.306  1.00 67.98           C  
+ATOM   1423  C1'  DC D  30      63.146  18.953  65.454  1.00 55.26           C  
+ATOM   1424  N1   DC D  30      64.479  18.568  66.003  1.00 48.65           N  
+ATOM   1425  C2   DC D  30      65.533  19.432  65.691  1.00 48.07           C  
+ATOM   1426  O2   DC D  30      65.294  20.431  65.001  1.00 52.94           O  
+ATOM   1427  N3   DC D  30      66.778  19.157  66.150  1.00 49.19           N  
+ATOM   1428  C4   DC D  30      66.991  18.066  66.885  1.00 54.57           C  
+ATOM   1429  N4   DC D  30      68.236  17.833  67.314  1.00 53.86           N  
+ATOM   1430  C5   DC D  30      65.933  17.168  67.216  1.00 51.99           C  
+ATOM   1431  C6   DC D  30      64.709  17.461  66.761  1.00 51.93           C  
+ATOM   1432  P    DT D  31      61.031  19.219  61.869  1.00 60.04           P  
+ATOM   1433  OP1  DT D  31      60.080  20.101  61.160  1.00 64.05           O  
+ATOM   1434  OP2  DT D  31      61.153  17.784  61.531  1.00 47.44           O  
+ATOM   1435  O5'  DT D  31      62.474  19.895  61.781  1.00 62.91           O  
+ATOM   1436  C5'  DT D  31      62.534  21.312  61.702  1.00 65.65           C  
+ATOM   1437  C4'  DT D  31      63.713  21.749  60.857  1.00 70.12           C  
+ATOM   1438  O4'  DT D  31      64.948  21.371  61.516  1.00 71.57           O  
+ATOM   1439  C3'  DT D  31      63.791  21.087  59.490  1.00 75.28           C  
+ATOM   1440  O3'  DT D  31      64.473  21.987  58.641  1.00 69.08           O  
+ATOM   1441  C2'  DT D  31      64.645  19.855  59.778  1.00 64.55           C  
+ATOM   1442  C1'  DT D  31      65.686  20.509  60.674  1.00 49.24           C  
+ATOM   1443  N1   DT D  31      66.443  19.577  61.542  1.00 45.45           N  
+ATOM   1444  C2   DT D  31      67.773  19.881  61.754  1.00 41.26           C  
+ATOM   1445  O2   DT D  31      68.344  20.836  61.252  1.00 40.55           O  
+ATOM   1446  N3   DT D  31      68.427  19.004  62.574  1.00 33.63           N  
+ATOM   1447  C4   DT D  31      67.875  17.909  63.214  1.00 39.39           C  
+ATOM   1448  O4   DT D  31      68.571  17.221  63.956  1.00 38.88           O  
+ATOM   1449  C5   DT D  31      66.480  17.664  62.959  1.00 35.20           C  
+ATOM   1450  C7   DT D  31      65.849  16.470  63.617  1.00 31.52           C  
+ATOM   1451  C6   DT D  31      65.822  18.508  62.158  1.00 37.50           C  
+ATOM   1452  P    DT D  32      64.381  21.833  57.056  1.00 67.37           P  
+ATOM   1453  OP1  DT D  32      63.908  23.147  56.563  1.00 52.42           O  
+ATOM   1454  OP2  DT D  32      63.660  20.578  56.739  1.00 63.36           O  
+ATOM   1455  O5'  DT D  32      65.916  21.681  56.641  1.00 79.26           O  
+ATOM   1456  C5'  DT D  32      66.779  22.791  56.851  1.00 76.23           C  
+ATOM   1457  C4'  DT D  32      68.203  22.396  56.517  1.00 69.40           C  
+ATOM   1458  O4'  DT D  32      68.707  21.514  57.554  1.00 68.66           O  
+ATOM   1459  C3'  DT D  32      68.308  21.586  55.233  1.00 61.56           C  
+ATOM   1460  O3'  DT D  32      69.483  21.975  54.552  1.00 64.89           O  
+ATOM   1461  C2'  DT D  32      68.403  20.153  55.740  1.00 48.02           C  
+ATOM   1462  C1'  DT D  32      69.307  20.400  56.935  1.00 47.11           C  
+ATOM   1463  N1   DT D  32      69.333  19.284  57.904  1.00 48.31           N  
+ATOM   1464  C2   DT D  32      70.493  19.163  58.642  1.00 52.97           C  
+ATOM   1465  O2   DT D  32      71.436  19.928  58.518  1.00 54.31           O  
+ATOM   1466  N3   DT D  32      70.490  18.130  59.544  1.00 43.82           N  
+ATOM   1467  C4   DT D  32      69.464  17.223  59.744  1.00 41.70           C  
+ATOM   1468  O4   DT D  32      69.590  16.330  60.572  1.00 40.92           O  
+ATOM   1469  C5   DT D  32      68.295  17.412  58.927  1.00 44.24           C  
+ATOM   1470  C7   DT D  32      67.169  16.445  59.126  1.00 43.15           C  
+ATOM   1471  C6   DT D  32      68.267  18.421  58.051  1.00 43.05           C  
+ATOM   1472  P    DA D  33      69.319  22.615  53.099  1.00 66.53           P  
+ATOM   1473  OP1  DA D  33      69.003  24.056  53.228  1.00 64.54           O  
+ATOM   1474  OP2  DA D  33      68.417  21.729  52.330  1.00 78.33           O  
+ATOM   1475  O5'  DA D  33      70.815  22.506  52.545  1.00 69.82           O  
+ATOM   1476  C5'  DA D  33      71.847  23.334  53.084  1.00 52.21           C  
+ATOM   1477  C4'  DA D  33      72.977  22.479  53.632  1.00 56.87           C  
+ATOM   1478  O4'  DA D  33      72.406  21.520  54.558  1.00 64.08           O  
+ATOM   1479  C3'  DA D  33      73.745  21.659  52.598  1.00 61.16           C  
+ATOM   1480  O3'  DA D  33      75.145  21.870  52.730  1.00 63.16           O  
+ATOM   1481  C2'  DA D  33      73.381  20.207  52.896  1.00 57.96           C  
+ATOM   1482  C1'  DA D  33      73.027  20.266  54.374  1.00 55.34           C  
+ATOM   1483  N9   DA D  33      72.104  19.210  54.776  1.00 48.16           N  
+ATOM   1484  C8   DA D  33      70.857  18.921  54.302  1.00 50.12           C  
+ATOM   1485  N7   DA D  33      70.307  17.884  54.891  1.00 54.34           N  
+ATOM   1486  C5   DA D  33      71.257  17.466  55.807  1.00 47.24           C  
+ATOM   1487  C6   DA D  33      71.290  16.410  56.736  1.00 46.07           C  
+ATOM   1488  N6   DA D  33      70.269  15.561  56.866  1.00 47.83           N  
+ATOM   1489  N1   DA D  33      72.388  16.249  57.501  1.00 46.19           N  
+ATOM   1490  C2   DA D  33      73.393  17.113  57.331  1.00 48.76           C  
+ATOM   1491  N3   DA D  33      73.487  18.140  56.483  1.00 48.72           N  
+ATOM   1492  C4   DA D  33      72.373  18.270  55.746  1.00 47.25           C  
+ATOM   1493  P    DT D  34      76.071  22.167  51.457  1.00 62.48           P  
+ATOM   1494  OP1  DT D  34      77.343  22.712  51.974  1.00 92.48           O  
+ATOM   1495  OP2  DT D  34      75.302  22.949  50.458  1.00 77.17           O  
+ATOM   1496  O5'  DT D  34      76.380  20.711  50.868  1.00 51.43           O  
+ATOM   1497  C5'  DT D  34      76.004  19.534  51.570  1.00 45.38           C  
+ATOM   1498  C4'  DT D  34      76.806  19.408  52.850  1.00 38.65           C  
+ATOM   1499  O4'  DT D  34      75.966  18.780  53.848  1.00 98.59           O  
+ATOM   1500  C3'  DT D  34      78.016  18.491  52.769  1.00 72.65           C  
+ATOM   1501  O3'  DT D  34      78.871  18.753  53.878  1.00100.00           O  
+ATOM   1502  C2'  DT D  34      77.348  17.125  52.890  1.00 65.93           C  
+ATOM   1503  C1'  DT D  34      76.309  17.415  53.969  1.00 56.27           C  
+ATOM   1504  N1   DT D  34      75.057  16.642  53.815  1.00 56.05           N  
+ATOM   1505  C2   DT D  34      74.830  15.618  54.705  1.00 57.97           C  
+ATOM   1506  O2   DT D  34      75.601  15.339  55.606  1.00 57.88           O  
+ATOM   1507  N3   DT D  34      73.658  14.936  54.503  1.00 60.51           N  
+ATOM   1508  C4   DT D  34      72.721  15.183  53.516  1.00 61.83           C  
+ATOM   1509  O4   DT D  34      71.706  14.496  53.465  1.00 61.30           O  
+ATOM   1510  C5   DT D  34      73.041  16.259  52.611  1.00 55.85           C  
+ATOM   1511  C7   DT D  34      72.121  16.644  51.493  1.00 55.73           C  
+ATOM   1512  C6   DT D  34      74.174  16.939  52.801  1.00 54.92           C  
+TER    1513       DT D  34                                                      
+ATOM   1514  N   ALA A  18      34.728  52.682 104.426  1.00 91.61           N  
+ATOM   1515  CA  ALA A  18      35.288  51.642 103.568  1.00 90.68           C  
+ATOM   1516  C   ALA A  18      34.664  50.291 103.895  1.00 91.22           C  
+ATOM   1517  O   ALA A  18      35.264  49.249 103.639  1.00 92.64           O  
+ATOM   1518  CB  ALA A  18      36.806  51.581 103.715  1.00 91.48           C  
+ATOM   1519  N   THR A  19      33.458  50.321 104.458  1.00 82.64           N  
+ATOM   1520  CA  THR A  19      32.717  49.118 104.852  1.00 79.67           C  
+ATOM   1521  C   THR A  19      33.383  48.131 105.813  1.00 73.74           C  
+ATOM   1522  O   THR A  19      34.440  47.564 105.533  1.00 75.80           O  
+ATOM   1523  CB  THR A  19      31.977  48.466 103.684  1.00 86.22           C  
+ATOM   1524  OG1 THR A  19      32.383  47.092 103.522  1.00 68.78           O  
+ATOM   1525  CG2 THR A  19      32.176  49.314 102.424  1.00 90.23           C  
+ATOM   1526  N   SER A  20      32.766  47.964 106.972  1.00 59.36           N  
+ATOM   1527  CA  SER A  20      33.333  47.105 107.986  1.00 55.14           C  
+ATOM   1528  C   SER A  20      33.527  45.661 107.562  1.00 55.44           C  
+ATOM   1529  O   SER A  20      34.275  44.934 108.205  1.00 55.94           O  
+ATOM   1530  CB  SER A  20      32.538  47.213 109.284  1.00 59.20           C  
+ATOM   1531  OG  SER A  20      32.425  45.953 109.919  1.00 77.81           O  
+ATOM   1532  N   ASP A  21      32.868  45.224 106.492  1.00 53.23           N  
+ATOM   1533  CA  ASP A  21      33.023  43.840 106.038  1.00 53.56           C  
+ATOM   1534  C   ASP A  21      34.318  43.763 105.234  1.00 54.63           C  
+ATOM   1535  O   ASP A  21      35.023  42.752 105.247  1.00 53.22           O  
+ATOM   1536  CB  ASP A  21      31.825  43.402 105.174  1.00 57.45           C  
+ATOM   1537  CG  ASP A  21      30.695  42.771 105.995  1.00 73.89           C  
+ATOM   1538  OD1 ASP A  21      31.008  42.034 106.955  1.00 80.31           O  
+ATOM   1539  OD2 ASP A  21      29.503  43.013 105.688  1.00 75.91           O  
+ATOM   1540  N   GLU A  22      34.622  44.844 104.525  1.00 51.32           N  
+ATOM   1541  CA  GLU A  22      35.842  44.910 103.732  1.00 51.32           C  
+ATOM   1542  C   GLU A  22      37.015  44.952 104.697  1.00 53.41           C  
+ATOM   1543  O   GLU A  22      38.011  44.249 104.528  1.00 53.68           O  
+ATOM   1544  CB  GLU A  22      35.855  46.195 102.919  1.00 52.98           C  
+ATOM   1545  CG  GLU A  22      35.724  45.980 101.432  1.00 76.05           C  
+ATOM   1546  CD  GLU A  22      34.863  47.045 100.809  1.00100.00           C  
+ATOM   1547  OE1 GLU A  22      33.801  47.310 101.400  1.00 68.90           O  
+ATOM   1548  OE2 GLU A  22      35.225  47.620  99.762  1.00100.00           O  
+ATOM   1549  N   VAL A  23      36.871  45.804 105.707  1.00 45.99           N  
+ATOM   1550  CA  VAL A  23      37.879  45.968 106.746  1.00 43.26           C  
+ATOM   1551  C   VAL A  23      38.160  44.642 107.455  1.00 45.58           C  
+ATOM   1552  O   VAL A  23      39.311  44.233 107.596  1.00 45.55           O  
+ATOM   1553  CB  VAL A  23      37.489  47.076 107.744  1.00 44.82           C  
+ATOM   1554  CG1 VAL A  23      38.534  47.202 108.850  1.00 43.86           C  
+ATOM   1555  CG2 VAL A  23      37.297  48.397 106.998  1.00 43.15           C  
+ATOM   1556  N   ARG A  24      37.106  43.956 107.876  1.00 40.33           N  
+ATOM   1557  CA  ARG A  24      37.250  42.671 108.557  1.00 39.48           C  
+ATOM   1558  C   ARG A  24      37.961  41.661 107.660  1.00 40.24           C  
+ATOM   1559  O   ARG A  24      38.738  40.841 108.143  1.00 42.23           O  
+ATOM   1560  CB  ARG A  24      35.877  42.159 109.006  1.00 45.98           C  
+ATOM   1561  CG  ARG A  24      35.853  40.790 109.681  1.00 59.01           C  
+ATOM   1562  CD  ARG A  24      34.422  40.263 109.825  1.00 79.19           C  
+ATOM   1563  NE  ARG A  24      33.611  41.040 110.765  1.00 96.29           N  
+ATOM   1564  CZ  ARG A  24      33.897  41.187 112.057  1.00100.00           C  
+ATOM   1565  NH1 ARG A  24      34.976  40.613 112.568  1.00 82.14           N  
+ATOM   1566  NH2 ARG A  24      33.111  41.910 112.845  1.00 90.30           N  
+ATOM   1567  N   LYS A  25      37.715  41.725 106.354  1.00 34.81           N  
+ATOM   1568  CA  LYS A  25      38.385  40.839 105.397  1.00 32.66           C  
+ATOM   1569  C   LYS A  25      39.874  41.245 105.304  1.00 37.34           C  
+ATOM   1570  O   LYS A  25      40.780  40.405 105.295  1.00 34.01           O  
+ATOM   1571  CB  LYS A  25      37.688  40.945 104.036  1.00 29.45           C  
+ATOM   1572  CG  LYS A  25      38.476  40.372 102.860  1.00 26.07           C  
+ATOM   1573  CD  LYS A  25      38.838  38.905 103.052  1.00 31.72           C  
+ATOM   1574  CE  LYS A  25      39.092  38.246 101.704  1.00 35.39           C  
+ATOM   1575  NZ  LYS A  25      40.478  38.413 101.201  1.00 41.51           N  
+ATOM   1576  N   ASN A  26      40.117  42.551 105.217  1.00 35.03           N  
+ATOM   1577  CA  ASN A  26      41.472  43.099 105.178  1.00 35.05           C  
+ATOM   1578  C   ASN A  26      42.280  42.709 106.432  1.00 38.34           C  
+ATOM   1579  O   ASN A  26      43.432  42.298 106.316  1.00 40.08           O  
+ATOM   1580  CB  ASN A  26      41.422  44.620 105.055  1.00 31.00           C  
+ATOM   1581  CG  ASN A  26      41.097  45.068 103.659  1.00 46.11           C  
+ATOM   1582  OD1 ASN A  26      41.324  44.336 102.701  1.00 52.70           O  
+ATOM   1583  ND2 ASN A  26      40.567  46.275 103.528  1.00 45.50           N  
+ATOM   1584  N   LEU A  27      41.687  42.816 107.622  1.00 32.52           N  
+ATOM   1585  CA  LEU A  27      42.375  42.444 108.858  1.00 31.84           C  
+ATOM   1586  C   LEU A  27      42.669  40.944 108.955  1.00 35.25           C  
+ATOM   1587  O   LEU A  27      43.721  40.562 109.461  1.00 36.65           O  
+ATOM   1588  CB  LEU A  27      41.676  42.999 110.103  1.00 33.01           C  
+ATOM   1589  CG  LEU A  27      41.490  44.527 110.107  1.00 40.66           C  
+ATOM   1590  CD1 LEU A  27      40.580  45.020 111.229  1.00 41.18           C  
+ATOM   1591  CD2 LEU A  27      42.794  45.316 110.079  1.00 45.29           C  
+ATOM   1592  N   MET A  28      41.783  40.090 108.434  1.00 33.15           N  
+ATOM   1593  CA  MET A  28      42.044  38.642 108.413  1.00 34.67           C  
+ATOM   1594  C   MET A  28      43.180  38.348 107.395  1.00 41.13           C  
+ATOM   1595  O   MET A  28      43.992  37.428 107.581  1.00 37.66           O  
+ATOM   1596  CB  MET A  28      40.777  37.876 108.006  1.00 37.36           C  
+ATOM   1597  CG  MET A  28      39.528  38.150 108.845  1.00 42.17           C  
+ATOM   1598  SD  MET A  28      38.123  37.151 108.285  1.00 46.80           S  
+ATOM   1599  CE  MET A  28      37.449  36.541 109.839  1.00 44.41           C  
+ATOM   1600  N   ASP A  29      43.213  39.132 106.315  1.00 38.66           N  
+ATOM   1601  CA  ASP A  29      44.242  39.005 105.283  1.00 37.55           C  
+ATOM   1602  C   ASP A  29      45.575  39.251 106.005  1.00 43.21           C  
+ATOM   1603  O   ASP A  29      46.523  38.481 105.848  1.00 42.00           O  
+ATOM   1604  CB  ASP A  29      44.057  40.094 104.215  1.00 37.59           C  
+ATOM   1605  CG  ASP A  29      43.114  39.698 103.093  1.00 37.01           C  
+ATOM   1606  OD1 ASP A  29      42.602  38.562 103.080  1.00 40.70           O  
+ATOM   1607  OD2 ASP A  29      42.882  40.555 102.217  1.00 35.81           O  
+ATOM   1608  N   MET A  30      45.632  40.326 106.794  1.00 41.68           N  
+ATOM   1609  CA  MET A  30      46.822  40.715 107.553  1.00 42.49           C  
+ATOM   1610  C   MET A  30      47.296  39.617 108.497  1.00 42.47           C  
+ATOM   1611  O   MET A  30      48.479  39.289 108.545  1.00 40.85           O  
+ATOM   1612  CB  MET A  30      46.505  41.955 108.384  1.00 46.85           C  
+ATOM   1613  CG  MET A  30      47.385  43.146 108.114  1.00 55.88           C  
+ATOM   1614  SD  MET A  30      46.545  44.685 108.549  1.00 66.17           S  
+ATOM   1615  CE  MET A  30      47.164  44.948 110.224  1.00 63.15           C  
+ATOM   1616  N   PHE A  31      46.368  39.031 109.241  1.00 37.87           N  
+ATOM   1617  CA  PHE A  31      46.757  38.003 110.182  1.00 37.09           C  
+ATOM   1618  C   PHE A  31      47.146  36.692 109.517  1.00 41.21           C  
+ATOM   1619  O   PHE A  31      48.004  35.962 110.023  1.00 39.80           O  
+ATOM   1620  CB  PHE A  31      45.683  37.800 111.251  1.00 40.15           C  
+ATOM   1621  CG  PHE A  31      46.093  36.845 112.331  1.00 44.38           C  
+ATOM   1622  CD1 PHE A  31      46.525  37.312 113.552  1.00 46.97           C  
+ATOM   1623  CD2 PHE A  31      46.095  35.476 112.090  1.00 49.38           C  
+ATOM   1624  CE1 PHE A  31      46.940  36.429 114.527  1.00 50.90           C  
+ATOM   1625  CE2 PHE A  31      46.504  34.585 113.061  1.00 50.33           C  
+ATOM   1626  CZ  PHE A  31      46.902  35.062 114.277  1.00 49.87           C  
+ATOM   1627  N   ARG A  32      46.506  36.401 108.386  1.00 35.42           N  
+ATOM   1628  CA  ARG A  32      46.743  35.155 107.666  1.00 31.76           C  
+ATOM   1629  C   ARG A  32      48.141  35.119 107.077  1.00 31.72           C  
+ATOM   1630  O   ARG A  32      48.799  34.077 107.035  1.00 29.56           O  
+ATOM   1631  CB  ARG A  32      45.744  34.953 106.530  1.00 30.96           C  
+ATOM   1632  CG  ARG A  32      46.038  33.668 105.774  1.00 21.87           C  
+ATOM   1633  CD  ARG A  32      45.055  33.427 104.658  1.00 21.43           C  
+ATOM   1634  NE  ARG A  32      44.797  34.618 103.850  1.00 30.70           N  
+ATOM   1635  CZ  ARG A  32      43.890  34.644 102.878  1.00 39.02           C  
+ATOM   1636  NH1 ARG A  32      43.180  33.556 102.615  1.00 29.95           N  
+ATOM   1637  NH2 ARG A  32      43.681  35.738 102.162  1.00 23.93           N  
+ATOM   1638  N   ASP A  33      48.556  36.275 106.578  1.00 27.63           N  
+ATOM   1639  CA  ASP A  33      49.877  36.413 105.990  1.00 27.48           C  
+ATOM   1640  C   ASP A  33      50.684  37.380 106.855  1.00 34.95           C  
+ATOM   1641  O   ASP A  33      51.229  38.374 106.372  1.00 33.52           O  
+ATOM   1642  CB  ASP A  33      49.781  36.903 104.544  1.00 26.28           C  
+ATOM   1643  CG  ASP A  33      49.330  35.807 103.584  1.00 30.48           C  
+ATOM   1644  OD1 ASP A  33      49.605  34.613 103.827  1.00 30.05           O  
+ATOM   1645  OD2 ASP A  33      48.663  36.136 102.583  1.00 27.81           O  
+ATOM   1646  N   ARG A  34      50.714  37.101 108.156  1.00 36.00           N  
+ATOM   1647  CA  ARG A  34      51.460  37.938 109.093  1.00 36.46           C  
+ATOM   1648  C   ARG A  34      52.963  37.737 108.907  1.00 35.89           C  
+ATOM   1649  O   ARG A  34      53.748  38.631 109.226  1.00 35.30           O  
+ATOM   1650  CB  ARG A  34      51.055  37.652 110.541  1.00 36.48           C  
+ATOM   1651  CG  ARG A  34      51.067  36.178 110.906  1.00 38.38           C  
+ATOM   1652  CD  ARG A  34      50.155  35.878 112.098  1.00 43.57           C  
+ATOM   1653  NE  ARG A  34      50.368  34.533 112.620  1.00 53.53           N  
+ATOM   1654  CZ  ARG A  34      49.953  33.435 112.007  1.00 73.83           C  
+ATOM   1655  NH1 ARG A  34      49.274  33.538 110.874  1.00 64.08           N  
+ATOM   1656  NH2 ARG A  34      50.184  32.249 112.537  1.00 73.52           N  
+ATOM   1657  N   GLN A  35      53.334  36.562 108.399  1.00 29.25           N  
+ATOM   1658  CA  GLN A  35      54.713  36.195 108.098  1.00 30.17           C  
+ATOM   1659  C   GLN A  35      55.254  37.002 106.930  1.00 40.23           C  
+ATOM   1660  O   GLN A  35      56.294  36.678 106.363  1.00 46.24           O  
+ATOM   1661  CB  GLN A  35      54.753  34.739 107.668  1.00 32.19           C  
+ATOM   1662  CG  GLN A  35      54.730  33.775 108.813  1.00 62.79           C  
+ATOM   1663  CD  GLN A  35      55.656  32.617 108.573  1.00 98.68           C  
+ATOM   1664  OE1 GLN A  35      56.739  32.780 108.016  1.00100.00           O  
+ATOM   1665  NE2 GLN A  35      55.235  31.428 108.976  1.00 98.74           N  
+ATOM   1666  N   ALA A  36      54.509  38.030 106.553  1.00 35.68           N  
+ATOM   1667  CA  ALA A  36      54.880  38.914 105.458  1.00 35.30           C  
+ATOM   1668  C   ALA A  36      55.827  39.954 106.040  1.00 41.40           C  
+ATOM   1669  O   ALA A  36      56.600  40.597 105.331  1.00 39.60           O  
+ATOM   1670  CB  ALA A  36      53.632  39.591 104.898  1.00 35.75           C  
+ATOM   1671  N   PHE A  37      55.759  40.087 107.359  1.00 40.69           N  
+ATOM   1672  CA  PHE A  37      56.595  41.015 108.098  1.00 39.55           C  
+ATOM   1673  C   PHE A  37      57.435  40.342 109.164  1.00 42.86           C  
+ATOM   1674  O   PHE A  37      57.192  39.199 109.563  1.00 41.10           O  
+ATOM   1675  CB  PHE A  37      55.751  42.148 108.666  1.00 41.83           C  
+ATOM   1676  CG  PHE A  37      54.962  42.846 107.612  1.00 46.32           C  
+ATOM   1677  CD1 PHE A  37      53.628  42.523 107.394  1.00 51.17           C  
+ATOM   1678  CD2 PHE A  37      55.594  43.706 106.736  1.00 51.56           C  
+ATOM   1679  CE1 PHE A  37      52.910  43.106 106.369  1.00 54.17           C  
+ATOM   1680  CE2 PHE A  37      54.882  44.302 105.719  1.00 54.87           C  
+ATOM   1681  CZ  PHE A  37      53.536  44.003 105.534  1.00 53.35           C  
+ATOM   1682  N   SER A  38      58.463  41.069 109.576  1.00 42.26           N  
+ATOM   1683  CA  SER A  38      59.361  40.586 110.604  1.00 42.20           C  
+ATOM   1684  C   SER A  38      58.548  40.738 111.890  1.00 42.55           C  
+ATOM   1685  O   SER A  38      57.651  41.579 111.964  1.00 35.71           O  
+ATOM   1686  CB  SER A  38      60.630  41.452 110.636  1.00 44.40           C  
+ATOM   1687  OG  SER A  38      60.355  42.757 111.103  1.00 57.01           O  
+ATOM   1688  N   GLU A  39      58.861  39.926 112.886  1.00 41.09           N  
+ATOM   1689  CA  GLU A  39      58.178  40.021 114.163  1.00 41.44           C  
+ATOM   1690  C   GLU A  39      58.559  41.333 114.856  1.00 42.62           C  
+ATOM   1691  O   GLU A  39      57.770  41.861 115.635  1.00 43.29           O  
+ATOM   1692  CB  GLU A  39      58.410  38.783 115.034  1.00 44.21           C  
+ATOM   1693  CG  GLU A  39      59.869  38.427 115.277  1.00 70.07           C  
+ATOM   1694  CD  GLU A  39      60.047  37.347 116.337  1.00100.00           C  
+ATOM   1695  OE1 GLU A  39      59.680  37.594 117.505  1.00100.00           O  
+ATOM   1696  OE2 GLU A  39      60.556  36.251 116.008  1.00100.00           O  
+ATOM   1697  N   HIS A  40      59.711  41.905 114.510  1.00 36.38           N  
+ATOM   1698  CA  HIS A  40      60.126  43.188 115.083  1.00 37.29           C  
+ATOM   1699  C   HIS A  40      59.148  44.257 114.606  1.00 40.02           C  
+ATOM   1700  O   HIS A  40      58.830  45.203 115.327  1.00 43.45           O  
+ATOM   1701  CB  HIS A  40      61.508  43.620 114.531  1.00 41.32           C  
+ATOM   1702  CG  HIS A  40      62.690  42.972 115.186  1.00 46.50           C  
+ATOM   1703  ND1 HIS A  40      63.010  43.148 116.516  1.00 48.62           N  
+ATOM   1704  CD2 HIS A  40      63.674  42.201 114.666  1.00 49.46           C  
+ATOM   1705  CE1 HIS A  40      64.125  42.493 116.789  1.00 48.88           C  
+ATOM   1706  NE2 HIS A  40      64.544  41.903 115.684  1.00 49.61           N  
+ATOM   1707  N   THR A  41      58.738  44.127 113.346  1.00 35.37           N  
+ATOM   1708  CA  THR A  41      57.835  45.074 112.689  1.00 34.43           C  
+ATOM   1709  C   THR A  41      56.479  45.043 113.362  1.00 37.57           C  
+ATOM   1710  O   THR A  41      55.890  46.083 113.659  1.00 39.27           O  
+ATOM   1711  CB  THR A  41      57.620  44.737 111.198  1.00 42.89           C  
+ATOM   1712  OG1 THR A  41      58.875  44.435 110.576  1.00 37.68           O  
+ATOM   1713  CG2 THR A  41      56.979  45.918 110.485  1.00 36.48           C  
+ATOM   1714  N   TRP A  42      55.998  43.827 113.598  1.00 36.10           N  
+ATOM   1715  CA  TRP A  42      54.718  43.610 114.265  1.00 37.08           C  
+ATOM   1716  C   TRP A  42      54.770  44.200 115.662  1.00 35.45           C  
+ATOM   1717  O   TRP A  42      53.836  44.854 116.113  1.00 35.26           O  
+ATOM   1718  CB  TRP A  42      54.406  42.117 114.360  1.00 37.55           C  
+ATOM   1719  CG  TRP A  42      53.801  41.577 113.108  1.00 39.95           C  
+ATOM   1720  CD1 TRP A  42      54.342  40.647 112.264  1.00 43.36           C  
+ATOM   1721  CD2 TRP A  42      52.556  41.966 112.527  1.00 40.39           C  
+ATOM   1722  NE1 TRP A  42      53.500  40.421 111.204  1.00 42.68           N  
+ATOM   1723  CE2 TRP A  42      52.397  41.224 111.343  1.00 44.55           C  
+ATOM   1724  CE3 TRP A  42      51.558  42.874 112.892  1.00 42.97           C  
+ATOM   1725  CZ2 TRP A  42      51.270  41.343 110.537  1.00 44.04           C  
+ATOM   1726  CZ3 TRP A  42      50.450  43.004 112.079  1.00 44.36           C  
+ATOM   1727  CH2 TRP A  42      50.311  42.240 110.921  1.00 44.73           C  
+ATOM   1728  N   LYS A  43      55.884  43.962 116.338  1.00 33.30           N  
+ATOM   1729  CA  LYS A  43      56.100  44.488 117.678  1.00 34.56           C  
+ATOM   1730  C   LYS A  43      55.943  46.014 117.664  1.00 36.41           C  
+ATOM   1731  O   LYS A  43      55.216  46.599 118.473  1.00 37.57           O  
+ATOM   1732  CB  LYS A  43      57.471  44.039 118.202  1.00 37.98           C  
+ATOM   1733  CG  LYS A  43      57.575  42.521 118.381  1.00 49.63           C  
+ATOM   1734  CD  LYS A  43      56.798  42.069 119.605  1.00 60.43           C  
+ATOM   1735  CE  LYS A  43      55.704  41.069 119.275  1.00 74.75           C  
+ATOM   1736  NZ  LYS A  43      54.852  40.863 120.482  1.00 99.28           N  
+ATOM   1737  N   MET A  44      56.598  46.660 116.714  1.00 29.03           N  
+ATOM   1738  CA  MET A  44      56.454  48.106 116.612  1.00 29.91           C  
+ATOM   1739  C   MET A  44      55.009  48.530 116.277  1.00 37.85           C  
+ATOM   1740  O   MET A  44      54.488  49.482 116.860  1.00 37.67           O  
+ATOM   1741  CB  MET A  44      57.489  48.710 115.657  1.00 32.51           C  
+ATOM   1742  CG  MET A  44      58.892  48.816 116.253  1.00 36.81           C  
+ATOM   1743  SD  MET A  44      58.883  49.292 118.003  1.00 41.81           S  
+ATOM   1744  CE  MET A  44      58.542  50.993 117.901  1.00 37.27           C  
+ATOM   1745  N   LEU A  45      54.358  47.822 115.351  1.00 33.75           N  
+ATOM   1746  CA  LEU A  45      52.965  48.125 115.009  1.00 31.84           C  
+ATOM   1747  C   LEU A  45      52.090  48.026 116.260  1.00 31.52           C  
+ATOM   1748  O   LEU A  45      51.363  48.958 116.604  1.00 31.78           O  
+ATOM   1749  CB  LEU A  45      52.431  47.163 113.937  1.00 33.19           C  
+ATOM   1750  CG  LEU A  45      50.922  47.188 113.645  1.00 35.20           C  
+ATOM   1751  CD1 LEU A  45      50.530  48.449 112.891  1.00 31.34           C  
+ATOM   1752  CD2 LEU A  45      50.460  45.927 112.918  1.00 34.47           C  
+ATOM   1753  N   LEU A  46      52.149  46.890 116.940  1.00 28.50           N  
+ATOM   1754  CA  LEU A  46      51.356  46.723 118.152  1.00 32.69           C  
+ATOM   1755  C   LEU A  46      51.599  47.863 119.154  1.00 40.33           C  
+ATOM   1756  O   LEU A  46      50.669  48.427 119.754  1.00 38.77           O  
+ATOM   1757  CB  LEU A  46      51.675  45.361 118.781  1.00 34.34           C  
+ATOM   1758  CG  LEU A  46      50.804  44.136 118.466  1.00 40.22           C  
+ATOM   1759  CD1 LEU A  46      50.103  44.241 117.119  1.00 40.35           C  
+ATOM   1760  CD2 LEU A  46      51.649  42.875 118.525  1.00 41.01           C  
+ATOM   1761  N   SER A  47      52.874  48.194 119.336  1.00 37.56           N  
+ATOM   1762  CA  SER A  47      53.282  49.232 120.269  1.00 35.51           C  
+ATOM   1763  C   SER A  47      52.644  50.580 119.924  1.00 38.58           C  
+ATOM   1764  O   SER A  47      52.134  51.279 120.802  1.00 39.18           O  
+ATOM   1765  CB  SER A  47      54.819  49.304 120.326  1.00 37.62           C  
+ATOM   1766  OG  SER A  47      55.300  50.371 121.149  1.00 39.11           O  
+ATOM   1767  N   VAL A  48      52.688  50.964 118.653  1.00 36.17           N  
+ATOM   1768  CA  VAL A  48      52.130  52.259 118.273  1.00 35.79           C  
+ATOM   1769  C   VAL A  48      50.625  52.327 118.491  1.00 41.79           C  
+ATOM   1770  O   VAL A  48      50.089  53.354 118.909  1.00 40.95           O  
+ATOM   1771  CB  VAL A  48      52.402  52.590 116.811  1.00 37.29           C  
+ATOM   1772  CG1 VAL A  48      51.587  53.819 116.385  1.00 35.31           C  
+ATOM   1773  CG2 VAL A  48      53.900  52.750 116.565  1.00 35.42           C  
+ATOM   1774  N   CYS A  49      49.958  51.215 118.189  1.00 40.65           N  
+ATOM   1775  CA  CYS A  49      48.512  51.103 118.337  1.00 44.33           C  
+ATOM   1776  C   CYS A  49      48.124  51.248 119.802  1.00 48.47           C  
+ATOM   1777  O   CYS A  49      47.211  51.999 120.147  1.00 47.45           O  
+ATOM   1778  CB  CYS A  49      48.018  49.766 117.781  1.00 46.11           C  
+ATOM   1779  SG  CYS A  49      48.161  49.641 115.965  1.00 50.23           S  
+ATOM   1780  N   ARG A  50      48.840  50.534 120.667  1.00 47.21           N  
+ATOM   1781  CA  ARG A  50      48.581  50.613 122.102  1.00 46.03           C  
+ATOM   1782  C   ARG A  50      48.694  52.058 122.548  1.00 45.94           C  
+ATOM   1783  O   ARG A  50      47.836  52.565 123.266  1.00 46.26           O  
+ATOM   1784  CB  ARG A  50      49.581  49.759 122.888  1.00 41.78           C  
+ATOM   1785  CG  ARG A  50      49.235  48.282 122.960  1.00 39.22           C  
+ATOM   1786  CD  ARG A  50      49.993  47.626 124.102  1.00 52.63           C  
+ATOM   1787  NE  ARG A  50      51.423  47.543 123.821  1.00 52.41           N  
+ATOM   1788  CZ  ARG A  50      51.984  46.536 123.162  1.00 63.80           C  
+ATOM   1789  NH1 ARG A  50      51.238  45.538 122.707  1.00 58.82           N  
+ATOM   1790  NH2 ARG A  50      53.286  46.549 122.929  1.00 41.95           N  
+ATOM   1791  N   SER A  51      49.751  52.724 122.105  1.00 42.45           N  
+ATOM   1792  CA  SER A  51      49.951  54.112 122.488  1.00 43.02           C  
+ATOM   1793  C   SER A  51      48.846  55.011 121.926  1.00 45.00           C  
+ATOM   1794  O   SER A  51      48.324  55.896 122.619  1.00 41.22           O  
+ATOM   1795  CB  SER A  51      51.331  54.586 122.031  1.00 47.77           C  
+ATOM   1796  OG  SER A  51      51.261  55.909 121.529  1.00 67.75           O  
+ATOM   1797  N   TRP A  52      48.511  54.778 120.663  1.00 41.21           N  
+ATOM   1798  CA  TRP A  52      47.478  55.552 120.001  1.00 39.70           C  
+ATOM   1799  C   TRP A  52      46.097  55.322 120.638  1.00 47.60           C  
+ATOM   1800  O   TRP A  52      45.348  56.273 120.830  1.00 49.80           O  
+ATOM   1801  CB  TRP A  52      47.504  55.279 118.489  1.00 36.53           C  
+ATOM   1802  CG  TRP A  52      46.247  55.629 117.769  1.00 36.10           C  
+ATOM   1803  CD1 TRP A  52      45.362  54.759 117.216  1.00 38.21           C  
+ATOM   1804  CD2 TRP A  52      45.733  56.943 117.517  1.00 35.66           C  
+ATOM   1805  NE1 TRP A  52      44.307  55.442 116.660  1.00 37.54           N  
+ATOM   1806  CE2 TRP A  52      44.511  56.786 116.831  1.00 39.39           C  
+ATOM   1807  CE3 TRP A  52      46.179  58.231 117.808  1.00 36.37           C  
+ATOM   1808  CZ2 TRP A  52      43.732  57.870 116.429  1.00 38.89           C  
+ATOM   1809  CZ3 TRP A  52      45.404  59.302 117.420  1.00 38.57           C  
+ATOM   1810  CH2 TRP A  52      44.197  59.119 116.734  1.00 39.56           C  
+ATOM   1811  N   ALA A  53      45.779  54.064 120.967  1.00 45.78           N  
+ATOM   1812  CA  ALA A  53      44.518  53.637 121.592  1.00 45.97           C  
+ATOM   1813  C   ALA A  53      44.295  54.250 122.985  1.00 50.37           C  
+ATOM   1814  O   ALA A  53      43.205  54.753 123.300  1.00 48.36           O  
+ATOM   1815  CB  ALA A  53      44.485  52.105 121.699  1.00 46.61           C  
+ATOM   1816  N   ALA A  54      45.355  54.218 123.790  1.00 45.09           N  
+ATOM   1817  CA  ALA A  54      45.328  54.729 125.153  1.00 45.16           C  
+ATOM   1818  C   ALA A  54      45.121  56.239 125.240  1.00 52.87           C  
+ATOM   1819  O   ALA A  54      44.432  56.748 126.125  1.00 54.96           O  
+ATOM   1820  CB  ALA A  54      46.594  54.319 125.859  1.00 45.45           C  
+ATOM   1821  N   TRP A  55      45.707  56.929 124.261  1.00 48.86           N  
+ATOM   1822  CA  TRP A  55      45.634  58.386 124.112  1.00 46.24           C  
+ATOM   1823  C   TRP A  55      44.268  58.793 123.584  1.00 46.62           C  
+ATOM   1824  O   TRP A  55      43.745  59.858 123.909  1.00 44.10           O  
+ATOM   1825  CB  TRP A  55      46.692  58.899 123.133  1.00 43.94           C  
+ATOM   1826  CG  TRP A  55      46.543  60.365 122.879  1.00 43.98           C  
+ATOM   1827  CD1 TRP A  55      47.204  61.360 123.532  1.00 46.78           C  
+ATOM   1828  CD2 TRP A  55      45.656  61.009 121.951  1.00 43.78           C  
+ATOM   1829  NE1 TRP A  55      46.821  62.581 123.048  1.00 45.72           N  
+ATOM   1830  CE2 TRP A  55      45.870  62.398 122.074  1.00 47.28           C  
+ATOM   1831  CE3 TRP A  55      44.731  60.553 121.007  1.00 45.65           C  
+ATOM   1832  CZ2 TRP A  55      45.186  63.341 121.296  1.00 46.61           C  
+ATOM   1833  CZ3 TRP A  55      44.049  61.500 120.228  1.00 47.38           C  
+ATOM   1834  CH2 TRP A  55      44.279  62.877 120.383  1.00 47.60           C  
+ATOM   1835  N   CYS A  56      43.689  57.929 122.761  1.00 43.56           N  
+ATOM   1836  CA  CYS A  56      42.368  58.192 122.228  1.00 43.73           C  
+ATOM   1837  C   CYS A  56      41.354  58.042 123.352  1.00 50.60           C  
+ATOM   1838  O   CYS A  56      40.405  58.821 123.446  1.00 50.39           O  
+ATOM   1839  CB  CYS A  56      42.056  57.204 121.112  1.00 42.94           C  
+ATOM   1840  SG  CYS A  56      42.769  57.707 119.519  1.00 46.57           S  
+ATOM   1841  N   LYS A  57      41.559  57.022 124.189  1.00 49.99           N  
+ATOM   1842  CA  LYS A  57      40.683  56.743 125.331  1.00 50.59           C  
+ATOM   1843  C   LYS A  57      40.753  57.968 126.211  1.00 58.02           C  
+ATOM   1844  O   LYS A  57      39.792  58.723 126.364  1.00 57.36           O  
+ATOM   1845  CB  LYS A  57      41.188  55.554 126.152  1.00 52.54           C  
+ATOM   1846  CG  LYS A  57      40.190  55.132 127.232  1.00 77.08           C  
+ATOM   1847  CD  LYS A  57      40.594  53.861 127.963  1.00 89.65           C  
+ATOM   1848  CE  LYS A  57      39.510  53.412 128.931  1.00 99.62           C  
+ATOM   1849  NZ  LYS A  57      39.157  51.982 128.714  1.00100.00           N  
+ATOM   1850  N   LEU A  58      41.955  58.168 126.730  1.00 56.67           N  
+ATOM   1851  CA  LEU A  58      42.295  59.304 127.562  1.00 56.04           C  
+ATOM   1852  C   LEU A  58      41.686  60.588 127.021  1.00 59.04           C  
+ATOM   1853  O   LEU A  58      41.101  61.358 127.777  1.00 61.04           O  
+ATOM   1854  CB  LEU A  58      43.812  59.447 127.580  1.00 56.13           C  
+ATOM   1855  CG  LEU A  58      44.438  60.419 128.570  1.00 61.71           C  
+ATOM   1856  CD1 LEU A  58      43.930  60.166 129.988  1.00 61.41           C  
+ATOM   1857  CD2 LEU A  58      45.927  60.182 128.514  1.00 67.06           C  
+ATOM   1858  N   ASN A  59      41.835  60.837 125.725  1.00 54.47           N  
+ATOM   1859  CA  ASN A  59      41.317  62.076 125.164  1.00 53.75           C  
+ATOM   1860  C   ASN A  59      39.922  62.006 124.578  1.00 58.96           C  
+ATOM   1861  O   ASN A  59      39.442  62.987 124.007  1.00 60.40           O  
+ATOM   1862  CB  ASN A  59      42.289  62.672 124.158  1.00 51.06           C  
+ATOM   1863  CG  ASN A  59      43.591  63.076 124.799  1.00 60.51           C  
+ATOM   1864  OD1 ASN A  59      43.744  64.214 125.221  1.00 67.61           O  
+ATOM   1865  ND2 ASN A  59      44.525  62.139 124.884  1.00 51.42           N  
+ATOM   1866  N   ASN A  60      39.278  60.850 124.727  1.00 53.67           N  
+ATOM   1867  CA  ASN A  60      37.915  60.658 124.245  1.00 53.32           C  
+ATOM   1868  C   ASN A  60      37.791  60.769 122.723  1.00 57.66           C  
+ATOM   1869  O   ASN A  60      36.965  61.526 122.220  1.00 57.98           O  
+ATOM   1870  CB  ASN A  60      36.965  61.642 124.943  1.00 56.50           C  
+ATOM   1871  CG  ASN A  60      37.135  61.655 126.463  1.00 92.80           C  
+ATOM   1872  OD1 ASN A  60      36.880  60.651 127.124  1.00100.00           O  
+ATOM   1873  ND2 ASN A  60      37.562  62.788 127.019  1.00 72.08           N  
+ATOM   1874  N   ARG A  61      38.618  60.014 122.003  1.00 51.32           N  
+ATOM   1875  CA  ARG A  61      38.580  59.981 120.538  1.00 47.42           C  
+ATOM   1876  C   ARG A  61      38.459  58.533 120.110  1.00 46.84           C  
+ATOM   1877  O   ARG A  61      38.787  57.629 120.887  1.00 45.14           O  
+ATOM   1878  CB  ARG A  61      39.876  60.509 119.921  1.00 45.83           C  
+ATOM   1879  CG  ARG A  61      40.441  61.724 120.594  1.00 47.26           C  
+ATOM   1880  CD  ARG A  61      39.506  62.887 120.386  1.00 52.46           C  
+ATOM   1881  NE  ARG A  61      40.067  64.089 120.975  1.00 55.05           N  
+ATOM   1882  CZ  ARG A  61      40.946  64.873 120.363  1.00 79.02           C  
+ATOM   1883  NH1 ARG A  61      41.354  64.598 119.132  1.00 60.76           N  
+ATOM   1884  NH2 ARG A  61      41.414  65.947 120.980  1.00 86.85           N  
+ATOM   1885  N   LYS A  62      38.036  58.312 118.867  1.00 42.75           N  
+ATOM   1886  CA  LYS A  62      37.916  56.956 118.328  1.00 43.79           C  
+ATOM   1887  C   LYS A  62      39.246  56.561 117.703  1.00 47.44           C  
+ATOM   1888  O   LYS A  62      39.858  57.343 116.980  1.00 46.15           O  
+ATOM   1889  CB  LYS A  62      36.810  56.874 117.283  1.00 49.68           C  
+ATOM   1890  CG  LYS A  62      35.431  56.676 117.891  1.00 90.14           C  
+ATOM   1891  CD  LYS A  62      35.307  55.328 118.590  1.00100.00           C  
+ATOM   1892  CE  LYS A  62      35.849  55.344 120.012  1.00 96.03           C  
+ATOM   1893  NZ  LYS A  62      35.600  54.039 120.688  1.00 91.68           N  
+ATOM   1894  N   TRP A  63      39.723  55.360 117.984  1.00 47.67           N  
+ATOM   1895  CA  TRP A  63      41.028  54.996 117.452  1.00 49.83           C  
+ATOM   1896  C   TRP A  63      41.045  54.244 116.118  1.00 55.92           C  
+ATOM   1897  O   TRP A  63      42.110  54.060 115.528  1.00 55.42           O  
+ATOM   1898  CB  TRP A  63      41.867  54.295 118.526  1.00 48.35           C  
+ATOM   1899  CG  TRP A  63      41.515  52.867 118.660  1.00 48.94           C  
+ATOM   1900  CD1 TRP A  63      40.418  52.354 119.281  1.00 52.67           C  
+ATOM   1901  CD2 TRP A  63      42.191  51.765 118.049  1.00 48.12           C  
+ATOM   1902  NE1 TRP A  63      40.382  50.989 119.123  1.00 53.14           N  
+ATOM   1903  CE2 TRP A  63      41.465  50.601 118.374  1.00 53.29           C  
+ATOM   1904  CE3 TRP A  63      43.339  51.651 117.256  1.00 47.55           C  
+ATOM   1905  CZ2 TRP A  63      41.866  49.336 117.953  1.00 51.24           C  
+ATOM   1906  CZ3 TRP A  63      43.724  50.401 116.832  1.00 48.09           C  
+ATOM   1907  CH2 TRP A  63      42.997  49.259 117.185  1.00 49.18           C  
+ATOM   1908  N   PHE A  64      39.881  53.811 115.647  1.00 53.95           N  
+ATOM   1909  CA  PHE A  64      39.788  53.091 114.381  1.00 54.54           C  
+ATOM   1910  C   PHE A  64      38.406  53.250 113.742  1.00 62.20           C  
+ATOM   1911  O   PHE A  64      37.409  52.785 114.294  1.00 67.77           O  
+ATOM   1912  CB  PHE A  64      40.116  51.611 114.567  1.00 56.33           C  
+ATOM   1913  CG  PHE A  64      40.297  50.875 113.273  1.00 61.39           C  
+ATOM   1914  CD1 PHE A  64      41.300  51.248 112.387  1.00 67.79           C  
+ATOM   1915  CD2 PHE A  64      39.453  49.831 112.925  1.00 66.50           C  
+ATOM   1916  CE1 PHE A  64      41.472  50.584 111.179  1.00 69.74           C  
+ATOM   1917  CE2 PHE A  64      39.625  49.152 111.724  1.00 70.98           C  
+ATOM   1918  CZ  PHE A  64      40.632  49.535 110.846  1.00 69.69           C  
+ATOM   1919  N   PRO A  65      38.329  53.913 112.593  1.00 53.17           N  
+ATOM   1920  CA  PRO A  65      39.482  54.458 111.901  1.00 51.42           C  
+ATOM   1921  C   PRO A  65      39.917  55.783 112.492  1.00 51.00           C  
+ATOM   1922  O   PRO A  65      39.124  56.476 113.121  1.00 52.33           O  
+ATOM   1923  CB  PRO A  65      38.954  54.691 110.478  1.00 54.06           C  
+ATOM   1924  CG  PRO A  65      37.513  54.232 110.470  1.00 58.71           C  
+ATOM   1925  CD  PRO A  65      37.374  53.327 111.645  1.00 53.88           C  
+ATOM   1926  N   ALA A  66      41.174  56.143 112.258  1.00 44.60           N  
+ATOM   1927  CA  ALA A  66      41.728  57.386 112.776  1.00 44.65           C  
+ATOM   1928  C   ALA A  66      41.332  58.640 111.992  1.00 52.61           C  
+ATOM   1929  O   ALA A  66      41.478  58.683 110.774  1.00 52.75           O  
+ATOM   1930  CB  ALA A  66      43.247  57.269 112.877  1.00 44.92           C  
+ATOM   1931  N   GLU A  67      40.840  59.658 112.694  1.00 54.72           N  
+ATOM   1932  CA  GLU A  67      40.455  60.901 112.043  1.00 56.52           C  
+ATOM   1933  C   GLU A  67      41.677  61.823 111.994  1.00 58.27           C  
+ATOM   1934  O   GLU A  67      42.419  61.936 112.973  1.00 56.59           O  
+ATOM   1935  CB  GLU A  67      39.269  61.538 112.786  1.00 58.72           C  
+ATOM   1936  CG  GLU A  67      38.164  62.097 111.896  1.00 74.27           C  
+ATOM   1937  CD  GLU A  67      38.136  63.619 111.914  1.00100.00           C  
+ATOM   1938  OE1 GLU A  67      37.494  64.191 112.818  1.00100.00           O  
+ATOM   1939  OE2 GLU A  67      38.794  64.242 111.049  1.00100.00           O  
+ATOM   1940  N   PRO A  68      41.885  62.467 110.847  1.00 55.23           N  
+ATOM   1941  CA  PRO A  68      42.992  63.389 110.688  1.00 53.58           C  
+ATOM   1942  C   PRO A  68      43.171  64.392 111.817  1.00 55.05           C  
+ATOM   1943  O   PRO A  68      44.284  64.549 112.314  1.00 56.68           O  
+ATOM   1944  CB  PRO A  68      42.643  64.110 109.386  1.00 55.68           C  
+ATOM   1945  CG  PRO A  68      41.859  63.106 108.595  1.00 61.81           C  
+ATOM   1946  CD  PRO A  68      41.442  61.988 109.525  1.00 57.51           C  
+ATOM   1947  N   GLU A  69      42.121  65.091 112.226  1.00 47.75           N  
+ATOM   1948  CA  GLU A  69      42.332  66.055 113.296  1.00 46.59           C  
+ATOM   1949  C   GLU A  69      42.841  65.372 114.562  1.00 53.68           C  
+ATOM   1950  O   GLU A  69      43.631  65.949 115.308  1.00 54.56           O  
+ATOM   1951  CB  GLU A  69      41.053  66.828 113.595  1.00 46.97           C  
+ATOM   1952  CG  GLU A  69      40.539  67.611 112.405  1.00 59.28           C  
+ATOM   1953  CD  GLU A  69      41.509  68.688 111.957  1.00 72.64           C  
+ATOM   1954  OE1 GLU A  69      42.104  69.338 112.845  1.00 47.94           O  
+ATOM   1955  OE2 GLU A  69      41.665  68.885 110.729  1.00 54.76           O  
+ATOM   1956  N   ASP A  70      42.365  64.151 114.801  1.00 50.64           N  
+ATOM   1957  CA  ASP A  70      42.726  63.378 115.986  1.00 48.41           C  
+ATOM   1958  C   ASP A  70      44.154  62.899 115.889  1.00 47.69           C  
+ATOM   1959  O   ASP A  70      44.881  62.893 116.876  1.00 48.94           O  
+ATOM   1960  CB  ASP A  70      41.812  62.164 116.144  1.00 50.09           C  
+ATOM   1961  CG  ASP A  70      40.401  62.544 116.534  1.00 60.08           C  
+ATOM   1962  OD1 ASP A  70      40.192  63.633 117.108  1.00 62.65           O  
+ATOM   1963  OD2 ASP A  70      39.499  61.731 116.274  1.00 58.08           O  
+ATOM   1964  N   VAL A  71      44.561  62.487 114.697  1.00 42.13           N  
+ATOM   1965  CA  VAL A  71      45.926  62.026 114.523  1.00 41.82           C  
+ATOM   1966  C   VAL A  71      46.866  63.216 114.630  1.00 45.24           C  
+ATOM   1967  O   VAL A  71      47.983  63.058 115.104  1.00 48.69           O  
+ATOM   1968  CB  VAL A  71      46.167  61.262 113.187  1.00 45.66           C  
+ATOM   1969  CG1 VAL A  71      47.597  60.739 113.114  1.00 45.37           C  
+ATOM   1970  CG2 VAL A  71      45.172  60.114 113.020  1.00 44.71           C  
+ATOM   1971  N   ARG A  72      46.415  64.398 114.219  1.00 40.13           N  
+ATOM   1972  CA  ARG A  72      47.250  65.595 114.277  1.00 41.64           C  
+ATOM   1973  C   ARG A  72      47.482  65.993 115.729  1.00 46.93           C  
+ATOM   1974  O   ARG A  72      48.576  66.398 116.126  1.00 46.08           O  
+ATOM   1975  CB  ARG A  72      46.594  66.744 113.503  1.00 47.51           C  
+ATOM   1976  CG  ARG A  72      46.932  68.147 114.016  1.00 54.11           C  
+ATOM   1977  CD  ARG A  72      46.772  69.204 112.931  1.00 49.00           C  
+ATOM   1978  NE  ARG A  72      47.392  70.468 113.312  1.00 48.42           N  
+ATOM   1979  CZ  ARG A  72      47.037  71.158 114.388  1.00 62.26           C  
+ATOM   1980  NH1 ARG A  72      46.069  70.687 115.159  1.00 61.41           N  
+ATOM   1981  NH2 ARG A  72      47.641  72.302 114.689  1.00 50.81           N  
+ATOM   1982  N   ASP A  73      46.434  65.867 116.530  1.00 44.18           N  
+ATOM   1983  CA  ASP A  73      46.522  66.200 117.946  1.00 43.35           C  
+ATOM   1984  C   ASP A  73      47.473  65.235 118.653  1.00 47.19           C  
+ATOM   1985  O   ASP A  73      48.166  65.607 119.601  1.00 46.57           O  
+ATOM   1986  CB  ASP A  73      45.143  66.133 118.615  1.00 44.90           C  
+ATOM   1987  CG  ASP A  73      44.259  67.280 118.188  1.00 63.52           C  
+ATOM   1988  OD1 ASP A  73      44.803  68.321 117.804  1.00 67.43           O  
+ATOM   1989  OD2 ASP A  73      43.019  67.117 118.271  1.00 70.31           O  
+ATOM   1990  N   TYR A  74      47.500  63.995 118.177  1.00 44.09           N  
+ATOM   1991  CA  TYR A  74      48.356  62.951 118.736  1.00 42.38           C  
+ATOM   1992  C   TYR A  74      49.821  63.172 118.373  1.00 47.21           C  
+ATOM   1993  O   TYR A  74      50.702  62.941 119.202  1.00 49.16           O  
+ATOM   1994  CB  TYR A  74      47.871  61.568 118.273  1.00 40.74           C  
+ATOM   1995  CG  TYR A  74      48.770  60.399 118.641  1.00 37.77           C  
+ATOM   1996  CD1 TYR A  74      48.941  60.012 119.966  1.00 37.75           C  
+ATOM   1997  CD2 TYR A  74      49.421  59.663 117.654  1.00 38.13           C  
+ATOM   1998  CE1 TYR A  74      49.756  58.923 120.293  1.00 36.06           C  
+ATOM   1999  CE2 TYR A  74      50.243  58.587 117.974  1.00 38.19           C  
+ATOM   2000  CZ  TYR A  74      50.404  58.220 119.293  1.00 37.84           C  
+ATOM   2001  OH  TYR A  74      51.224  57.157 119.588  1.00 37.59           O  
+ATOM   2002  N   LEU A  75      50.083  63.622 117.149  1.00 43.44           N  
+ATOM   2003  CA  LEU A  75      51.455  63.857 116.717  1.00 42.57           C  
+ATOM   2004  C   LEU A  75      52.021  65.035 117.494  1.00 51.56           C  
+ATOM   2005  O   LEU A  75      53.220  65.086 117.770  1.00 53.44           O  
+ATOM   2006  CB  LEU A  75      51.530  64.108 115.211  1.00 40.71           C  
+ATOM   2007  CG  LEU A  75      51.177  62.909 114.323  1.00 43.24           C  
+ATOM   2008  CD1 LEU A  75      51.392  63.232 112.849  1.00 43.68           C  
+ATOM   2009  CD2 LEU A  75      51.896  61.624 114.718  1.00 39.79           C  
+ATOM   2010  N   LEU A  76      51.160  65.978 117.861  1.00 45.85           N  
+ATOM   2011  CA  LEU A  76      51.624  67.126 118.624  1.00 45.10           C  
+ATOM   2012  C   LEU A  76      51.888  66.672 120.057  1.00 53.55           C  
+ATOM   2013  O   LEU A  76      52.808  67.154 120.717  1.00 56.86           O  
+ATOM   2014  CB  LEU A  76      50.568  68.225 118.616  1.00 44.21           C  
+ATOM   2015  CG  LEU A  76      50.461  69.048 117.337  1.00 47.67           C  
+ATOM   2016  CD1 LEU A  76      49.169  69.863 117.350  1.00 45.22           C  
+ATOM   2017  CD2 LEU A  76      51.708  69.916 117.130  1.00 51.72           C  
+ATOM   2018  N   TYR A  77      51.059  65.745 120.529  1.00 47.82           N  
+ATOM   2019  CA  TYR A  77      51.177  65.189 121.870  1.00 45.06           C  
+ATOM   2020  C   TYR A  77      52.523  64.467 121.953  1.00 46.18           C  
+ATOM   2021  O   TYR A  77      53.253  64.601 122.935  1.00 46.10           O  
+ATOM   2022  CB  TYR A  77      49.993  64.248 122.159  1.00 44.09           C  
+ATOM   2023  CG  TYR A  77      50.258  63.269 123.284  1.00 42.14           C  
+ATOM   2024  CD1 TYR A  77      50.244  63.690 124.592  1.00 41.54           C  
+ATOM   2025  CD2 TYR A  77      50.536  61.928 123.030  1.00 43.10           C  
+ATOM   2026  CE1 TYR A  77      50.540  62.794 125.608  1.00 40.32           C  
+ATOM   2027  CE2 TYR A  77      50.834  61.041 124.040  1.00 43.16           C  
+ATOM   2028  CZ  TYR A  77      50.773  61.480 125.324  1.00 42.90           C  
+ATOM   2029  OH  TYR A  77      50.983  60.565 126.314  1.00 53.35           O  
+ATOM   2030  N   LEU A  78      52.871  63.761 120.884  1.00 41.93           N  
+ATOM   2031  CA  LEU A  78      54.141  63.049 120.812  1.00 41.68           C  
+ATOM   2032  C   LEU A  78      55.326  64.024 120.816  1.00 52.20           C  
+ATOM   2033  O   LEU A  78      56.361  63.750 121.422  1.00 54.52           O  
+ATOM   2034  CB  LEU A  78      54.188  62.181 119.549  1.00 40.32           C  
+ATOM   2035  CG  LEU A  78      53.253  60.984 119.379  1.00 41.03           C  
+ATOM   2036  CD1 LEU A  78      53.666  60.237 118.132  1.00 40.25           C  
+ATOM   2037  CD2 LEU A  78      53.331  60.054 120.563  1.00 43.10           C  
+ATOM   2038  N   GLN A  79      55.183  65.154 120.133  1.00 49.04           N  
+ATOM   2039  CA  GLN A  79      56.251  66.146 120.098  1.00 49.93           C  
+ATOM   2040  C   GLN A  79      56.409  66.823 121.451  1.00 55.10           C  
+ATOM   2041  O   GLN A  79      57.528  67.054 121.912  1.00 58.43           O  
+ATOM   2042  CB  GLN A  79      55.965  67.211 119.047  1.00 51.36           C  
+ATOM   2043  CG  GLN A  79      56.700  68.509 119.287  1.00 49.41           C  
+ATOM   2044  CD  GLN A  79      56.344  69.535 118.240  1.00 62.80           C  
+ATOM   2045  OE1 GLN A  79      55.223  70.033 118.224  1.00 72.41           O  
+ATOM   2046  NE2 GLN A  79      57.290  69.817 117.358  1.00 47.83           N  
+ATOM   2047  N   ALA A  80      55.282  67.157 122.066  1.00 46.30           N  
+ATOM   2048  CA  ALA A  80      55.263  67.804 123.372  1.00 45.65           C  
+ATOM   2049  C   ALA A  80      55.896  66.849 124.371  1.00 53.71           C  
+ATOM   2050  O   ALA A  80      56.406  67.250 125.416  1.00 55.54           O  
+ATOM   2051  CB  ALA A  80      53.833  68.104 123.776  1.00 46.37           C  
+ATOM   2052  N   ARG A  81      55.850  65.568 124.045  1.00 50.60           N  
+ATOM   2053  CA  ARG A  81      56.430  64.567 124.922  1.00 49.19           C  
+ATOM   2054  C   ARG A  81      57.944  64.585 124.751  1.00 49.18           C  
+ATOM   2055  O   ARG A  81      58.654  63.834 125.416  1.00 50.79           O  
+ATOM   2056  CB  ARG A  81      55.920  63.179 124.525  1.00 51.09           C  
+ATOM   2057  CG  ARG A  81      54.702  62.662 125.286  1.00 62.01           C  
+ATOM   2058  CD  ARG A  81      54.533  61.155 125.088  1.00 63.14           C  
+ATOM   2059  NE  ARG A  81      55.596  60.401 125.743  1.00 65.33           N  
+ATOM   2060  CZ  ARG A  81      56.054  59.228 125.325  1.00 80.44           C  
+ATOM   2061  NH1 ARG A  81      55.550  58.654 124.241  1.00 67.71           N  
+ATOM   2062  NH2 ARG A  81      57.027  58.635 125.996  1.00 80.33           N  
+ATOM   2063  N   GLY A  82      58.445  65.380 123.815  1.00 43.13           N  
+ATOM   2064  CA  GLY A  82      59.877  65.420 123.582  1.00 42.86           C  
+ATOM   2065  C   GLY A  82      60.395  64.201 122.829  1.00 51.19           C  
+ATOM   2066  O   GLY A  82      61.554  63.828 122.991  1.00 55.41           O  
+ATOM   2067  N   LEU A  83      59.575  63.590 121.981  1.00 45.81           N  
+ATOM   2068  CA  LEU A  83      60.069  62.441 121.230  1.00 46.05           C  
+ATOM   2069  C   LEU A  83      60.789  62.924 119.969  1.00 46.50           C  
+ATOM   2070  O   LEU A  83      60.547  64.028 119.488  1.00 46.65           O  
+ATOM   2071  CB  LEU A  83      58.936  61.467 120.886  1.00 47.57           C  
+ATOM   2072  CG  LEU A  83      58.319  60.549 121.952  1.00 52.74           C  
+ATOM   2073  CD1 LEU A  83      57.111  59.824 121.379  1.00 52.43           C  
+ATOM   2074  CD2 LEU A  83      59.351  59.536 122.422  1.00 54.47           C  
+ATOM   2075  N   ALA A  84      61.676  62.092 119.439  1.00 39.09           N  
+ATOM   2076  CA  ALA A  84      62.441  62.430 118.246  1.00 38.23           C  
+ATOM   2077  C   ALA A  84      61.604  62.507 116.973  1.00 47.67           C  
+ATOM   2078  O   ALA A  84      60.723  61.679 116.746  1.00 49.90           O  
+ATOM   2079  CB  ALA A  84      63.548  61.416 118.057  1.00 38.68           C  
+ATOM   2080  N   VAL A  85      61.915  63.465 116.112  1.00 45.65           N  
+ATOM   2081  CA  VAL A  85      61.175  63.564 114.861  1.00 46.83           C  
+ATOM   2082  C   VAL A  85      61.069  62.221 114.134  1.00 55.76           C  
+ATOM   2083  O   VAL A  85      60.123  61.981 113.386  1.00 57.98           O  
+ATOM   2084  CB  VAL A  85      61.826  64.558 113.899  1.00 49.94           C  
+ATOM   2085  CG1 VAL A  85      61.246  64.404 112.494  1.00 48.39           C  
+ATOM   2086  CG2 VAL A  85      61.664  65.979 114.423  1.00 50.15           C  
+ATOM   2087  N   LYS A  86      62.051  61.352 114.334  1.00 52.96           N  
+ATOM   2088  CA  LYS A  86      62.052  60.060 113.664  1.00 52.40           C  
+ATOM   2089  C   LYS A  86      61.137  59.096 114.389  1.00 57.29           C  
+ATOM   2090  O   LYS A  86      60.738  58.071 113.845  1.00 59.46           O  
+ATOM   2091  CB  LYS A  86      63.464  59.480 113.591  1.00 56.10           C  
+ATOM   2092  CG  LYS A  86      64.245  59.908 112.348  1.00 95.58           C  
+ATOM   2093  CD  LYS A  86      64.256  61.436 112.198  1.00100.00           C  
+ATOM   2094  CE  LYS A  86      65.315  61.935 111.214  1.00100.00           C  
+ATOM   2095  NZ  LYS A  86      65.224  63.410 110.978  1.00100.00           N  
+ATOM   2096  N   THR A  87      60.814  59.417 115.631  1.00 50.94           N  
+ATOM   2097  CA  THR A  87      59.941  58.562 116.402  1.00 49.32           C  
+ATOM   2098  C   THR A  87      58.509  58.922 116.054  1.00 54.77           C  
+ATOM   2099  O   THR A  87      57.678  58.038 115.823  1.00 57.71           O  
+ATOM   2100  CB  THR A  87      60.243  58.729 117.881  1.00 45.91           C  
+ATOM   2101  OG1 THR A  87      61.499  58.103 118.150  1.00 57.05           O  
+ATOM   2102  CG2 THR A  87      59.181  58.082 118.742  1.00 40.72           C  
+ATOM   2103  N   ILE A  88      58.227  60.219 115.943  1.00 45.51           N  
+ATOM   2104  CA  ILE A  88      56.888  60.642 115.559  1.00 44.46           C  
+ATOM   2105  C   ILE A  88      56.598  60.063 114.169  1.00 50.37           C  
+ATOM   2106  O   ILE A  88      55.488  59.642 113.868  1.00 48.79           O  
+ATOM   2107  CB  ILE A  88      56.758  62.171 115.561  1.00 46.76           C  
+ATOM   2108  CG1 ILE A  88      56.627  62.696 116.995  1.00 47.10           C  
+ATOM   2109  CG2 ILE A  88      55.602  62.614 114.684  1.00 45.46           C  
+ATOM   2110  CD1 ILE A  88      57.611  63.804 117.345  1.00 41.26           C  
+ATOM   2111  N   GLN A  89      57.633  59.997 113.345  1.00 50.45           N  
+ATOM   2112  CA  GLN A  89      57.518  59.418 112.016  1.00 51.00           C  
+ATOM   2113  C   GLN A  89      57.061  57.958 112.122  1.00 52.71           C  
+ATOM   2114  O   GLN A  89      56.145  57.536 111.416  1.00 52.61           O  
+ATOM   2115  CB  GLN A  89      58.877  59.487 111.309  1.00 53.33           C  
+ATOM   2116  CG  GLN A  89      58.848  60.182 109.945  1.00 66.88           C  
+ATOM   2117  CD  GLN A  89      60.003  61.156 109.745  1.00100.00           C  
+ATOM   2118  OE1 GLN A  89      59.793  62.357 109.505  1.00100.00           O  
+ATOM   2119  NE2 GLN A  89      61.232  60.651 109.772  1.00 94.79           N  
+ATOM   2120  N   GLN A  90      57.726  57.180 112.975  1.00 47.58           N  
+ATOM   2121  CA  GLN A  90      57.371  55.770 113.136  1.00 45.62           C  
+ATOM   2122  C   GLN A  90      55.890  55.625 113.495  1.00 47.41           C  
+ATOM   2123  O   GLN A  90      55.197  54.754 112.974  1.00 46.32           O  
+ATOM   2124  CB  GLN A  90      58.269  55.054 114.162  1.00 45.22           C  
+ATOM   2125  CG  GLN A  90      57.868  53.595 114.508  1.00 34.26           C  
+ATOM   2126  CD  GLN A  90      58.457  52.526 113.588  1.00 57.52           C  
+ATOM   2127  OE1 GLN A  90      59.615  52.127 113.725  1.00 58.01           O  
+ATOM   2128  NE2 GLN A  90      57.648  52.053 112.646  1.00 57.13           N  
+ATOM   2129  N   HIS A  91      55.404  56.472 114.394  1.00 40.24           N  
+ATOM   2130  CA  HIS A  91      54.012  56.384 114.792  1.00 39.04           C  
+ATOM   2131  C   HIS A  91      53.078  56.615 113.608  1.00 42.95           C  
+ATOM   2132  O   HIS A  91      52.335  55.717 113.221  1.00 42.20           O  
+ATOM   2133  CB  HIS A  91      53.733  57.354 115.932  1.00 39.75           C  
+ATOM   2134  CG  HIS A  91      54.209  56.860 117.265  1.00 43.98           C  
+ATOM   2135  ND1 HIS A  91      53.415  56.876 118.393  1.00 45.94           N  
+ATOM   2136  CD2 HIS A  91      55.399  56.343 117.651  1.00 43.40           C  
+ATOM   2137  CE1 HIS A  91      54.097  56.393 119.416  1.00 43.64           C  
+ATOM   2138  NE2 HIS A  91      55.301  56.053 118.991  1.00 42.96           N  
+ATOM   2139  N   LEU A  92      53.145  57.809 113.023  1.00 42.06           N  
+ATOM   2140  CA  LEU A  92      52.332  58.155 111.859  1.00 42.25           C  
+ATOM   2141  C   LEU A  92      52.489  57.017 110.864  1.00 47.73           C  
+ATOM   2142  O   LEU A  92      51.526  56.535 110.269  1.00 49.51           O  
+ATOM   2143  CB  LEU A  92      52.853  59.444 111.212  1.00 41.15           C  
+ATOM   2144  CG  LEU A  92      51.888  60.400 110.503  1.00 43.39           C  
+ATOM   2145  CD1 LEU A  92      52.672  61.374 109.638  1.00 40.45           C  
+ATOM   2146  CD2 LEU A  92      50.805  59.679 109.701  1.00 41.65           C  
+ATOM   2147  N   GLY A  93      53.732  56.588 110.696  1.00 41.61           N  
+ATOM   2148  CA  GLY A  93      54.065  55.524 109.767  1.00 38.81           C  
+ATOM   2149  C   GLY A  93      53.276  54.248 110.008  1.00 42.53           C  
+ATOM   2150  O   GLY A  93      52.679  53.708 109.084  1.00 42.42           O  
+ATOM   2151  N   GLN A  94      53.307  53.724 111.228  1.00 40.96           N  
+ATOM   2152  CA  GLN A  94      52.589  52.484 111.501  1.00 40.77           C  
+ATOM   2153  C   GLN A  94      51.079  52.713 111.336  1.00 46.31           C  
+ATOM   2154  O   GLN A  94      50.381  51.878 110.755  1.00 47.71           O  
+ATOM   2155  CB  GLN A  94      52.960  51.897 112.874  1.00 41.36           C  
+ATOM   2156  CG  GLN A  94      54.455  51.571 113.086  1.00 44.78           C  
+ATOM   2157  CD  GLN A  94      54.960  50.301 112.365  1.00 68.14           C  
+ATOM   2158  OE1 GLN A  94      54.207  49.606 111.695  1.00 59.17           O  
+ATOM   2159  NE2 GLN A  94      56.256  50.030 112.529  1.00 57.53           N  
+ATOM   2160  N   LEU A  95      50.582  53.855 111.808  1.00 38.85           N  
+ATOM   2161  CA  LEU A  95      49.163  54.182 111.658  1.00 37.09           C  
+ATOM   2162  C   LEU A  95      48.802  54.160 110.182  1.00 47.45           C  
+ATOM   2163  O   LEU A  95      47.846  53.504 109.782  1.00 47.77           O  
+ATOM   2164  CB  LEU A  95      48.840  55.548 112.250  1.00 35.65           C  
+ATOM   2165  CG  LEU A  95      48.672  55.470 113.766  1.00 40.41           C  
+ATOM   2166  CD1 LEU A  95      48.398  56.835 114.359  1.00 40.95           C  
+ATOM   2167  CD2 LEU A  95      47.593  54.473 114.156  1.00 43.95           C  
+ATOM   2168  N   ASN A  96      49.598  54.855 109.376  1.00 46.87           N  
+ATOM   2169  CA  ASN A  96      49.394  54.909 107.937  1.00 46.60           C  
+ATOM   2170  C   ASN A  96      49.299  53.503 107.340  1.00 54.25           C  
+ATOM   2171  O   ASN A  96      48.536  53.274 106.405  1.00 56.60           O  
+ATOM   2172  CB  ASN A  96      50.552  55.659 107.278  1.00 40.47           C  
+ATOM   2173  CG  ASN A  96      50.370  57.157 107.307  1.00 57.61           C  
+ATOM   2174  OD1 ASN A  96      49.270  57.665 107.508  1.00 48.08           O  
+ATOM   2175  ND2 ASN A  96      51.464  57.873 107.092  1.00 69.63           N  
+ATOM   2176  N   MET A  97      50.090  52.567 107.854  1.00 53.12           N  
+ATOM   2177  CA  MET A  97      50.075  51.194 107.347  1.00 55.33           C  
+ATOM   2178  C   MET A  97      48.828  50.453 107.843  1.00 57.76           C  
+ATOM   2179  O   MET A  97      48.134  49.776 107.080  1.00 57.08           O  
+ATOM   2180  CB  MET A  97      51.358  50.448 107.752  1.00 59.22           C  
+ATOM   2181  CG  MET A  97      51.123  49.147 108.532  1.00 65.02           C  
+ATOM   2182  SD  MET A  97      52.545  48.026 108.708  1.00 70.76           S  
+ATOM   2183  CE  MET A  97      51.802  46.447 108.216  1.00 66.41           C  
+ATOM   2184  N   LEU A  98      48.533  50.595 109.129  1.00 50.09           N  
+ATOM   2185  CA  LEU A  98      47.356  49.949 109.677  1.00 47.04           C  
+ATOM   2186  C   LEU A  98      46.156  50.308 108.801  1.00 51.44           C  
+ATOM   2187  O   LEU A  98      45.344  49.448 108.476  1.00 54.79           O  
+ATOM   2188  CB  LEU A  98      47.107  50.379 111.125  1.00 45.83           C  
+ATOM   2189  CG  LEU A  98      45.860  49.754 111.754  1.00 47.53           C  
+ATOM   2190  CD1 LEU A  98      45.919  48.236 111.727  1.00 46.95           C  
+ATOM   2191  CD2 LEU A  98      45.650  50.264 113.160  1.00 44.58           C  
+ATOM   2192  N   HIS A  99      46.041  51.566 108.395  1.00 45.21           N  
+ATOM   2193  CA  HIS A  99      44.899  51.994 107.587  1.00 45.75           C  
+ATOM   2194  C   HIS A  99      45.003  51.638 106.099  1.00 56.53           C  
+ATOM   2195  O   HIS A  99      43.993  51.372 105.419  1.00 55.52           O  
+ATOM   2196  CB  HIS A  99      44.666  53.519 107.763  1.00 46.40           C  
+ATOM   2197  CG  HIS A  99      44.298  53.933 109.160  1.00 51.82           C  
+ATOM   2198  ND1 HIS A  99      44.953  53.481 110.286  1.00 55.42           N  
+ATOM   2199  CD2 HIS A  99      43.337  54.776 109.613  1.00 55.81           C  
+ATOM   2200  CE1 HIS A  99      44.415  54.020 111.368  1.00 56.28           C  
+ATOM   2201  NE2 HIS A  99      43.433  54.815 110.985  1.00 56.69           N  
+ATOM   2202  N   ARG A 100      46.235  51.642 105.594  1.00 54.91           N  
+ATOM   2203  CA  ARG A 100      46.510  51.357 104.190  1.00 53.31           C  
+ATOM   2204  C   ARG A 100      46.214  49.891 103.895  1.00 60.71           C  
+ATOM   2205  O   ARG A 100      45.658  49.542 102.855  1.00 61.54           O  
+ATOM   2206  CB  ARG A 100      47.965  51.694 103.848  1.00 46.10           C  
+ATOM   2207  CG  ARG A 100      48.280  51.672 102.359  1.00 65.10           C  
+ATOM   2208  CD  ARG A 100      49.771  51.426 102.089  1.00 98.41           C  
+ATOM   2209  NE  ARG A 100      50.641  52.374 102.793  1.00100.00           N  
+ATOM   2210  CZ  ARG A 100      51.651  52.041 103.591  1.00100.00           C  
+ATOM   2211  NH1 ARG A 100      51.943  50.767 103.832  1.00 83.34           N  
+ATOM   2212  NH2 ARG A 100      52.355  52.997 104.191  1.00 87.09           N  
+ATOM   2213  N   ARG A 101      46.574  49.047 104.856  1.00 57.63           N  
+ATOM   2214  CA  ARG A 101      46.393  47.605 104.775  1.00 57.19           C  
+ATOM   2215  C   ARG A 101      45.102  47.174 105.414  1.00 65.96           C  
+ATOM   2216  O   ARG A 101      44.945  46.020 105.807  1.00 68.27           O  
+ATOM   2217  CB  ARG A 101      47.488  46.924 105.560  1.00 50.01           C  
+ATOM   2218  CG  ARG A 101      48.789  47.045 104.911  1.00 53.11           C  
+ATOM   2219  CD  ARG A 101      48.885  45.898 103.997  1.00 42.07           C  
+ATOM   2220  NE  ARG A 101      50.257  45.760 103.557  1.00 65.07           N  
+ATOM   2221  CZ  ARG A 101      50.585  45.349 102.342  1.00 69.15           C  
+ATOM   2222  NH1 ARG A 101      49.629  45.042 101.473  1.00 38.39           N  
+ATOM   2223  NH2 ARG A 101      51.860  45.235 101.988  1.00 48.85           N  
+ATOM   2224  N   SER A 102      44.169  48.097 105.555  1.00 59.14           N  
+ATOM   2225  CA  SER A 102      42.878  47.707 106.082  1.00 56.16           C  
+ATOM   2226  C   SER A 102      41.833  48.259 105.114  1.00 55.51           C  
+ATOM   2227  O   SER A 102      40.667  47.881 105.161  1.00 58.07           O  
+ATOM   2228  CB  SER A 102      42.654  48.064 107.555  1.00 54.17           C  
+ATOM   2229  OG  SER A 102      42.322  49.432 107.699  1.00 67.32           O  
+ATOM   2230  N   GLY A 103      42.253  49.147 104.219  1.00 43.27           N  
+ATOM   2231  CA  GLY A 103      41.347  49.667 103.202  1.00 40.70           C  
+ATOM   2232  C   GLY A 103      40.841  51.068 103.465  1.00 47.64           C  
+ATOM   2233  O   GLY A 103      40.094  51.630 102.656  1.00 47.35           O  
+ATOM   2234  N   LEU A 104      41.253  51.633 104.591  1.00 45.71           N  
+ATOM   2235  CA  LEU A 104      40.831  52.981 104.947  1.00 44.79           C  
+ATOM   2236  C   LEU A 104      41.841  54.031 104.467  1.00 50.37           C  
+ATOM   2237  O   LEU A 104      42.985  53.701 104.149  1.00 49.77           O  
+ATOM   2238  CB  LEU A 104      40.549  53.059 106.456  1.00 43.77           C  
+ATOM   2239  CG  LEU A 104      39.903  51.770 106.978  1.00 46.34           C  
+ATOM   2240  CD1 LEU A 104      39.663  51.731 108.482  1.00 46.38           C  
+ATOM   2241  CD2 LEU A 104      38.615  51.526 106.229  1.00 51.07           C  
+ATOM   2242  N   PRO A 105      41.422  55.285 104.365  1.00 48.18           N  
+ATOM   2243  CA  PRO A 105      42.364  56.291 103.917  1.00 49.22           C  
+ATOM   2244  C   PRO A 105      43.435  56.500 104.995  1.00 53.56           C  
+ATOM   2245  O   PRO A 105      43.136  56.455 106.194  1.00 51.62           O  
+ATOM   2246  CB  PRO A 105      41.496  57.546 103.769  1.00 50.17           C  
+ATOM   2247  CG  PRO A 105      40.244  57.290 104.546  1.00 51.33           C  
+ATOM   2248  CD  PRO A 105      40.295  55.895 105.093  1.00 47.05           C  
+ATOM   2249  N   ARG A 106      44.676  56.701 104.563  1.00 49.62           N  
+ATOM   2250  CA  ARG A 106      45.775  56.936 105.490  1.00 48.50           C  
+ATOM   2251  C   ARG A 106      45.651  58.344 106.036  1.00 53.42           C  
+ATOM   2252  O   ARG A 106      45.117  59.244 105.385  1.00 55.35           O  
+ATOM   2253  CB  ARG A 106      47.125  56.828 104.789  1.00 46.79           C  
+ATOM   2254  CG  ARG A 106      47.359  55.529 104.075  1.00 59.85           C  
+ATOM   2255  CD  ARG A 106      48.192  55.787 102.840  1.00 82.13           C  
+ATOM   2256  NE  ARG A 106      49.615  55.902 103.141  1.00 84.66           N  
+ATOM   2257  CZ  ARG A 106      50.284  57.051 103.194  1.00100.00           C  
+ATOM   2258  NH1 ARG A 106      49.660  58.206 102.962  1.00 92.24           N  
+ATOM   2259  NH2 ARG A 106      51.580  57.048 103.453  1.00 90.83           N  
+ATOM   2260  N   PRO A 107      46.151  58.523 107.249  1.00 47.32           N  
+ATOM   2261  CA  PRO A 107      46.121  59.828 107.900  1.00 46.47           C  
+ATOM   2262  C   PRO A 107      47.072  60.800 107.184  1.00 48.48           C  
+ATOM   2263  O   PRO A 107      46.805  61.996 107.083  1.00 45.13           O  
+ATOM   2264  CB  PRO A 107      46.605  59.512 109.321  1.00 48.37           C  
+ATOM   2265  CG  PRO A 107      46.270  58.067 109.524  1.00 51.45           C  
+ATOM   2266  CD  PRO A 107      46.449  57.423 108.184  1.00 46.44           C  
+ATOM   2267  N   SER A 108      48.169  60.261 106.663  1.00 47.54           N  
+ATOM   2268  CA  SER A 108      49.153  61.059 105.949  1.00 49.51           C  
+ATOM   2269  C   SER A 108      48.543  61.686 104.703  1.00 64.13           C  
+ATOM   2270  O   SER A 108      49.096  62.615 104.110  1.00 67.57           O  
+ATOM   2271  CB  SER A 108      50.341  60.179 105.598  1.00 51.42           C  
+ATOM   2272  OG  SER A 108      51.185  60.117 106.729  1.00 66.23           O  
+ATOM   2273  N   ASP A 109      47.372  61.191 104.330  1.00 61.63           N  
+ATOM   2274  CA  ASP A 109      46.703  61.708 103.153  1.00 61.77           C  
+ATOM   2275  C   ASP A 109      45.829  62.911 103.461  1.00 64.51           C  
+ATOM   2276  O   ASP A 109      45.094  63.384 102.595  1.00 68.60           O  
+ATOM   2277  CB  ASP A 109      45.888  60.608 102.472  1.00 64.95           C  
+ATOM   2278  CG  ASP A 109      46.762  59.501 101.904  1.00 78.27           C  
+ATOM   2279  OD1 ASP A 109      47.996  59.691 101.817  1.00 73.64           O  
+ATOM   2280  OD2 ASP A 109      46.215  58.436 101.547  1.00 92.35           O  
+ATOM   2281  N   SER A 110      45.912  63.413 104.685  1.00 55.31           N  
+ATOM   2282  CA  SER A 110      45.129  64.582 105.042  1.00 54.19           C  
+ATOM   2283  C   SER A 110      46.007  65.819 105.216  1.00 62.89           C  
+ATOM   2284  O   SER A 110      47.027  65.784 105.904  1.00 63.09           O  
+ATOM   2285  CB  SER A 110      44.347  64.319 106.320  1.00 53.18           C  
+ATOM   2286  OG  SER A 110      45.206  63.741 107.272  1.00 61.97           O  
+ATOM   2287  N   ASN A 111      45.592  66.909 104.576  1.00 61.52           N  
+ATOM   2288  CA  ASN A 111      46.286  68.191 104.660  1.00 59.69           C  
+ATOM   2289  C   ASN A 111      46.770  68.447 106.097  1.00 56.67           C  
+ATOM   2290  O   ASN A 111      47.970  68.596 106.329  1.00 54.45           O  
+ATOM   2291  CB  ASN A 111      45.358  69.312 104.182  1.00 55.78           C  
+ATOM   2292  CG  ASN A 111      46.093  70.590 103.869  1.00 57.24           C  
+ATOM   2293  OD1 ASN A 111      47.082  70.597 103.131  1.00 65.99           O  
+ATOM   2294  ND2 ASN A 111      45.610  71.690 104.435  1.00 45.77           N  
+ATOM   2295  N   ALA A 112      45.850  68.469 107.056  1.00 52.27           N  
+ATOM   2296  CA  ALA A 112      46.221  68.710 108.448  1.00 52.84           C  
+ATOM   2297  C   ALA A 112      47.322  67.806 108.999  1.00 54.01           C  
+ATOM   2298  O   ALA A 112      48.167  68.257 109.768  1.00 53.60           O  
+ATOM   2299  CB  ALA A 112      44.997  68.675 109.346  1.00 54.24           C  
+ATOM   2300  N   VAL A 113      47.319  66.533 108.624  1.00 50.35           N  
+ATOM   2301  CA  VAL A 113      48.357  65.623 109.103  1.00 50.34           C  
+ATOM   2302  C   VAL A 113      49.692  65.864 108.390  1.00 56.64           C  
+ATOM   2303  O   VAL A 113      50.754  65.779 109.004  1.00 56.49           O  
+ATOM   2304  CB  VAL A 113      47.953  64.144 108.964  1.00 51.11           C  
+ATOM   2305  CG1 VAL A 113      49.188  63.271 108.918  1.00 49.81           C  
+ATOM   2306  CG2 VAL A 113      47.047  63.727 110.113  1.00 49.95           C  
+ATOM   2307  N   SER A 114      49.624  66.189 107.099  1.00 53.62           N  
+ATOM   2308  CA  SER A 114      50.809  66.475 106.295  1.00 54.10           C  
+ATOM   2309  C   SER A 114      51.481  67.761 106.776  1.00 56.68           C  
+ATOM   2310  O   SER A 114      52.698  67.820 106.958  1.00 55.50           O  
+ATOM   2311  CB  SER A 114      50.424  66.625 104.820  1.00 59.42           C  
+ATOM   2312  OG  SER A 114      49.356  65.765 104.475  1.00 73.84           O  
+ATOM   2313  N   LEU A 115      50.671  68.796 106.977  1.00 52.47           N  
+ATOM   2314  CA  LEU A 115      51.153  70.088 107.445  1.00 52.08           C  
+ATOM   2315  C   LEU A 115      51.808  70.018 108.824  1.00 51.89           C  
+ATOM   2316  O   LEU A 115      52.881  70.576 109.038  1.00 50.57           O  
+ATOM   2317  CB  LEU A 115      50.003  71.099 107.478  1.00 52.84           C  
+ATOM   2318  CG  LEU A 115      49.529  71.638 106.129  1.00 58.65           C  
+ATOM   2319  CD1 LEU A 115      48.389  72.620 106.342  1.00 58.07           C  
+ATOM   2320  CD2 LEU A 115      50.673  72.279 105.345  1.00 62.83           C  
+ATOM   2321  N   VAL A 116      51.146  69.360 109.770  1.00 48.07           N  
+ATOM   2322  CA  VAL A 116      51.685  69.261 111.121  1.00 48.94           C  
+ATOM   2323  C   VAL A 116      53.018  68.515 111.244  1.00 52.27           C  
+ATOM   2324  O   VAL A 116      53.898  68.935 111.993  1.00 51.28           O  
+ATOM   2325  CB  VAL A 116      50.626  68.771 112.127  1.00 52.99           C  
+ATOM   2326  CG1 VAL A 116      50.487  67.256 112.080  1.00 52.76           C  
+ATOM   2327  CG2 VAL A 116      50.929  69.282 113.532  1.00 51.80           C  
+ATOM   2328  N   MET A 117      53.174  67.440 110.474  1.00 49.04           N  
+ATOM   2329  CA  MET A 117      54.402  66.637 110.428  1.00 48.06           C  
+ATOM   2330  C   MET A 117      55.549  67.542 109.942  1.00 52.12           C  
+ATOM   2331  O   MET A 117      56.643  67.555 110.511  1.00 50.64           O  
+ATOM   2332  CB  MET A 117      54.181  65.475 109.446  1.00 48.91           C  
+ATOM   2333  CG  MET A 117      54.711  64.118 109.856  1.00 50.70           C  
+ATOM   2334  SD  MET A 117      54.926  63.931 111.619  1.00 53.90           S  
+ATOM   2335  CE  MET A 117      56.447  62.976 111.664  1.00 51.19           C  
+ATOM   2336  N   ARG A 118      55.256  68.319 108.902  1.00 49.31           N  
+ATOM   2337  CA  ARG A 118      56.197  69.275 108.326  1.00 48.52           C  
+ATOM   2338  C   ARG A 118      56.634  70.292 109.370  1.00 52.72           C  
+ATOM   2339  O   ARG A 118      57.822  70.501 109.591  1.00 54.84           O  
+ATOM   2340  CB  ARG A 118      55.510  70.029 107.185  1.00 48.15           C  
+ATOM   2341  CG  ARG A 118      56.438  70.591 106.119  1.00 54.75           C  
+ATOM   2342  CD  ARG A 118      55.641  70.948 104.873  1.00 56.79           C  
+ATOM   2343  NE  ARG A 118      56.279  71.993 104.076  1.00 59.18           N  
+ATOM   2344  CZ  ARG A 118      55.649  72.712 103.150  1.00 70.96           C  
+ATOM   2345  NH1 ARG A 118      54.367  72.500 102.900  1.00 62.60           N  
+ATOM   2346  NH2 ARG A 118      56.294  73.647 102.466  1.00 56.60           N  
+ATOM   2347  N   ARG A 119      55.667  70.962 109.981  1.00 49.85           N  
+ATOM   2348  CA  ARG A 119      55.974  71.968 110.983  1.00 51.24           C  
+ATOM   2349  C   ARG A 119      56.809  71.371 112.100  1.00 54.09           C  
+ATOM   2350  O   ARG A 119      57.880  71.887 112.427  1.00 50.10           O  
+ATOM   2351  CB  ARG A 119      54.676  72.531 111.560  1.00 54.12           C  
+ATOM   2352  CG  ARG A 119      54.682  72.662 113.069  1.00 59.75           C  
+ATOM   2353  CD  ARG A 119      53.589  73.597 113.562  1.00 63.74           C  
+ATOM   2354  NE  ARG A 119      53.321  73.362 114.977  1.00 77.12           N  
+ATOM   2355  CZ  ARG A 119      52.187  73.670 115.598  1.00 94.76           C  
+ATOM   2356  NH1 ARG A 119      51.189  74.237 114.931  1.00 75.82           N  
+ATOM   2357  NH2 ARG A 119      52.049  73.409 116.890  1.00 85.02           N  
+ATOM   2358  N   ILE A 120      56.279  70.293 112.680  1.00 54.54           N  
+ATOM   2359  CA  ILE A 120      56.893  69.536 113.776  1.00 53.83           C  
+ATOM   2360  C   ILE A 120      58.329  69.186 113.433  1.00 58.03           C  
+ATOM   2361  O   ILE A 120      59.244  69.363 114.237  1.00 57.96           O  
+ATOM   2362  CB  ILE A 120      56.125  68.226 114.058  1.00 54.65           C  
+ATOM   2363  CG1 ILE A 120      55.064  68.451 115.138  1.00 53.21           C  
+ATOM   2364  CG2 ILE A 120      57.086  67.111 114.440  1.00 52.97           C  
+ATOM   2365  CD1 ILE A 120      54.292  67.207 115.507  1.00 52.44           C  
+ATOM   2366  N   ARG A 121      58.524  68.707 112.214  1.00 54.33           N  
+ATOM   2367  CA  ARG A 121      59.857  68.382 111.752  1.00 55.61           C  
+ATOM   2368  C   ARG A 121      60.687  69.673 111.780  1.00 62.54           C  
+ATOM   2369  O   ARG A 121      61.780  69.698 112.348  1.00 61.24           O  
+ATOM   2370  CB  ARG A 121      59.753  67.820 110.335  1.00 57.87           C  
+ATOM   2371  CG  ARG A 121      61.056  67.686 109.582  1.00 68.07           C  
+ATOM   2372  CD  ARG A 121      60.839  66.883 108.309  1.00 70.94           C  
+ATOM   2373  NE  ARG A 121      61.220  65.488 108.494  1.00 82.44           N  
+ATOM   2374  CZ  ARG A 121      62.460  65.094 108.780  1.00100.00           C  
+ATOM   2375  NH1 ARG A 121      63.427  65.994 108.894  1.00 96.48           N  
+ATOM   2376  NH2 ARG A 121      62.730  63.805 108.893  1.00100.00           N  
+ATOM   2377  N   LYS A 122      60.146  70.749 111.202  1.00 61.39           N  
+ATOM   2378  CA  LYS A 122      60.808  72.052 111.148  1.00 60.11           C  
+ATOM   2379  C   LYS A 122      61.140  72.569 112.542  1.00 60.81           C  
+ATOM   2380  O   LYS A 122      62.264  73.007 112.787  1.00 58.43           O  
+ATOM   2381  CB  LYS A 122      59.930  73.073 110.397  1.00 63.42           C  
+ATOM   2382  CG  LYS A 122      60.341  74.550 110.547  1.00 80.18           C  
+ATOM   2383  CD  LYS A 122      59.648  75.459 109.521  1.00 73.17           C  
+ATOM   2384  CE  LYS A 122      59.502  76.915 109.984  1.00 65.19           C  
+ATOM   2385  NZ  LYS A 122      58.552  77.117 111.134  1.00 74.07           N  
+ATOM   2386  N   GLU A 123      60.167  72.510 113.449  1.00 57.46           N  
+ATOM   2387  CA  GLU A 123      60.353  72.988 114.816  1.00 56.19           C  
+ATOM   2388  C   GLU A 123      61.446  72.240 115.588  1.00 60.79           C  
+ATOM   2389  O   GLU A 123      62.150  72.843 116.396  1.00 62.87           O  
+ATOM   2390  CB  GLU A 123      59.033  72.935 115.601  1.00 56.95           C  
+ATOM   2391  CG  GLU A 123      57.799  73.382 114.827  1.00 61.85           C  
+ATOM   2392  CD  GLU A 123      56.695  73.891 115.739  1.00 69.06           C  
+ATOM   2393  OE1 GLU A 123      56.337  73.184 116.704  1.00 67.10           O  
+ATOM   2394  OE2 GLU A 123      56.188  75.007 115.495  1.00 58.60           O  
+ATOM   2395  N   ASN A 124      61.548  70.937 115.367  1.00 55.24           N  
+ATOM   2396  CA  ASN A 124      62.501  70.073 116.068  1.00 54.88           C  
+ATOM   2397  C   ASN A 124      63.968  70.226 115.667  1.00 59.79           C  
+ATOM   2398  O   ASN A 124      64.865  70.311 116.507  1.00 60.48           O  
+ATOM   2399  CB  ASN A 124      62.045  68.623 115.969  1.00 51.31           C  
+ATOM   2400  CG  ASN A 124      61.069  68.245 117.050  1.00 62.50           C  
+ATOM   2401  OD1 ASN A 124      60.223  69.050 117.435  1.00 55.06           O  
+ATOM   2402  ND2 ASN A 124      61.196  67.034 117.560  1.00 58.59           N  
+ATOM   2403  N   VAL A 125      64.182  70.233 114.362  1.00 56.75           N  
+ATOM   2404  CA  VAL A 125      65.504  70.415 113.756  1.00 56.52           C  
+ATOM   2405  C   VAL A 125      66.130  71.716 114.347  1.00 66.07           C  
+ATOM   2406  O   VAL A 125      67.347  71.811 114.522  1.00 68.69           O  
+ATOM   2407  CB  VAL A 125      65.368  70.440 112.201  1.00 58.41           C  
+ATOM   2408  CG1 VAL A 125      66.643  70.926 111.568  1.00 58.12           C  
+ATOM   2409  CG2 VAL A 125      64.980  69.052 111.655  1.00 57.38           C  
+ATOM   2410  N   ASP A 126      65.278  72.694 114.696  1.00 60.85           N  
+ATOM   2411  CA  ASP A 126      65.535  74.050 115.261  1.00 60.20           C  
+ATOM   2412  C   ASP A 126      65.463  74.162 116.783  1.00 69.09           C  
+ATOM   2413  O   ASP A 126      65.095  75.217 117.323  1.00 71.29           O  
+ATOM   2414  CB  ASP A 126      64.443  75.031 114.812  1.00 62.16           C  
+ATOM   2415  CG  ASP A 126      64.792  75.767 113.536  1.00 85.81           C  
+ATOM   2416  OD1 ASP A 126      65.978  75.739 113.135  1.00 90.05           O  
+ATOM   2417  OD2 ASP A 126      63.865  76.362 112.934  1.00 88.44           O  
+ATOM   2418  N   ALA A 127      65.709  73.056 117.458  1.00 65.12           N  
+ATOM   2419  CA  ALA A 127      65.693  73.041 118.916  1.00 63.76           C  
+ATOM   2420  C   ALA A 127      66.970  72.283 119.164  1.00 66.17           C  
+ATOM   2421  O   ALA A 127      67.368  72.071 120.298  1.00 65.24           O  
+ATOM   2422  CB  ALA A 127      64.494  72.260 119.407  1.00 64.94           C  
+ATOM   2423  N   GLY A 128      67.588  71.900 118.049  1.00 66.14           N  
+ATOM   2424  CA  GLY A 128      68.851  71.192 118.041  1.00 68.85           C  
+ATOM   2425  C   GLY A 128      68.736  69.687 117.859  1.00 77.18           C  
+ATOM   2426  O   GLY A 128      69.668  68.948 118.174  1.00 76.53           O  
+ATOM   2427  N   GLU A 129      67.616  69.223 117.319  1.00 76.39           N  
+ATOM   2428  CA  GLU A 129      67.460  67.787 117.127  1.00 76.08           C  
+ATOM   2429  C   GLU A 129      68.674  67.066 116.545  1.00 78.87           C  
+ATOM   2430  O   GLU A 129      69.015  67.217 115.366  1.00 78.50           O  
+ATOM   2431  CB  GLU A 129      66.158  67.398 116.425  1.00 77.70           C  
+ATOM   2432  CG  GLU A 129      65.937  65.891 116.461  1.00 84.59           C  
+ATOM   2433  CD  GLU A 129      64.513  65.478 116.772  1.00 84.75           C  
+ATOM   2434  OE1 GLU A 129      64.054  65.644 117.925  1.00 56.48           O  
+ATOM   2435  OE2 GLU A 129      63.861  64.963 115.843  1.00 70.06           O  
+ATOM   2436  N   ARG A 130      69.309  66.264 117.396  1.00 73.32           N  
+ATOM   2437  CA  ARG A 130      70.490  65.506 117.006  1.00 71.71           C  
+ATOM   2438  C   ARG A 130      70.302  64.022 116.747  1.00 68.19           C  
+ATOM   2439  O   ARG A 130      70.006  63.253 117.654  1.00 68.17           O  
+ATOM   2440  CB  ARG A 130      71.596  65.685 118.038  1.00 74.75           C  
+ATOM   2441  CG  ARG A 130      71.994  67.124 118.178  1.00 70.55           C  
+ATOM   2442  CD  ARG A 130      72.382  67.650 116.819  1.00 53.81           C  
+ATOM   2443  NE  ARG A 130      73.705  68.252 116.898  1.00 84.64           N  
+ATOM   2444  CZ  ARG A 130      73.924  69.498 117.305  1.00100.00           C  
+ATOM   2445  NH1 ARG A 130      72.901  70.276 117.640  1.00 83.55           N  
+ATOM   2446  NH2 ARG A 130      75.162  69.974 117.357  1.00 97.88           N  
+ATOM   2447  N   ALA A 131      70.551  63.609 115.511  1.00 60.26           N  
+ATOM   2448  CA  ALA A 131      70.470  62.186 115.208  1.00 59.35           C  
+ATOM   2449  C   ALA A 131      71.749  61.569 115.781  1.00 65.69           C  
+ATOM   2450  O   ALA A 131      72.850  61.959 115.401  1.00 69.37           O  
+ATOM   2451  CB  ALA A 131      70.390  61.961 113.710  1.00 59.65           C  
+ATOM   2452  N   LYS A 132      71.617  60.645 116.728  1.00 59.72           N  
+ATOM   2453  CA  LYS A 132      72.785  60.035 117.363  1.00 58.77           C  
+ATOM   2454  C   LYS A 132      73.268  58.772 116.627  1.00 65.41           C  
+ATOM   2455  O   LYS A 132      72.524  58.210 115.826  1.00 65.41           O  
+ATOM   2456  CB  LYS A 132      72.468  59.734 118.836  1.00 60.38           C  
+ATOM   2457  CG  LYS A 132      71.619  60.802 119.538  1.00 67.99           C  
+ATOM   2458  CD  LYS A 132      72.450  61.648 120.504  1.00 78.35           C  
+ATOM   2459  CE  LYS A 132      72.066  61.417 121.967  1.00 75.14           C  
+ATOM   2460  NZ  LYS A 132      73.254  61.397 122.881  1.00 76.96           N  
+ATOM   2461  N   GLN A 133      74.515  58.354 116.872  1.00 63.63           N  
+ATOM   2462  CA  GLN A 133      75.119  57.134 116.311  1.00 62.99           C  
+ATOM   2463  C   GLN A 133      75.965  56.543 117.438  1.00 68.07           C  
+ATOM   2464  O   GLN A 133      76.282  57.229 118.406  1.00 70.14           O  
+ATOM   2465  CB  GLN A 133      75.997  57.373 115.057  1.00 64.39           C  
+ATOM   2466  CG  GLN A 133      76.707  58.736 114.886  1.00 70.73           C  
+ATOM   2467  CD  GLN A 133      78.186  58.624 114.491  1.00100.00           C  
+ATOM   2468  OE1 GLN A 133      78.954  57.866 115.094  1.00100.00           O  
+ATOM   2469  NE2 GLN A 133      78.610  59.377 113.481  1.00100.00           N  
+ATOM   2470  N   ALA A 134      76.315  55.268 117.324  1.00 63.49           N  
+ATOM   2471  CA  ALA A 134      77.103  54.574 118.344  1.00 62.53           C  
+ATOM   2472  C   ALA A 134      78.458  55.191 118.706  1.00 65.00           C  
+ATOM   2473  O   ALA A 134      79.174  55.707 117.839  1.00 64.33           O  
+ATOM   2474  CB  ALA A 134      77.281  53.099 117.966  1.00 62.52           C  
+ATOM   2475  N   LEU A 135      78.815  55.102 119.988  1.00 58.87           N  
+ATOM   2476  CA  LEU A 135      80.095  55.601 120.483  1.00 57.27           C  
+ATOM   2477  C   LEU A 135      81.168  54.698 119.884  1.00 54.34           C  
+ATOM   2478  O   LEU A 135      81.084  53.479 120.000  1.00 52.03           O  
+ATOM   2479  CB  LEU A 135      80.128  55.491 122.003  1.00 58.14           C  
+ATOM   2480  CG  LEU A 135      80.883  56.554 122.801  1.00 64.20           C  
+ATOM   2481  CD1 LEU A 135      81.079  56.031 124.210  1.00 65.52           C  
+ATOM   2482  CD2 LEU A 135      82.233  56.851 122.156  1.00 64.04           C  
+ATOM   2483  N   ALA A 136      82.156  55.270 119.205  1.00 46.97           N  
+ATOM   2484  CA  ALA A 136      83.133  54.404 118.566  1.00 45.72           C  
+ATOM   2485  C   ALA A 136      83.851  53.480 119.519  1.00 51.20           C  
+ATOM   2486  O   ALA A 136      84.023  53.792 120.694  1.00 52.11           O  
+ATOM   2487  CB  ALA A 136      84.121  55.191 117.740  1.00 46.26           C  
+ATOM   2488  N   PHE A 137      84.251  52.330 118.995  1.00 48.69           N  
+ATOM   2489  CA  PHE A 137      85.040  51.363 119.740  1.00 48.67           C  
+ATOM   2490  C   PHE A 137      86.143  51.096 118.738  1.00 54.82           C  
+ATOM   2491  O   PHE A 137      86.031  50.224 117.877  1.00 53.82           O  
+ATOM   2492  CB  PHE A 137      84.270  50.087 120.050  1.00 50.15           C  
+ATOM   2493  CG  PHE A 137      85.097  49.056 120.749  1.00 52.17           C  
+ATOM   2494  CD1 PHE A 137      85.394  49.194 122.097  1.00 55.36           C  
+ATOM   2495  CD2 PHE A 137      85.600  47.967 120.056  1.00 54.38           C  
+ATOM   2496  CE1 PHE A 137      86.173  48.258 122.750  1.00 55.57           C  
+ATOM   2497  CE2 PHE A 137      86.382  47.030 120.698  1.00 57.29           C  
+ATOM   2498  CZ  PHE A 137      86.664  47.172 122.048  1.00 55.36           C  
+ATOM   2499  N   GLU A 138      87.165  51.940 118.807  1.00 55.13           N  
+ATOM   2500  CA  GLU A 138      88.281  51.892 117.883  1.00 55.86           C  
+ATOM   2501  C   GLU A 138      89.449  51.077 118.442  1.00 68.79           C  
+ATOM   2502  O   GLU A 138      89.431  50.672 119.607  1.00 71.40           O  
+ATOM   2503  CB  GLU A 138      88.704  53.321 117.525  1.00 56.47           C  
+ATOM   2504  CG  GLU A 138      87.614  54.378 117.703  1.00 58.89           C  
+ATOM   2505  CD  GLU A 138      87.728  55.496 116.683  1.00 78.79           C  
+ATOM   2506  OE1 GLU A 138      87.309  55.279 115.532  1.00 88.71           O  
+ATOM   2507  OE2 GLU A 138      88.247  56.585 117.019  1.00 76.12           O  
+ATOM   2508  N   ARG A 139      90.444  50.823 117.593  1.00 66.45           N  
+ATOM   2509  CA  ARG A 139      91.628  50.056 117.970  1.00 66.15           C  
+ATOM   2510  C   ARG A 139      92.241  50.528 119.283  1.00 72.30           C  
+ATOM   2511  O   ARG A 139      92.669  49.716 120.106  1.00 73.25           O  
+ATOM   2512  CB  ARG A 139      92.694  50.123 116.883  1.00 61.45           C  
+ATOM   2513  CG  ARG A 139      94.076  49.853 117.431  1.00 58.79           C  
+ATOM   2514  CD  ARG A 139      94.736  48.715 116.696  1.00 69.77           C  
+ATOM   2515  NE  ARG A 139      94.261  47.411 117.141  1.00 89.57           N  
+ATOM   2516  CZ  ARG A 139      94.527  46.271 116.515  1.00100.00           C  
+ATOM   2517  NH1 ARG A 139      95.277  46.278 115.417  1.00 93.14           N  
+ATOM   2518  NH2 ARG A 139      94.069  45.121 116.995  1.00100.00           N  
+ATOM   2519  N   THR A 140      92.311  51.841 119.472  1.00 67.78           N  
+ATOM   2520  CA  THR A 140      92.884  52.359 120.704  1.00 67.80           C  
+ATOM   2521  C   THR A 140      92.074  51.747 121.833  1.00 71.18           C  
+ATOM   2522  O   THR A 140      92.587  51.478 122.917  1.00 71.46           O  
+ATOM   2523  CB  THR A 140      92.754  53.884 120.793  1.00 81.42           C  
+ATOM   2524  OG1 THR A 140      91.450  54.216 121.286  1.00 79.19           O  
+ATOM   2525  CG2 THR A 140      92.951  54.514 119.426  1.00 87.48           C  
+ATOM   2526  N   ASP A 141      90.795  51.520 121.559  1.00 66.11           N  
+ATOM   2527  CA  ASP A 141      89.892  50.946 122.549  1.00 64.23           C  
+ATOM   2528  C   ASP A 141      90.085  49.441 122.759  1.00 67.65           C  
+ATOM   2529  O   ASP A 141      90.100  48.949 123.887  1.00 66.12           O  
+ATOM   2530  CB  ASP A 141      88.443  51.311 122.216  1.00 65.27           C  
+ATOM   2531  CG  ASP A 141      88.157  52.795 122.409  1.00 76.59           C  
+ATOM   2532  OD1 ASP A 141      88.168  53.258 123.570  1.00 80.80           O  
+ATOM   2533  OD2 ASP A 141      87.909  53.499 121.406  1.00 73.65           O  
+ATOM   2534  N   PHE A 142      90.265  48.726 121.655  1.00 65.19           N  
+ATOM   2535  CA  PHE A 142      90.472  47.281 121.664  1.00 66.11           C  
+ATOM   2536  C   PHE A 142      91.790  46.911 122.349  1.00 75.19           C  
+ATOM   2537  O   PHE A 142      91.828  46.009 123.187  1.00 76.09           O  
+ATOM   2538  CB  PHE A 142      90.438  46.771 120.221  1.00 67.46           C  
+ATOM   2539  CG  PHE A 142      90.406  45.272 120.093  1.00 69.13           C  
+ATOM   2540  CD1 PHE A 142      89.600  44.485 120.907  1.00 70.60           C  
+ATOM   2541  CD2 PHE A 142      91.185  44.644 119.131  1.00 71.74           C  
+ATOM   2542  CE1 PHE A 142      89.583  43.099 120.766  1.00 70.81           C  
+ATOM   2543  CE2 PHE A 142      91.169  43.266 118.980  1.00 72.95           C  
+ATOM   2544  CZ  PHE A 142      90.372  42.491 119.802  1.00 70.03           C  
+ATOM   2545  N   ASP A 143      92.860  47.627 122.013  1.00 72.86           N  
+ATOM   2546  CA  ASP A 143      94.175  47.388 122.603  1.00 71.94           C  
+ATOM   2547  C   ASP A 143      94.137  47.565 124.108  1.00 71.15           C  
+ATOM   2548  O   ASP A 143      94.597  46.711 124.865  1.00 70.10           O  
+ATOM   2549  CB  ASP A 143      95.185  48.371 122.022  1.00 74.95           C  
+ATOM   2550  CG  ASP A 143      95.737  47.909 120.696  1.00 91.23           C  
+ATOM   2551  OD1 ASP A 143      95.521  46.734 120.329  1.00 90.82           O  
+ATOM   2552  OD2 ASP A 143      96.390  48.724 120.015  1.00100.00           O  
+ATOM   2553  N   GLN A 144      93.594  48.705 124.520  1.00 66.07           N  
+ATOM   2554  CA  GLN A 144      93.479  49.042 125.929  1.00 64.61           C  
+ATOM   2555  C   GLN A 144      92.645  48.018 126.679  1.00 70.50           C  
+ATOM   2556  O   GLN A 144      92.923  47.702 127.837  1.00 71.88           O  
+ATOM   2557  CB  GLN A 144      92.835  50.408 126.123  1.00 64.30           C  
+ATOM   2558  CG  GLN A 144      92.393  50.601 127.563  1.00 63.41           C  
+ATOM   2559  CD  GLN A 144      92.028  52.024 127.880  1.00 98.81           C  
+ATOM   2560  OE1 GLN A 144      91.518  52.308 128.969  1.00100.00           O  
+ATOM   2561  NE2 GLN A 144      92.241  52.932 126.940  1.00 98.25           N  
+ATOM   2562  N   VAL A 145      91.586  47.538 126.036  1.00 66.77           N  
+ATOM   2563  CA  VAL A 145      90.715  46.552 126.660  1.00 66.13           C  
+ATOM   2564  C   VAL A 145      91.506  45.264 126.651  1.00 69.86           C  
+ATOM   2565  O   VAL A 145      91.619  44.580 127.669  1.00 67.95           O  
+ATOM   2566  CB  VAL A 145      89.400  46.371 125.875  1.00 69.21           C  
+ATOM   2567  CG1 VAL A 145      88.551  45.267 126.486  1.00 68.39           C  
+ATOM   2568  CG2 VAL A 145      88.619  47.668 125.878  1.00 69.17           C  
+ATOM   2569  N   ARG A 146      92.082  44.974 125.492  1.00 69.63           N  
+ATOM   2570  CA  ARG A 146      92.921  43.800 125.313  1.00 71.09           C  
+ATOM   2571  C   ARG A 146      93.999  43.823 126.399  1.00 78.99           C  
+ATOM   2572  O   ARG A 146      94.375  42.784 126.936  1.00 78.98           O  
+ATOM   2573  CB  ARG A 146      93.593  43.895 123.945  1.00 72.38           C  
+ATOM   2574  CG  ARG A 146      93.514  42.645 123.101  1.00 82.04           C  
+ATOM   2575  CD  ARG A 146      94.803  42.475 122.314  1.00 93.87           C  
+ATOM   2576  NE  ARG A 146      94.729  43.113 121.005  1.00 95.46           N  
+ATOM   2577  CZ  ARG A 146      94.277  42.502 119.917  1.00100.00           C  
+ATOM   2578  NH1 ARG A 146      93.855  41.245 119.997  1.00 95.43           N  
+ATOM   2579  NH2 ARG A 146      94.226  43.144 118.757  1.00 92.74           N  
+ATOM   2580  N   SER A 147      94.502  45.014 126.715  1.00 77.08           N  
+ATOM   2581  CA  SER A 147      95.536  45.155 127.731  1.00 78.29           C  
+ATOM   2582  C   SER A 147      95.053  44.755 129.127  1.00 87.03           C  
+ATOM   2583  O   SER A 147      95.711  43.972 129.811  1.00 89.64           O  
+ATOM   2584  CB  SER A 147      96.094  46.577 127.741  1.00 82.13           C  
+ATOM   2585  OG  SER A 147      96.084  47.109 129.055  1.00 93.44           O  
+ATOM   2586  N   LEU A 148      93.901  45.285 129.529  1.00 83.44           N  
+ATOM   2587  CA  LEU A 148      93.302  44.996 130.825  1.00 83.78           C  
+ATOM   2588  C   LEU A 148      92.676  43.612 130.910  1.00 89.75           C  
+ATOM   2589  O   LEU A 148      92.116  43.265 131.947  1.00 92.06           O  
+ATOM   2590  CB  LEU A 148      92.194  46.004 131.113  1.00 84.14           C  
+ATOM   2591  CG  LEU A 148      92.659  47.219 131.906  1.00 90.35           C  
+ATOM   2592  CD1 LEU A 148      91.940  48.465 131.426  1.00 91.72           C  
+ATOM   2593  CD2 LEU A 148      92.409  46.991 133.387  1.00 94.83           C  
+ATOM   2594  N   MET A 149      92.731  42.821 129.842  1.00 85.71           N  
+ATOM   2595  CA  MET A 149      92.097  41.505 129.910  1.00 86.03           C  
+ATOM   2596  C   MET A 149      92.792  40.223 129.429  1.00 90.40           C  
+ATOM   2597  O   MET A 149      92.582  39.164 130.017  1.00 90.04           O  
+ATOM   2598  CB  MET A 149      90.641  41.568 129.418  1.00 88.97           C  
+ATOM   2599  CG  MET A 149      89.830  42.764 129.943  1.00 93.89           C  
+ATOM   2600  SD  MET A 149      88.254  43.139 129.100  1.00 99.07           S  
+ATOM   2601  CE  MET A 149      87.727  41.523 128.589  1.00 95.71           C  
+ATOM   2602  N   GLU A 150      93.578  40.293 128.356  1.00 88.40           N  
+ATOM   2603  CA  GLU A 150      94.254  39.111 127.812  1.00 88.92           C  
+ATOM   2604  C   GLU A 150      94.974  38.300 128.887  1.00 94.32           C  
+ATOM   2605  O   GLU A 150      95.332  37.140 128.678  1.00 94.70           O  
+ATOM   2606  CB  GLU A 150      95.208  39.506 126.692  1.00 89.75           C  
+ATOM   2607  CG  GLU A 150      96.130  40.614 127.108  1.00 93.92           C  
+ATOM   2608  CD  GLU A 150      96.887  41.166 125.939  1.00100.00           C  
+ATOM   2609  OE1 GLU A 150      96.618  40.720 124.807  1.00 91.46           O  
+ATOM   2610  OE2 GLU A 150      97.764  42.028 126.149  1.00 90.39           O  
+ATOM   2611  N   ASN A 151      95.169  38.905 130.048  1.00 89.43           N  
+ATOM   2612  CA  ASN A 151      95.803  38.191 131.130  1.00 88.69           C  
+ATOM   2613  C   ASN A 151      94.779  37.741 132.149  1.00 94.28           C  
+ATOM   2614  O   ASN A 151      95.123  37.438 133.290  1.00 96.69           O  
+ATOM   2615  CB  ASN A 151      96.890  39.059 131.732  1.00 86.77           C  
+ATOM   2616  CG  ASN A 151      97.739  39.675 130.658  1.00100.00           C  
+ATOM   2617  OD1 ASN A 151      97.417  40.739 130.131  1.00100.00           O  
+ATOM   2618  ND2 ASN A 151      98.781  38.960 130.250  1.00100.00           N  
+ATOM   2619  N   SER A 152      93.516  37.675 131.741  1.00 88.44           N  
+ATOM   2620  CA  SER A 152      92.491  37.221 132.676  1.00 86.39           C  
+ATOM   2621  C   SER A 152      92.075  35.779 132.453  1.00 84.19           C  
+ATOM   2622  O   SER A 152      91.649  35.397 131.366  1.00 82.12           O  
+ATOM   2623  CB  SER A 152      91.257  38.114 132.721  1.00 90.36           C  
+ATOM   2624  OG  SER A 152      90.244  37.448 133.465  1.00 97.85           O  
+ATOM   2625  N   ASP A 153      92.206  34.994 133.515  1.00 77.82           N  
+ATOM   2626  CA  ASP A 153      91.886  33.571 133.534  1.00 76.24           C  
+ATOM   2627  C   ASP A 153      90.380  33.353 133.456  1.00 75.63           C  
+ATOM   2628  O   ASP A 153      89.906  32.326 132.964  1.00 74.90           O  
+ATOM   2629  CB  ASP A 153      92.389  33.008 134.862  1.00 79.40           C  
+ATOM   2630  CG  ASP A 153      91.848  33.786 136.055  1.00 99.70           C  
+ATOM   2631  OD1 ASP A 153      92.234  34.963 136.236  1.00100.00           O  
+ATOM   2632  OD2 ASP A 153      90.996  33.233 136.788  1.00100.00           O  
+ATOM   2633  N   ARG A 154      89.648  34.347 133.956  1.00 69.13           N  
+ATOM   2634  CA  ARG A 154      88.188  34.347 133.983  1.00 67.14           C  
+ATOM   2635  C   ARG A 154      87.535  33.916 132.678  1.00 68.79           C  
+ATOM   2636  O   ARG A 154      87.712  34.529 131.622  1.00 67.33           O  
+ATOM   2637  CB  ARG A 154      87.648  35.721 134.383  1.00 66.21           C  
+ATOM   2638  CG  ARG A 154      88.093  36.201 135.749  1.00 71.53           C  
+ATOM   2639  CD  ARG A 154      86.954  36.890 136.488  1.00 73.22           C  
+ATOM   2640  NE  ARG A 154      86.338  37.932 135.678  1.00 70.82           N  
+ATOM   2641  CZ  ARG A 154      85.605  38.930 136.163  1.00 94.90           C  
+ATOM   2642  NH1 ARG A 154      85.413  39.048 137.470  1.00 81.82           N  
+ATOM   2643  NH2 ARG A 154      85.095  39.829 135.333  1.00 88.25           N  
+ATOM   2644  N   CYS A 155      86.738  32.865 132.781  1.00 64.31           N  
+ATOM   2645  CA  CYS A 155      86.038  32.363 131.624  1.00 64.16           C  
+ATOM   2646  C   CYS A 155      85.295  33.499 130.930  1.00 70.99           C  
+ATOM   2647  O   CYS A 155      85.393  33.630 129.711  1.00 71.70           O  
+ATOM   2648  CB  CYS A 155      85.081  31.250 132.038  1.00 65.21           C  
+ATOM   2649  SG  CYS A 155      84.511  30.219 130.648  1.00 69.52           S  
+ATOM   2650  N   GLN A 156      84.570  34.330 131.682  1.00 68.50           N  
+ATOM   2651  CA  GLN A 156      83.828  35.446 131.078  1.00 67.18           C  
+ATOM   2652  C   GLN A 156      84.744  36.529 130.526  1.00 67.06           C  
+ATOM   2653  O   GLN A 156      84.378  37.247 129.597  1.00 66.51           O  
+ATOM   2654  CB  GLN A 156      82.769  36.039 132.018  1.00 68.39           C  
+ATOM   2655  CG  GLN A 156      81.672  36.853 131.307  1.00 86.37           C  
+ATOM   2656  CD  GLN A 156      80.250  36.506 131.747  1.00100.00           C  
+ATOM   2657  OE1 GLN A 156      79.516  35.816 131.039  1.00 92.48           O  
+ATOM   2658  NE2 GLN A 156      79.852  37.007 132.908  1.00 99.92           N  
+ATOM   2659  N   ASP A 157      85.933  36.654 131.102  1.00 61.76           N  
+ATOM   2660  CA  ASP A 157      86.865  37.632 130.586  1.00 62.06           C  
+ATOM   2661  C   ASP A 157      87.376  37.079 129.253  1.00 66.69           C  
+ATOM   2662  O   ASP A 157      87.414  37.795 128.248  1.00 66.64           O  
+ATOM   2663  CB  ASP A 157      87.963  37.964 131.596  1.00 64.92           C  
+ATOM   2664  CG  ASP A 157      87.566  39.116 132.494  1.00 81.28           C  
+ATOM   2665  OD1 ASP A 157      86.349  39.228 132.764  1.00 84.02           O  
+ATOM   2666  OD2 ASP A 157      88.442  39.904 132.911  1.00 89.33           O  
+ATOM   2667  N   ILE A 158      87.694  35.792 129.196  1.00 61.03           N  
+ATOM   2668  CA  ILE A 158      88.151  35.261 127.921  1.00 59.51           C  
+ATOM   2669  C   ILE A 158      87.106  35.385 126.812  1.00 61.91           C  
+ATOM   2670  O   ILE A 158      87.436  35.831 125.716  1.00 60.85           O  
+ATOM   2671  CB  ILE A 158      88.821  33.873 128.013  1.00 62.11           C  
+ATOM   2672  CG1 ILE A 158      87.831  32.753 127.840  1.00 61.58           C  
+ATOM   2673  CG2 ILE A 158      89.671  33.710 129.249  1.00 63.55           C  
+ATOM   2674  CD1 ILE A 158      88.291  31.958 126.705  1.00 56.70           C  
+ATOM   2675  N   ARG A 159      85.854  35.028 127.101  1.00 59.28           N  
+ATOM   2676  CA  ARG A 159      84.756  35.105 126.126  1.00 57.81           C  
+ATOM   2677  C   ARG A 159      84.489  36.518 125.606  1.00 63.50           C  
+ATOM   2678  O   ARG A 159      84.284  36.731 124.408  1.00 63.73           O  
+ATOM   2679  CB  ARG A 159      83.457  34.545 126.710  1.00 50.96           C  
+ATOM   2680  CG  ARG A 159      82.362  34.436 125.657  1.00 52.52           C  
+ATOM   2681  CD  ARG A 159      80.950  34.540 126.219  1.00 63.65           C  
+ATOM   2682  NE  ARG A 159      80.731  35.761 126.989  1.00 61.43           N  
+ATOM   2683  CZ  ARG A 159      79.700  35.954 127.806  1.00 61.10           C  
+ATOM   2684  NH1 ARG A 159      78.766  35.019 127.934  1.00 37.12           N  
+ATOM   2685  NH2 ARG A 159      79.582  37.099 128.466  1.00 43.78           N  
+ATOM   2686  N   ASN A 160      84.473  37.482 126.519  1.00 59.03           N  
+ATOM   2687  CA  ASN A 160      84.226  38.858 126.138  1.00 57.97           C  
+ATOM   2688  C   ASN A 160      85.363  39.432 125.300  1.00 63.60           C  
+ATOM   2689  O   ASN A 160      85.214  40.496 124.704  1.00 64.13           O  
+ATOM   2690  CB  ASN A 160      83.959  39.737 127.361  1.00 52.75           C  
+ATOM   2691  CG  ASN A 160      82.714  39.324 128.133  1.00 48.27           C  
+ATOM   2692  OD1 ASN A 160      82.079  38.310 127.841  1.00 45.30           O  
+ATOM   2693  ND2 ASN A 160      82.369  40.111 129.142  1.00 43.25           N  
+ATOM   2694  N   LEU A 161      86.497  38.746 125.233  1.00 62.22           N  
+ATOM   2695  CA  LEU A 161      87.581  39.277 124.407  1.00 63.74           C  
+ATOM   2696  C   LEU A 161      87.378  38.834 122.966  1.00 65.13           C  
+ATOM   2697  O   LEU A 161      87.392  39.642 122.036  1.00 64.70           O  
+ATOM   2698  CB  LEU A 161      88.971  38.907 124.933  1.00 64.30           C  
+ATOM   2699  CG  LEU A 161      89.693  40.095 125.578  1.00 68.61           C  
+ATOM   2700  CD1 LEU A 161      91.183  39.852 125.729  1.00 68.74           C  
+ATOM   2701  CD2 LEU A 161      89.446  41.361 124.776  1.00 69.95           C  
+ATOM   2702  N   ALA A 162      87.115  37.541 122.798  1.00 59.79           N  
+ATOM   2703  CA  ALA A 162      86.845  36.987 121.487  1.00 60.27           C  
+ATOM   2704  C   ALA A 162      85.768  37.842 120.822  1.00 64.33           C  
+ATOM   2705  O   ALA A 162      85.834  38.134 119.629  1.00 64.74           O  
+ATOM   2706  CB  ALA A 162      86.342  35.560 121.643  1.00 61.14           C  
+ATOM   2707  N   PHE A 163      84.760  38.215 121.605  1.00 57.47           N  
+ATOM   2708  CA  PHE A 163      83.635  38.977 121.087  1.00 52.41           C  
+ATOM   2709  C   PHE A 163      83.958  40.326 120.519  1.00 54.75           C  
+ATOM   2710  O   PHE A 163      83.513  40.655 119.425  1.00 52.87           O  
+ATOM   2711  CB  PHE A 163      82.538  39.167 122.120  1.00 51.66           C  
+ATOM   2712  CG  PHE A 163      81.357  39.941 121.600  1.00 50.18           C  
+ATOM   2713  CD1 PHE A 163      80.444  39.338 120.748  1.00 47.61           C  
+ATOM   2714  CD2 PHE A 163      81.166  41.267 121.954  1.00 49.68           C  
+ATOM   2715  CE1 PHE A 163      79.356  40.031 120.278  1.00 46.00           C  
+ATOM   2716  CE2 PHE A 163      80.076  41.964 121.489  1.00 50.83           C  
+ATOM   2717  CZ  PHE A 163      79.170  41.343 120.646  1.00 48.13           C  
+ATOM   2718  N   LEU A 164      84.671  41.128 121.299  1.00 55.52           N  
+ATOM   2719  CA  LEU A 164      85.033  42.464 120.863  1.00 57.00           C  
+ATOM   2720  C   LEU A 164      85.996  42.287 119.697  1.00 64.66           C  
+ATOM   2721  O   LEU A 164      86.117  43.160 118.837  1.00 65.84           O  
+ATOM   2722  CB  LEU A 164      85.623  43.275 122.022  1.00 56.47           C  
+ATOM   2723  CG  LEU A 164      84.644  43.490 123.185  1.00 58.95           C  
+ATOM   2724  CD1 LEU A 164      85.343  43.967 124.448  1.00 57.99           C  
+ATOM   2725  CD2 LEU A 164      83.494  44.415 122.806  1.00 55.21           C  
+ATOM   2726  N   GLY A 165      86.607  41.106 119.631  1.00 61.94           N  
+ATOM   2727  CA  GLY A 165      87.538  40.771 118.557  1.00 60.20           C  
+ATOM   2728  C   GLY A 165      86.763  40.582 117.262  1.00 61.21           C  
+ATOM   2729  O   GLY A 165      87.009  41.266 116.274  1.00 59.17           O  
+ATOM   2730  N   ILE A 166      85.792  39.673 117.303  1.00 61.40           N  
+ATOM   2731  CA  ILE A 166      84.920  39.358 116.170  1.00 62.54           C  
+ATOM   2732  C   ILE A 166      83.956  40.499 115.827  1.00 71.03           C  
+ATOM   2733  O   ILE A 166      83.330  40.492 114.769  1.00 72.05           O  
+ATOM   2734  CB  ILE A 166      84.130  38.023 116.402  1.00 64.64           C  
+ATOM   2735  CG1 ILE A 166      85.088  36.829 116.505  1.00 66.27           C  
+ATOM   2736  CG2 ILE A 166      83.102  37.762 115.301  1.00 61.07           C  
+ATOM   2737  CD1 ILE A 166      84.396  35.482 116.658  1.00 71.73           C  
+ATOM   2738  N   ALA A 167      83.865  41.507 116.684  1.00 68.01           N  
+ATOM   2739  CA  ALA A 167      82.960  42.615 116.416  1.00 66.63           C  
+ATOM   2740  C   ALA A 167      83.716  43.717 115.690  1.00 68.64           C  
+ATOM   2741  O   ALA A 167      83.210  44.306 114.729  1.00 64.06           O  
+ATOM   2742  CB  ALA A 167      82.358  43.134 117.715  1.00 67.25           C  
+ATOM   2743  N   TYR A 168      84.938  43.967 116.160  1.00 67.98           N  
+ATOM   2744  CA  TYR A 168      85.816  44.987 115.591  1.00 68.97           C  
+ATOM   2745  C   TYR A 168      86.537  44.495 114.335  1.00 72.12           C  
+ATOM   2746  O   TYR A 168      86.421  45.090 113.261  1.00 68.98           O  
+ATOM   2747  CB  TYR A 168      86.823  45.492 116.621  1.00 70.31           C  
+ATOM   2748  CG  TYR A 168      87.788  46.509 116.054  1.00 74.00           C  
+ATOM   2749  CD1 TYR A 168      87.512  47.871 116.121  1.00 76.00           C  
+ATOM   2750  CD2 TYR A 168      88.963  46.107 115.433  1.00 75.69           C  
+ATOM   2751  CE1 TYR A 168      88.394  48.809 115.609  1.00 76.42           C  
+ATOM   2752  CE2 TYR A 168      89.856  47.041 114.915  1.00 76.66           C  
+ATOM   2753  CZ  TYR A 168      89.562  48.392 115.009  1.00 83.78           C  
+ATOM   2754  OH  TYR A 168      90.428  49.341 114.506  1.00 85.65           O  
+ATOM   2755  N   ASN A 169      87.267  43.394 114.471  1.00 70.48           N  
+ATOM   2756  CA  ASN A 169      87.969  42.787 113.349  1.00 69.94           C  
+ATOM   2757  C   ASN A 169      86.979  42.585 112.177  1.00 72.23           C  
+ATOM   2758  O   ASN A 169      87.361  42.713 111.012  1.00 72.53           O  
+ATOM   2759  CB  ASN A 169      88.582  41.454 113.834  1.00 69.66           C  
+ATOM   2760  CG  ASN A 169      89.325  40.691 112.746  1.00 88.50           C  
+ATOM   2761  OD1 ASN A 169      90.553  40.590 112.760  1.00 75.51           O  
+ATOM   2762  ND2 ASN A 169      88.570  40.129 111.808  1.00 83.69           N  
+ATOM   2763  N   THR A 170      85.699  42.378 112.478  1.00 67.86           N  
+ATOM   2764  CA  THR A 170      84.680  42.098 111.449  1.00 66.73           C  
+ATOM   2765  C   THR A 170      83.520  43.048 111.075  1.00 67.98           C  
+ATOM   2766  O   THR A 170      82.974  42.974 109.972  1.00 66.02           O  
+ATOM   2767  CB  THR A 170      84.245  40.597 111.473  1.00 75.44           C  
+ATOM   2768  OG1 THR A 170      83.049  40.432 112.253  1.00 68.19           O  
+ATOM   2769  CG2 THR A 170      85.366  39.705 112.026  1.00 71.69           C  
+ATOM   2770  N   LEU A 171      83.148  43.941 111.983  1.00 62.68           N  
+ATOM   2771  CA  LEU A 171      82.086  44.886 111.678  1.00 60.34           C  
+ATOM   2772  C   LEU A 171      80.765  44.159 111.503  1.00 60.77           C  
+ATOM   2773  O   LEU A 171      79.829  44.720 110.936  1.00 59.90           O  
+ATOM   2774  CB  LEU A 171      82.411  45.688 110.406  1.00 59.94           C  
+ATOM   2775  CG  LEU A 171      83.433  46.833 110.440  1.00 63.96           C  
+ATOM   2776  CD1 LEU A 171      84.846  46.381 110.090  1.00 62.47           C  
+ATOM   2777  CD2 LEU A 171      82.987  47.978 109.540  1.00 65.44           C  
+ATOM   2778  N   LEU A 172      80.685  42.926 111.993  1.00 55.68           N  
+ATOM   2779  CA  LEU A 172      79.453  42.147 111.908  1.00 54.90           C  
+ATOM   2780  C   LEU A 172      78.394  42.692 112.869  1.00 58.06           C  
+ATOM   2781  O   LEU A 172      78.715  43.161 113.959  1.00 58.10           O  
+ATOM   2782  CB  LEU A 172      79.750  40.695 112.261  1.00 55.46           C  
+ATOM   2783  CG  LEU A 172      79.988  39.731 111.101  1.00 60.79           C  
+ATOM   2784  CD1 LEU A 172      80.572  38.448 111.663  1.00 61.31           C  
+ATOM   2785  CD2 LEU A 172      78.695  39.464 110.321  1.00 62.67           C  
+ATOM   2786  N   ARG A 173      77.126  42.629 112.484  1.00 56.18           N  
+ATOM   2787  CA  ARG A 173      76.073  43.135 113.363  1.00 59.18           C  
+ATOM   2788  C   ARG A 173      75.733  42.206 114.543  1.00 62.01           C  
+ATOM   2789  O   ARG A 173      75.962  40.992 114.481  1.00 61.62           O  
+ATOM   2790  CB  ARG A 173      74.841  43.565 112.560  1.00 68.30           C  
+ATOM   2791  CG  ARG A 173      75.161  44.551 111.427  1.00 89.72           C  
+ATOM   2792  CD  ARG A 173      74.100  44.526 110.330  1.00 96.38           C  
+ATOM   2793  NE  ARG A 173      74.345  45.499 109.264  1.00100.00           N  
+ATOM   2794  CZ  ARG A 173      74.607  45.184 107.998  1.00100.00           C  
+ATOM   2795  NH1 ARG A 173      74.686  43.910 107.628  1.00100.00           N  
+ATOM   2796  NH2 ARG A 173      74.810  46.146 107.104  1.00 97.56           N  
+ATOM   2797  N   ILE A 174      75.229  42.780 115.636  1.00 53.87           N  
+ATOM   2798  CA  ILE A 174      74.921  41.966 116.811  1.00 49.77           C  
+ATOM   2799  C   ILE A 174      74.005  40.794 116.564  1.00 52.37           C  
+ATOM   2800  O   ILE A 174      74.295  39.690 117.007  1.00 53.56           O  
+ATOM   2801  CB  ILE A 174      74.548  42.723 118.102  1.00 50.26           C  
+ATOM   2802  CG1 ILE A 174      73.400  43.712 117.888  1.00 50.24           C  
+ATOM   2803  CG2 ILE A 174      75.784  43.363 118.712  1.00 48.79           C  
+ATOM   2804  CD1 ILE A 174      72.783  44.259 119.185  1.00 35.78           C  
+ATOM   2805  N   ALA A 175      72.913  41.034 115.851  1.00 47.15           N  
+ATOM   2806  CA  ALA A 175      71.972  39.969 115.516  1.00 48.18           C  
+ATOM   2807  C   ALA A 175      72.706  38.958 114.634  1.00 56.00           C  
+ATOM   2808  O   ALA A 175      72.297  37.799 114.490  1.00 54.39           O  
+ATOM   2809  CB  ALA A 175      70.762  40.531 114.789  1.00 49.14           C  
+ATOM   2810  N   GLU A 176      73.833  39.396 114.087  1.00 54.30           N  
+ATOM   2811  CA  GLU A 176      74.631  38.519 113.253  1.00 55.12           C  
+ATOM   2812  C   GLU A 176      75.642  37.642 113.996  1.00 61.21           C  
+ATOM   2813  O   GLU A 176      75.818  36.481 113.631  1.00 57.61           O  
+ATOM   2814  CB  GLU A 176      75.281  39.299 112.110  1.00 57.78           C  
+ATOM   2815  CG  GLU A 176      74.326  39.622 110.957  1.00 76.05           C  
+ATOM   2816  CD  GLU A 176      74.936  40.552 109.921  1.00100.00           C  
+ATOM   2817  OE1 GLU A 176      76.168  40.737 109.945  1.00100.00           O  
+ATOM   2818  OE2 GLU A 176      74.185  41.107 109.090  1.00 91.24           O  
+ATOM   2819  N   ILE A 177      76.327  38.157 115.018  1.00 64.06           N  
+ATOM   2820  CA  ILE A 177      77.296  37.301 115.718  1.00 65.11           C  
+ATOM   2821  C   ILE A 177      76.613  36.242 116.555  1.00 66.34           C  
+ATOM   2822  O   ILE A 177      77.124  35.139 116.739  1.00 65.80           O  
+ATOM   2823  CB  ILE A 177      78.263  38.051 116.633  1.00 68.80           C  
+ATOM   2824  CG1 ILE A 177      79.257  38.845 115.787  1.00 71.22           C  
+ATOM   2825  CG2 ILE A 177      79.016  37.056 117.515  1.00 66.68           C  
+ATOM   2826  CD1 ILE A 177      79.013  40.339 115.815  1.00 87.44           C  
+ATOM   2827  N   ALA A 178      75.435  36.593 117.049  1.00 62.06           N  
+ATOM   2828  CA  ALA A 178      74.646  35.664 117.836  1.00 61.99           C  
+ATOM   2829  C   ALA A 178      74.323  34.431 116.985  1.00 64.60           C  
+ATOM   2830  O   ALA A 178      74.427  33.308 117.470  1.00 63.93           O  
+ATOM   2831  CB  ALA A 178      73.364  36.331 118.327  1.00 62.34           C  
+ATOM   2832  N   ARG A 179      73.948  34.646 115.725  1.00 59.32           N  
+ATOM   2833  CA  ARG A 179      73.592  33.573 114.794  1.00 57.64           C  
+ATOM   2834  C   ARG A 179      74.730  32.592 114.511  1.00 62.26           C  
+ATOM   2835  O   ARG A 179      74.486  31.418 114.243  1.00 62.22           O  
+ATOM   2836  CB  ARG A 179      73.133  34.181 113.458  1.00 56.98           C  
+ATOM   2837  CG  ARG A 179      71.659  34.014 113.100  1.00 74.96           C  
+ATOM   2838  CD  ARG A 179      71.381  34.395 111.640  1.00 97.39           C  
+ATOM   2839  NE  ARG A 179      71.457  35.835 111.408  1.00100.00           N  
+ATOM   2840  CZ  ARG A 179      70.537  36.709 111.804  1.00100.00           C  
+ATOM   2841  NH1 ARG A 179      69.465  36.297 112.465  1.00 85.17           N  
+ATOM   2842  NH2 ARG A 179      70.701  38.000 111.552  1.00 84.00           N  
+ATOM   2843  N   ILE A 180      75.966  33.081 114.535  1.00 59.09           N  
+ATOM   2844  CA  ILE A 180      77.142  32.264 114.232  1.00 59.54           C  
+ATOM   2845  C   ILE A 180      77.308  30.899 114.925  1.00 71.28           C  
+ATOM   2846  O   ILE A 180      77.267  30.794 116.157  1.00 73.68           O  
+ATOM   2847  CB  ILE A 180      78.426  33.096 114.377  1.00 61.06           C  
+ATOM   2848  CG1 ILE A 180      78.260  34.442 113.661  1.00 58.94           C  
+ATOM   2849  CG2 ILE A 180      79.659  32.287 113.951  1.00 63.32           C  
+ATOM   2850  CD1 ILE A 180      79.175  35.528 114.158  1.00 60.19           C  
+ATOM   2851  N   ARG A 181      77.558  29.856 114.132  1.00 69.60           N  
+ATOM   2852  CA  ARG A 181      77.773  28.521 114.701  1.00 71.00           C  
+ATOM   2853  C   ARG A 181      79.261  28.165 114.646  1.00 78.19           C  
+ATOM   2854  O   ARG A 181      80.045  28.878 114.020  1.00 79.40           O  
+ATOM   2855  CB  ARG A 181      76.945  27.450 113.963  1.00 71.81           C  
+ATOM   2856  CG  ARG A 181      75.547  27.286 114.554  1.00 80.29           C  
+ATOM   2857  CD  ARG A 181      74.463  26.857 113.599  1.00 82.20           C  
+ATOM   2858  NE  ARG A 181      73.116  27.165 114.119  1.00 85.18           N  
+ATOM   2859  CZ  ARG A 181      72.391  26.347 114.878  1.00 98.73           C  
+ATOM   2860  NH1 ARG A 181      72.887  25.173 115.248  1.00 80.15           N  
+ATOM   2861  NH2 ARG A 181      71.165  26.704 115.246  1.00 92.81           N  
+ATOM   2862  N   VAL A 182      79.658  27.078 115.304  1.00 75.04           N  
+ATOM   2863  CA  VAL A 182      81.063  26.682 115.299  1.00 74.52           C  
+ATOM   2864  C   VAL A 182      81.328  25.968 113.979  1.00 84.02           C  
+ATOM   2865  O   VAL A 182      82.461  25.911 113.495  1.00 84.06           O  
+ATOM   2866  CB  VAL A 182      81.421  25.790 116.498  0.00 77.41           C  
+ATOM   2867  CG1 VAL A 182      82.687  24.997 116.211  0.00 77.09           C  
+ATOM   2868  CG2 VAL A 182      81.598  26.642 117.746  0.00 77.10           C  
+ATOM   2869  N   LYS A 183      80.236  25.460 113.403  1.00 83.98           N  
+ATOM   2870  CA  LYS A 183      80.210  24.766 112.112  1.00 84.12           C  
+ATOM   2871  C   LYS A 183      80.163  25.809 110.993  1.00 87.40           C  
+ATOM   2872  O   LYS A 183      79.696  25.554 109.875  1.00 87.14           O  
+ATOM   2873  CB  LYS A 183      79.055  23.746 112.018  1.00 85.85           C  
+ATOM   2874  CG  LYS A 183      77.657  24.317 111.834  1.00 80.92           C  
+ATOM   2875  CD  LYS A 183      77.171  24.092 110.405  1.00 91.81           C  
+ATOM   2876  CE  LYS A 183      75.798  24.704 110.235  1.00 99.93           C  
+ATOM   2877  NZ  LYS A 183      75.150  24.431 108.927  1.00 97.40           N  
+ATOM   2878  N   ASP A 184      80.687  26.983 111.334  1.00 83.56           N  
+ATOM   2879  CA  ASP A 184      80.746  28.094 110.402  1.00 83.14           C  
+ATOM   2880  C   ASP A 184      82.162  28.655 110.316  1.00 87.29           C  
+ATOM   2881  O   ASP A 184      82.382  29.698 109.708  1.00 87.62           O  
+ATOM   2882  CB  ASP A 184      79.786  29.194 110.852  1.00 85.55           C  
+ATOM   2883  CG  ASP A 184      78.335  28.806 110.670  1.00 98.47           C  
+ATOM   2884  OD1 ASP A 184      78.093  27.638 110.302  1.00 97.57           O  
+ATOM   2885  OD2 ASP A 184      77.450  29.655 110.953  1.00100.00           O  
+ATOM   2886  N   ILE A 185      83.126  27.963 110.915  1.00 86.64           N  
+ATOM   2887  CA  ILE A 185      84.513  28.423 110.928  1.00 89.17           C  
+ATOM   2888  C   ILE A 185      85.487  27.505 110.184  1.00 99.43           C  
+ATOM   2889  O   ILE A 185      85.341  26.282 110.193  1.00100.00           O  
+ATOM   2890  CB  ILE A 185      85.013  28.590 112.382  1.00 92.35           C  
+ATOM   2891  CG1 ILE A 185      84.173  29.623 113.144  1.00 91.87           C  
+ATOM   2892  CG2 ILE A 185      86.485  28.919 112.404  1.00 92.61           C  
+ATOM   2893  CD1 ILE A 185      84.434  29.645 114.640  1.00 79.07           C  
+ATOM   2894  N   SER A 186      86.494  28.111 109.562  1.00 97.84           N  
+ATOM   2895  CA  SER A 186      87.517  27.396 108.803  1.00 96.75           C  
+ATOM   2896  C   SER A 186      88.890  27.714 109.403  1.00 99.98           C  
+ATOM   2897  O   SER A 186      88.967  28.200 110.529  1.00 99.68           O  
+ATOM   2898  CB  SER A 186      87.450  27.829 107.339  1.00 98.45           C  
+ATOM   2899  OG  SER A 186      86.628  28.979 107.200  1.00100.00           O  
+ATOM   2900  N   ARG A 187      89.977  27.440 108.689  1.00 96.13           N  
+ATOM   2901  CA  ARG A 187      91.298  27.721 109.258  1.00 95.87           C  
+ATOM   2902  C   ARG A 187      92.200  28.531 108.337  1.00100.00           C  
+ATOM   2903  O   ARG A 187      93.306  28.942 108.698  1.00 99.99           O  
+ATOM   2904  CB  ARG A 187      91.988  26.437 109.703  1.00 94.30           C  
+ATOM   2905  CG  ARG A 187      91.946  26.230 111.201  1.00 94.49           C  
+ATOM   2906  CD  ARG A 187      91.429  27.462 111.930  1.00 79.59           C  
+ATOM   2907  NE  ARG A 187      91.732  27.357 113.352  1.00 85.06           N  
+ATOM   2908  CZ  ARG A 187      92.754  27.965 113.941  1.00100.00           C  
+ATOM   2909  NH1 ARG A 187      93.560  28.751 113.237  1.00100.00           N  
+ATOM   2910  NH2 ARG A 187      92.964  27.810 115.240  1.00100.00           N  
+ATOM   2911  N   THR A 188      91.686  28.735 107.133  1.00 97.44           N  
+ATOM   2912  CA  THR A 188      92.296  29.521 106.069  1.00 97.06           C  
+ATOM   2913  C   THR A 188      93.630  30.263 106.268  1.00100.00           C  
+ATOM   2914  O   THR A 188      93.911  30.819 107.326  1.00 99.37           O  
+ATOM   2915  CB  THR A 188      91.261  30.564 105.623  1.00 99.96           C  
+ATOM   2916  OG1 THR A 188      91.850  31.466 104.676  1.00100.00           O  
+ATOM   2917  CG2 THR A 188      90.751  31.341 106.830  1.00 93.50           C  
+ATOM   2918  N   ASP A 189      94.415  30.317 105.198  1.00 96.87           N  
+ATOM   2919  CA  ASP A 189      95.670  31.051 105.154  1.00 96.65           C  
+ATOM   2920  C   ASP A 189      96.627  31.192 106.328  1.00100.00           C  
+ATOM   2921  O   ASP A 189      97.536  32.020 106.268  1.00100.00           O  
+ATOM   2922  CB  ASP A 189      95.517  32.354 104.373  1.00 98.12           C  
+ATOM   2923  CG  ASP A 189      95.316  32.113 102.890  1.00100.00           C  
+ATOM   2924  OD1 ASP A 189      94.646  31.118 102.523  1.00100.00           O  
+ATOM   2925  OD2 ASP A 189      95.834  32.915 102.088  1.00100.00           O  
+ATOM   2926  N   GLY A 190      96.491  30.375 107.367  1.00 96.07           N  
+ATOM   2927  CA  GLY A 190      97.504  30.463 108.409  1.00 95.82           C  
+ATOM   2928  C   GLY A 190      97.200  30.404 109.894  1.00100.00           C  
+ATOM   2929  O   GLY A 190      97.877  31.064 110.682  1.00100.00           O  
+ATOM   2930  N   GLY A 191      96.227  29.601 110.301  0.00 96.38           N  
+ATOM   2931  CA  GLY A 191      95.909  29.527 111.719  0.00 96.14           C  
+ATOM   2932  C   GLY A 191      95.063  30.764 111.933  0.00100.00           C  
+ATOM   2933  O   GLY A 191      94.711  31.124 113.056  0.00 99.53           O  
+ATOM   2934  N   ARG A 192      94.774  31.422 110.816  1.00 96.78           N  
+ATOM   2935  CA  ARG A 192      93.938  32.598 110.838  1.00 96.67           C  
+ATOM   2936  C   ARG A 192      92.645  31.918 111.209  1.00 99.26           C  
+ATOM   2937  O   ARG A 192      92.598  31.143 112.165  1.00 99.38           O  
+ATOM   2938  CB  ARG A 192      93.821  33.201 109.435  1.00 97.67           C  
+ATOM   2939  CG  ARG A 192      94.407  34.599 109.311  1.00100.00           C  
+ATOM   2940  CD  ARG A 192      95.260  34.935 110.528  1.00 99.81           C  
+ATOM   2941  NE  ARG A 192      96.397  35.780 110.193  1.00100.00           N  
+ATOM   2942  CZ  ARG A 192      97.612  35.572 110.690  1.00100.00           C  
+ATOM   2943  NH1 ARG A 192      97.808  34.603 111.570  1.00 81.11           N  
+ATOM   2944  NH2 ARG A 192      98.636  36.339 110.330  1.00100.00           N  
+ATOM   2945  N   MET A 193      91.653  32.110 110.352  1.00 94.09           N  
+ATOM   2946  CA  MET A 193      90.328  31.532 110.533  1.00 92.37           C  
+ATOM   2947  C   MET A 193      89.372  32.359 109.695  1.00 91.09           C  
+ATOM   2948  O   MET A 193      89.478  33.583 109.652  1.00 88.09           O  
+ATOM   2949  CB  MET A 193      89.873  31.630 112.004  1.00 94.51           C  
+ATOM   2950  CG  MET A 193      89.056  30.434 112.494  1.00 97.15           C  
+ATOM   2951  SD  MET A 193      88.822  30.111 114.264  1.00100.00           S  
+ATOM   2952  CE  MET A 193      89.944  31.204 115.073  1.00 96.82           C  
+ATOM   2953  N   LEU A 194      88.423  31.694 109.048  1.00 88.84           N  
+ATOM   2954  CA  LEU A 194      87.429  32.408 108.266  1.00 90.36           C  
+ATOM   2955  C   LEU A 194      86.065  32.101 108.880  1.00 93.67           C  
+ATOM   2956  O   LEU A 194      85.854  31.026 109.446  1.00 92.14           O  
+ATOM   2957  CB  LEU A 194      87.486  32.043 106.775  1.00 90.93           C  
+ATOM   2958  CG  LEU A 194      88.389  32.960 105.942  1.00 96.26           C  
+ATOM   2959  CD1 LEU A 194      88.519  32.513 104.491  1.00 97.39           C  
+ATOM   2960  CD2 LEU A 194      88.035  34.448 106.085  1.00 96.61           C  
+ATOM   2961  N   ILE A 195      85.153  33.064 108.784  1.00 88.41           N  
+ATOM   2962  CA  ILE A 195      83.798  32.929 109.313  1.00 85.94           C  
+ATOM   2963  C   ILE A 195      82.775  33.106 108.194  1.00 88.51           C  
+ATOM   2964  O   ILE A 195      82.360  34.228 107.904  1.00 85.54           O  
+ATOM   2965  CB  ILE A 195      83.481  33.980 110.417  1.00 88.01           C  
+ATOM   2966  CG1 ILE A 195      84.326  33.733 111.671  1.00 87.95           C  
+ATOM   2967  CG2 ILE A 195      81.997  33.960 110.769  1.00 86.34           C  
+ATOM   2968  CD1 ILE A 195      84.000  34.656 112.824  1.00 94.89           C  
+ATOM   2969  N   HIS A 196      82.351  32.004 107.575  1.00 89.19           N  
+ATOM   2970  CA  HIS A 196      81.349  32.131 106.518  1.00 90.93           C  
+ATOM   2971  C   HIS A 196      80.146  32.705 107.209  1.00 90.92           C  
+ATOM   2972  O   HIS A 196      79.575  32.104 108.119  1.00 89.53           O  
+ATOM   2973  CB  HIS A 196      80.990  30.795 105.795  1.00 93.04           C  
+ATOM   2974  CG  HIS A 196      79.622  30.757 105.151  1.00 97.55           C  
+ATOM   2975  ND1 HIS A 196      79.050  29.567 104.754  1.00100.00           N  
+ATOM   2976  CD2 HIS A 196      78.731  31.724 104.804  1.00100.00           C  
+ATOM   2977  CE1 HIS A 196      77.867  29.800 104.216  1.00 99.83           C  
+ATOM   2978  NE2 HIS A 196      77.647  31.102 104.234  1.00100.00           N  
+ATOM   2979  N   ILE A 197      79.742  33.874 106.735  1.00 87.44           N  
+ATOM   2980  CA  ILE A 197      78.572  34.503 107.306  1.00 88.19           C  
+ATOM   2981  C   ILE A 197      77.256  34.443 106.548  1.00 88.50           C  
+ATOM   2982  O   ILE A 197      76.810  33.381 106.124  1.00 86.05           O  
+ATOM   2983  CB  ILE A 197      78.823  35.748 108.214  1.00 92.90           C  
+ATOM   2984  CG1 ILE A 197      78.696  37.094 107.487  1.00 94.27           C  
+ATOM   2985  CG2 ILE A 197      80.154  35.636 108.935  1.00 94.29           C  
+ATOM   2986  CD1 ILE A 197      77.504  37.909 107.959  1.00100.00           C  
+ATOM   2987  N   GLY A 198      76.631  35.597 106.414  1.00 87.80           N  
+ATOM   2988  CA  GLY A 198      75.352  35.765 105.763  1.00 90.41           C  
+ATOM   2989  C   GLY A 198      74.901  37.075 106.388  1.00 99.06           C  
+ATOM   2990  O   GLY A 198      74.146  37.086 107.362  1.00100.00           O  
+ATOM   2991  N   ARG A 199      75.441  38.181 105.891  1.00 96.06           N  
+ATOM   2992  CA  ARG A 199      75.037  39.460 106.449  1.00 95.54           C  
+ATOM   2993  C   ARG A 199      74.080  40.106 105.489  1.00 98.39           C  
+ATOM   2994  O   ARG A 199      73.853  41.312 105.537  1.00 99.46           O  
+ATOM   2995  CB  ARG A 199      76.184  40.407 106.785  1.00 96.52           C  
+ATOM   2996  CG  ARG A 199      77.407  40.388 105.901  1.00100.00           C  
+ATOM   2997  CD  ARG A 199      78.622  40.647 106.784  1.00 97.81           C  
+ATOM   2998  NE  ARG A 199      78.914  42.063 107.029  1.00 99.46           N  
+ATOM   2999  CZ  ARG A 199      78.186  42.909 107.760  1.00100.00           C  
+ATOM   3000  NH1 ARG A 199      77.062  42.540 108.356  1.00 81.48           N  
+ATOM   3001  NH2 ARG A 199      78.600  44.155 107.916  1.00 84.70           N  
+ATOM   3002  N   THR A 200      73.527  39.284 104.609  1.00 93.97           N  
+ATOM   3003  CA  THR A 200      72.534  39.746 103.658  1.00 94.56           C  
+ATOM   3004  C   THR A 200      71.276  38.941 103.877  1.00 98.93           C  
+ATOM   3005  O   THR A 200      71.323  37.835 104.418  1.00 99.57           O  
+ATOM   3006  CB  THR A 200      72.992  39.625 102.201  1.00100.00           C  
+ATOM   3007  OG1 THR A 200      73.332  38.262 101.884  1.00100.00           O  
+ATOM   3008  CG2 THR A 200      74.140  40.596 102.061  1.00100.00           C  
+ATOM   3009  N   LYS A 201      70.148  39.508 103.470  1.00 92.35           N  
+ATOM   3010  CA  LYS A 201      68.850  38.853 103.546  1.00 90.81           C  
+ATOM   3011  C   LYS A 201      68.167  39.451 102.351  1.00 93.62           C  
+ATOM   3012  O   LYS A 201      66.992  39.805 102.394  1.00 92.61           O  
+ATOM   3013  CB  LYS A 201      68.092  39.221 104.822  1.00 92.77           C  
+ATOM   3014  CG  LYS A 201      67.305  38.068 105.435  1.00 94.66           C  
+ATOM   3015  CD  LYS A 201      68.231  36.986 105.968  1.00100.00           C  
+ATOM   3016  CE  LYS A 201      68.480  35.919 104.916  1.00100.00           C  
+ATOM   3017  NZ  LYS A 201      69.931  35.707 104.649  1.00100.00           N  
+ATOM   3018  N   THR A 202      68.939  39.644 101.300  1.00 90.30           N  
+ATOM   3019  CA  THR A 202      68.302  40.219 100.157  1.00 90.58           C  
+ATOM   3020  C   THR A 202      68.381  39.105  99.152  1.00 93.24           C  
+ATOM   3021  O   THR A 202      69.429  38.511  99.015  1.00 94.74           O  
+ATOM   3022  CB  THR A 202      68.895  41.598  99.816  1.00100.00           C  
+ATOM   3023  OG1 THR A 202      69.748  41.557  98.668  1.00100.00           O  
+ATOM   3024  CG2 THR A 202      69.651  42.180 100.994  1.00100.00           C  
+ATOM   3025  N   LEU A 203      67.317  38.783  98.440  1.00 85.88           N  
+ATOM   3026  CA  LEU A 203      67.445  37.699  97.471  1.00 83.74           C  
+ATOM   3027  C   LEU A 203      68.525  38.040  96.417  1.00 87.91           C  
+ATOM   3028  O   LEU A 203      69.373  37.225  96.069  1.00 86.29           O  
+ATOM   3029  CB  LEU A 203      66.096  37.479  96.791  1.00 82.18           C  
+ATOM   3030  CG  LEU A 203      66.015  36.416  95.696  1.00 81.88           C  
+ATOM   3031  CD1 LEU A 203      65.511  35.106  96.271  1.00 80.67           C  
+ATOM   3032  CD2 LEU A 203      65.130  36.884  94.552  1.00 78.58           C  
+ATOM   3033  N   VAL A 204      68.490  39.234  95.841  1.00 84.74           N  
+ATOM   3034  CA  VAL A 204      69.520  39.542  94.847  1.00 85.08           C  
+ATOM   3035  C   VAL A 204      70.678  40.312  95.441  1.00 91.29           C  
+ATOM   3036  O   VAL A 204      71.030  41.414  95.017  1.00 91.37           O  
+ATOM   3037  CB  VAL A 204      69.017  40.191  93.543  1.00 88.49           C  
+ATOM   3038  CG1 VAL A 204      69.299  39.289  92.343  1.00 88.55           C  
+ATOM   3039  CG2 VAL A 204      67.546  40.538  93.634  1.00 87.90           C  
+ATOM   3040  N   SER A 205      71.246  39.671  96.454  1.00 89.63           N  
+ATOM   3041  CA  SER A 205      72.438  40.140  97.134  1.00 91.06           C  
+ATOM   3042  C   SER A 205      73.434  39.013  97.118  1.00 99.28           C  
+ATOM   3043  O   SER A 205      74.042  38.693  96.093  1.00100.00           O  
+ATOM   3044  CB  SER A 205      72.275  40.450  98.618  1.00 93.52           C  
+ATOM   3045  OG  SER A 205      72.787  41.739  98.926  1.00100.00           O  
+ATOM   3046  N   THR A 206      73.585  38.424  98.297  1.00 96.57           N  
+ATOM   3047  CA  THR A 206      74.569  37.391  98.557  1.00 96.45           C  
+ATOM   3048  C   THR A 206      73.986  36.164  99.234  1.00100.00           C  
+ATOM   3049  O   THR A 206      72.859  36.180  99.728  1.00100.00           O  
+ATOM   3050  CB  THR A 206      75.597  37.956  99.551  1.00100.00           C  
+ATOM   3051  OG1 THR A 206      75.448  37.320 100.833  1.00100.00           O  
+ATOM   3052  CG2 THR A 206      75.386  39.437  99.657  1.00 98.56           C  
+ATOM   3053  N   ALA A 207      74.790  35.108  99.283  1.00 96.87           N  
+ATOM   3054  CA  ALA A 207      74.424  33.875  99.966  1.00 96.71           C  
+ATOM   3055  C   ALA A 207      75.080  33.898 101.352  1.00100.00           C  
+ATOM   3056  O   ALA A 207      74.491  33.455 102.340  1.00100.00           O  
+ATOM   3057  CB  ALA A 207      74.903  32.671  99.178  1.00 97.75           C  
+ATOM   3058  N   GLY A 208      76.310  34.408 101.395  1.00 95.78           N  
+ATOM   3059  CA  GLY A 208      77.106  34.529 102.614  1.00 94.53           C  
+ATOM   3060  C   GLY A 208      78.452  35.138 102.249  1.00 95.67           C  
+ATOM   3061  O   GLY A 208      78.693  35.468 101.087  1.00 94.63           O  
+ATOM   3062  N   VAL A 209      79.330  35.312 103.227  1.00 90.30           N  
+ATOM   3063  CA  VAL A 209      80.634  35.865 102.913  1.00 89.05           C  
+ATOM   3064  C   VAL A 209      81.637  35.216 103.824  1.00 90.85           C  
+ATOM   3065  O   VAL A 209      81.308  34.291 104.564  1.00 89.34           O  
+ATOM   3066  CB  VAL A 209      80.706  37.370 103.159  1.00 92.07           C  
+ATOM   3067  CG1 VAL A 209      80.962  37.645 104.631  1.00 92.14           C  
+ATOM   3068  CG2 VAL A 209      81.808  37.980 102.303  1.00 91.31           C  
+ATOM   3069  N   GLU A 210      82.868  35.697 103.769  1.00 86.82           N  
+ATOM   3070  CA  GLU A 210      83.891  35.149 104.631  1.00 86.32           C  
+ATOM   3071  C   GLU A 210      84.584  36.314 105.324  1.00 95.32           C  
+ATOM   3072  O   GLU A 210      84.987  37.282 104.675  1.00 96.92           O  
+ATOM   3073  CB  GLU A 210      84.869  34.312 103.815  1.00 86.30           C  
+ATOM   3074  CG  GLU A 210      85.656  33.357 104.664  1.00 81.24           C  
+ATOM   3075  CD  GLU A 210      85.426  31.902 104.325  1.00100.00           C  
+ATOM   3076  OE1 GLU A 210      85.736  31.475 103.190  1.00100.00           O  
+ATOM   3077  OE2 GLU A 210      84.966  31.177 105.228  1.00100.00           O  
+ATOM   3078  N   LYS A 211      84.657  36.261 106.647  1.00 92.38           N  
+ATOM   3079  CA  LYS A 211      85.302  37.330 107.393  1.00 91.60           C  
+ATOM   3080  C   LYS A 211      86.517  36.655 108.002  1.00 97.20           C  
+ATOM   3081  O   LYS A 211      86.419  35.541 108.515  1.00 96.93           O  
+ATOM   3082  CB  LYS A 211      84.365  37.877 108.475  1.00 91.99           C  
+ATOM   3083  CG  LYS A 211      83.436  39.001 107.986  1.00 87.57           C  
+ATOM   3084  CD  LYS A 211      84.232  40.257 107.635  1.00 90.67           C  
+ATOM   3085  CE  LYS A 211      83.352  41.443 107.290  1.00 93.96           C  
+ATOM   3086  NZ  LYS A 211      84.116  42.705 107.094  1.00 78.29           N  
+ATOM   3087  N   ALA A 212      87.677  37.292 107.884  1.00 95.02           N  
+ATOM   3088  CA  ALA A 212      88.923  36.721 108.400  1.00 95.20           C  
+ATOM   3089  C   ALA A 212      89.429  37.404 109.674  1.00 97.71           C  
+ATOM   3090  O   ALA A 212      88.950  38.478 110.038  1.00 97.85           O  
+ATOM   3091  CB  ALA A 212      89.998  36.735 107.321  1.00 96.22           C  
+ATOM   3092  N   LEU A 213      90.395  36.783 110.350  1.00 93.39           N  
+ATOM   3093  CA  LEU A 213      90.933  37.335 111.598  1.00 93.53           C  
+ATOM   3094  C   LEU A 213      92.471  37.393 111.759  1.00 97.02           C  
+ATOM   3095  O   LEU A 213      93.201  36.734 111.033  1.00 98.58           O  
+ATOM   3096  CB  LEU A 213      90.244  36.675 112.797  1.00 93.51           C  
+ATOM   3097  CG  LEU A 213      88.873  36.024 112.548  1.00 97.67           C  
+ATOM   3098  CD1 LEU A 213      88.451  35.158 113.731  1.00 97.93           C  
+ATOM   3099  CD2 LEU A 213      87.781  37.028 112.179  1.00 97.89           C  
+ATOM   3100  N   SER A 214      92.953  38.203 112.696  1.00 91.40           N  
+ATOM   3101  CA  SER A 214      94.383  38.408 112.936  1.00 90.56           C  
+ATOM   3102  C   SER A 214      95.008  37.488 113.986  1.00 93.60           C  
+ATOM   3103  O   SER A 214      94.462  36.428 114.286  1.00 94.34           O  
+ATOM   3104  CB  SER A 214      94.542  39.846 113.425  1.00 94.71           C  
+ATOM   3105  OG  SER A 214      93.349  40.581 113.183  1.00100.00           O  
+ATOM   3106  N   LEU A 215      96.148  37.897 114.546  0.00 87.17           N  
+ATOM   3107  CA  LEU A 215      96.777  37.148 115.634  0.00 85.84           C  
+ATOM   3108  C   LEU A 215      96.034  37.765 116.799  0.00 90.45           C  
+ATOM   3109  O   LEU A 215      96.032  37.256 117.921  0.00 89.74           O  
+ATOM   3110  CB  LEU A 215      98.270  37.449 115.793  0.00 85.37           C  
+ATOM   3111  CG  LEU A 215      98.868  36.924 117.106  0.00 89.39           C  
+ATOM   3112  CD1 LEU A 215      98.263  35.575 117.474  0.00 89.35           C  
+ATOM   3113  CD2 LEU A 215     100.383  36.827 117.012  0.00 91.66           C  
+ATOM   3114  N   GLY A 216      95.395  38.889 116.498  1.00 88.47           N  
+ATOM   3115  CA  GLY A 216      94.581  39.560 117.485  1.00 87.50           C  
+ATOM   3116  C   GLY A 216      93.470  38.526 117.603  1.00 86.15           C  
+ATOM   3117  O   GLY A 216      93.633  37.492 118.254  1.00 82.33           O  
+ATOM   3118  N   VAL A 217      92.383  38.763 116.877  1.00 82.30           N  
+ATOM   3119  CA  VAL A 217      91.229  37.872 116.879  1.00 82.07           C  
+ATOM   3120  C   VAL A 217      91.206  36.340 116.882  1.00 90.79           C  
+ATOM   3121  O   VAL A 217      90.758  35.737 117.855  1.00 93.88           O  
+ATOM   3122  CB  VAL A 217      89.887  38.553 116.611  1.00 84.71           C  
+ATOM   3123  CG1 VAL A 217      90.006  40.053 116.794  1.00 84.34           C  
+ATOM   3124  CG2 VAL A 217      89.397  38.217 115.225  1.00 84.55           C  
+ATOM   3125  N   THR A 218      91.621  35.707 115.790  1.00 85.90           N  
+ATOM   3126  CA  THR A 218      91.633  34.243 115.682  1.00 84.20           C  
+ATOM   3127  C   THR A 218      92.115  33.600 117.003  1.00 87.15           C  
+ATOM   3128  O   THR A 218      91.483  32.682 117.527  1.00 87.56           O  
+ATOM   3129  CB  THR A 218      92.512  33.814 114.473  1.00 85.91           C  
+ATOM   3130  OG1 THR A 218      92.077  32.553 113.940  1.00 76.89           O  
+ATOM   3131  CG2 THR A 218      93.973  33.735 114.884  1.00 87.54           C  
+ATOM   3132  N   LYS A 219      93.213  34.111 117.558  1.00 81.81           N  
+ATOM   3133  CA  LYS A 219      93.767  33.586 118.811  1.00 80.91           C  
+ATOM   3134  C   LYS A 219      92.793  33.673 119.979  1.00 81.17           C  
+ATOM   3135  O   LYS A 219      92.401  32.655 120.546  1.00 82.44           O  
+ATOM   3136  CB  LYS A 219      95.088  34.272 119.170  1.00 83.39           C  
+ATOM   3137  CG  LYS A 219      96.236  33.302 119.429  1.00 91.85           C  
+ATOM   3138  CD  LYS A 219      96.418  32.346 118.257  1.00 96.67           C  
+ATOM   3139  CE  LYS A 219      97.768  32.538 117.582  1.00100.00           C  
+ATOM   3140  NZ  LYS A 219      97.846  31.822 116.275  1.00100.00           N  
+ATOM   3141  N   LEU A 220      92.412  34.893 120.348  1.00 71.00           N  
+ATOM   3142  CA  LEU A 220      91.466  35.052 121.440  1.00 67.26           C  
+ATOM   3143  C   LEU A 220      90.383  34.021 121.161  1.00 68.20           C  
+ATOM   3144  O   LEU A 220      89.969  33.284 122.056  1.00 67.69           O  
+ATOM   3145  CB  LEU A 220      90.865  36.462 121.466  1.00 66.07           C  
+ATOM   3146  CG  LEU A 220      91.768  37.657 121.140  1.00 68.72           C  
+ATOM   3147  CD1 LEU A 220      91.084  38.610 120.174  1.00 67.49           C  
+ATOM   3148  CD2 LEU A 220      92.194  38.404 122.394  1.00 72.22           C  
+ATOM   3149  N   VAL A 221      89.961  33.947 119.904  1.00 62.29           N  
+ATOM   3150  CA  VAL A 221      88.927  33.006 119.520  1.00 63.09           C  
+ATOM   3151  C   VAL A 221      89.368  31.556 119.659  1.00 73.91           C  
+ATOM   3152  O   VAL A 221      88.634  30.640 119.297  1.00 78.15           O  
+ATOM   3153  CB  VAL A 221      88.343  33.328 118.134  0.00 67.03           C  
+ATOM   3154  CG1 VAL A 221      87.105  32.492 117.864  0.00 66.81           C  
+ATOM   3155  CG2 VAL A 221      87.997  34.806 118.053  0.00 66.82           C  
+ATOM   3156  N   GLU A 222      90.554  31.341 120.220  1.00 69.36           N  
+ATOM   3157  CA  GLU A 222      91.051  29.988 120.447  1.00 68.33           C  
+ATOM   3158  C   GLU A 222      90.839  29.702 121.928  1.00 70.95           C  
+ATOM   3159  O   GLU A 222      90.229  28.704 122.312  1.00 69.20           O  
+ATOM   3160  CB  GLU A 222      92.536  29.882 120.087  0.00 69.76           C  
+ATOM   3161  CG  GLU A 222      92.825  29.979 118.594  0.00 80.23           C  
+ATOM   3162  CD  GLU A 222      93.675  28.828 118.085  0.00100.00           C  
+ATOM   3163  OE1 GLU A 222      93.542  27.709 118.622  0.00 93.94           O  
+ATOM   3164  OE2 GLU A 222      94.469  29.041 117.145  0.00 94.21           O  
+ATOM   3165  N   ARG A 223      91.330  30.624 122.748  1.00 68.33           N  
+ATOM   3166  CA  ARG A 223      91.185  30.509 124.188  1.00 67.34           C  
+ATOM   3167  C   ARG A 223      89.704  30.385 124.529  1.00 75.64           C  
+ATOM   3168  O   ARG A 223      89.378  29.644 125.454  1.00 78.29           O  
+ATOM   3169  CB  ARG A 223      91.824  31.692 124.926  1.00 60.19           C  
+ATOM   3170  CG  ARG A 223      92.537  31.393 126.255  1.00 54.51           C  
+ATOM   3171  CD  ARG A 223      93.501  32.552 126.585  1.00 65.78           C  
+ATOM   3172  NE  ARG A 223      93.758  32.770 128.011  1.00 83.31           N  
+ATOM   3173  CZ  ARG A 223      94.085  33.948 128.559  1.00100.00           C  
+ATOM   3174  NH1 ARG A 223      94.208  35.043 127.815  1.00 90.52           N  
+ATOM   3175  NH2 ARG A 223      94.300  34.032 129.865  1.00 96.00           N  
+ATOM   3176  N   TRP A 224      88.803  31.072 123.810  1.00 71.39           N  
+ATOM   3177  CA  TRP A 224      87.369  30.941 124.101  1.00 70.93           C  
+ATOM   3178  C   TRP A 224      86.880  29.537 123.835  1.00 83.42           C  
+ATOM   3179  O   TRP A 224      86.035  29.049 124.556  1.00 83.91           O  
+ATOM   3180  CB  TRP A 224      86.438  32.028 123.530  1.00 67.62           C  
+ATOM   3181  CG  TRP A 224      84.956  31.703 123.770  1.00 66.99           C  
+ATOM   3182  CD1 TRP A 224      84.020  31.401 122.816  1.00 69.56           C  
+ATOM   3183  CD2 TRP A 224      84.278  31.596 125.041  1.00 66.22           C  
+ATOM   3184  NE1 TRP A 224      82.804  31.112 123.410  1.00 69.28           N  
+ATOM   3185  CE2 TRP A 224      82.937  31.239 124.771  1.00 70.48           C  
+ATOM   3186  CE3 TRP A 224      84.670  31.771 126.372  1.00 66.29           C  
+ATOM   3187  CZ2 TRP A 224      81.994  31.046 125.783  1.00 68.63           C  
+ATOM   3188  CZ3 TRP A 224      83.735  31.590 127.367  1.00 67.14           C  
+ATOM   3189  CH2 TRP A 224      82.418  31.241 127.071  1.00 67.72           C  
+ATOM   3190  N   ILE A 225      87.488  28.842 122.885  1.00 84.30           N  
+ATOM   3191  CA  ILE A 225      87.076  27.467 122.657  1.00 84.94           C  
+ATOM   3192  C   ILE A 225      87.649  26.401 123.597  1.00 86.56           C  
+ATOM   3193  O   ILE A 225      86.963  25.427 123.909  1.00 83.80           O  
+ATOM   3194  CB  ILE A 225      86.954  27.087 121.179  1.00 88.81           C  
+ATOM   3195  CG1 ILE A 225      85.799  27.876 120.555  1.00 88.91           C  
+ATOM   3196  CG2 ILE A 225      86.715  25.594 121.036  1.00 90.97           C  
+ATOM   3197  CD1 ILE A 225      86.004  28.211 119.092  1.00 92.28           C  
+ATOM   3198  N   SER A 226      88.862  26.616 124.101  1.00 84.02           N  
+ATOM   3199  CA  SER A 226      89.434  25.691 125.073  1.00 84.64           C  
+ATOM   3200  C   SER A 226      88.595  25.752 126.365  1.00 89.49           C  
+ATOM   3201  O   SER A 226      88.245  24.721 126.951  1.00 90.12           O  
+ATOM   3202  CB  SER A 226      90.902  26.048 125.364  1.00 86.23           C  
+ATOM   3203  OG  SER A 226      91.003  27.242 126.117  1.00 90.23           O  
+ATOM   3204  N   VAL A 227      88.275  26.971 126.796  1.00 83.51           N  
+ATOM   3205  CA  VAL A 227      87.511  27.219 128.014  1.00 82.36           C  
+ATOM   3206  C   VAL A 227      86.007  27.071 127.831  1.00 87.34           C  
+ATOM   3207  O   VAL A 227      85.333  26.597 128.744  1.00 90.15           O  
+ATOM   3208  CB  VAL A 227      87.818  28.594 128.607  1.00 86.03           C  
+ATOM   3209  CG1 VAL A 227      89.311  28.924 128.419  1.00 85.88           C  
+ATOM   3210  CG2 VAL A 227      86.903  29.626 127.936  1.00 85.77           C  
+ATOM   3211  N   SER A 228      85.463  27.474 126.686  1.00 82.05           N  
+ATOM   3212  CA  SER A 228      84.020  27.329 126.471  1.00 81.94           C  
+ATOM   3213  C   SER A 228      83.653  25.880 126.180  1.00 84.03           C  
+ATOM   3214  O   SER A 228      82.496  25.483 126.344  1.00 81.68           O  
+ATOM   3215  CB  SER A 228      83.517  28.155 125.291  1.00 87.79           C  
+ATOM   3216  OG  SER A 228      84.097  27.679 124.086  1.00100.00           O  
+ATOM   3217  N   GLY A 229      84.618  25.108 125.690  1.00 81.78           N  
+ATOM   3218  CA  GLY A 229      84.372  23.710 125.324  1.00 82.52           C  
+ATOM   3219  C   GLY A 229      83.163  23.738 124.400  1.00 87.38           C  
+ATOM   3220  O   GLY A 229      82.335  22.825 124.372  1.00 86.73           O  
+ATOM   3221  N   VAL A 230      83.079  24.839 123.662  1.00 84.09           N  
+ATOM   3222  CA  VAL A 230      81.972  25.129 122.767  1.00 83.68           C  
+ATOM   3223  C   VAL A 230      81.898  24.260 121.517  1.00 88.89           C  
+ATOM   3224  O   VAL A 230      80.821  24.053 120.947  1.00 87.70           O  
+ATOM   3225  CB  VAL A 230      81.937  26.639 122.405  1.00 86.97           C  
+ATOM   3226  CG1 VAL A 230      82.458  26.883 120.995  1.00 86.13           C  
+ATOM   3227  CG2 VAL A 230      80.534  27.197 122.579  1.00 86.83           C  
+ATOM   3228  N   ALA A 231      83.053  23.731 121.118  1.00 86.33           N  
+ATOM   3229  CA  ALA A 231      83.164  22.909 119.922  1.00 85.95           C  
+ATOM   3230  C   ALA A 231      82.867  21.416 120.074  1.00 90.07           C  
+ATOM   3231  O   ALA A 231      82.841  20.696 119.076  1.00 91.40           O  
+ATOM   3232  CB  ALA A 231      84.509  23.133 119.240  1.00 86.46           C  
+ATOM   3233  N   ASP A 232      82.621  20.947 121.295  1.00 83.63           N  
+ATOM   3234  CA  ASP A 232      82.333  19.533 121.498  1.00 81.77           C  
+ATOM   3235  C   ASP A 232      81.306  18.943 120.523  1.00 84.29           C  
+ATOM   3236  O   ASP A 232      81.440  17.792 120.110  1.00 87.58           O  
+ATOM   3237  CB  ASP A 232      82.033  19.230 122.968  1.00 83.92           C  
+ATOM   3238  CG  ASP A 232      83.271  19.354 123.852  1.00 99.81           C  
+ATOM   3239  OD1 ASP A 232      84.324  18.795 123.474  1.00100.00           O  
+ATOM   3240  OD2 ASP A 232      83.190  19.997 124.920  1.00100.00           O  
+ATOM   3241  N   ASP A 233      80.303  19.726 120.137  1.00 76.77           N  
+ATOM   3242  CA  ASP A 233      79.299  19.302 119.161  1.00 75.87           C  
+ATOM   3243  C   ASP A 233      79.262  20.479 118.206  1.00 79.93           C  
+ATOM   3244  O   ASP A 233      79.251  21.627 118.642  1.00 78.97           O  
+ATOM   3245  CB  ASP A 233      77.930  19.084 119.822  1.00 77.56           C  
+ATOM   3246  CG  ASP A 233      76.754  19.491 118.930  1.00 87.55           C  
+ATOM   3247  OD1 ASP A 233      76.792  19.278 117.697  1.00 84.25           O  
+ATOM   3248  OD2 ASP A 233      75.753  20.007 119.479  1.00100.00           O  
+ATOM   3249  N   PRO A 234      79.184  20.202 116.907  1.00 78.04           N  
+ATOM   3250  CA  PRO A 234      79.171  21.256 115.896  1.00 78.47           C  
+ATOM   3251  C   PRO A 234      77.831  21.883 115.579  1.00 89.29           C  
+ATOM   3252  O   PRO A 234      77.805  22.921 114.989  1.00 91.76           O  
+ATOM   3253  CB  PRO A 234      79.642  20.543 114.627  0.00 79.72           C  
+ATOM   3254  CG  PRO A 234      80.300  19.297 115.058  0.00 83.60           C  
+ATOM   3255  CD  PRO A 234      80.127  19.129 116.543  0.00 78.65           C  
+ATOM   3256  N   ASN A 235      76.675  21.321 115.898  1.00 86.50           N  
+ATOM   3257  CA  ASN A 235      75.526  22.102 115.567  1.00 84.55           C  
+ATOM   3258  C   ASN A 235      75.497  23.488 116.344  1.00 82.31           C  
+ATOM   3259  O   ASN A 235      75.117  24.565 115.822  1.00 80.67           O  
+ATOM   3260  CB  ASN A 235      74.271  21.253 115.693  1.00 84.56           C  
+ATOM   3261  CG  ASN A 235      74.327  20.028 114.754  1.00100.00           C  
+ATOM   3262  OD1 ASN A 235      73.457  19.851 113.901  1.00100.00           O  
+ATOM   3263  ND2 ASN A 235      75.366  19.202 114.898  1.00100.00           N  
+ATOM   3264  N   ASN A 236      75.976  23.418 117.583  1.00 75.84           N  
+ATOM   3265  CA  ASN A 236      76.126  24.571 118.470  1.00 75.05           C  
+ATOM   3266  C   ASN A 236      76.438  25.931 117.853  1.00 78.98           C  
+ATOM   3267  O   ASN A 236      76.895  25.970 116.727  1.00 80.14           O  
+ATOM   3268  CB  ASN A 236      77.224  24.281 119.486  1.00 74.84           C  
+ATOM   3269  CG  ASN A 236      76.711  23.469 120.635  1.00 95.72           C  
+ATOM   3270  OD1 ASN A 236      75.541  23.090 120.657  1.00 90.02           O  
+ATOM   3271  ND2 ASN A 236      77.571  23.208 121.605  1.00 86.25           N  
+ATOM   3272  N   TYR A 237      76.400  26.978 118.679  1.00 72.12           N  
+ATOM   3273  CA  TYR A 237      76.699  28.361 118.256  1.00 69.29           C  
+ATOM   3274  C   TYR A 237      77.989  28.813 118.928  1.00 70.44           C  
+ATOM   3275  O   TYR A 237      78.189  28.513 120.106  1.00 72.29           O  
+ATOM   3276  CB  TYR A 237      75.645  29.309 118.816  1.00 70.11           C  
+ATOM   3277  CG  TYR A 237      74.290  29.275 118.175  1.00 71.78           C  
+ATOM   3278  CD1 TYR A 237      73.249  28.576 118.771  1.00 73.67           C  
+ATOM   3279  CD2 TYR A 237      74.010  30.051 117.056  1.00 71.50           C  
+ATOM   3280  CE1 TYR A 237      71.989  28.577 118.222  1.00 74.00           C  
+ATOM   3281  CE2 TYR A 237      72.747  30.071 116.506  1.00 71.30           C  
+ATOM   3282  CZ  TYR A 237      71.742  29.334 117.095  1.00 79.84           C  
+ATOM   3283  OH  TYR A 237      70.479  29.328 116.550  1.00 80.97           O  
+ATOM   3284  N   LEU A 238      78.844  29.572 118.246  1.00 62.10           N  
+ATOM   3285  CA  LEU A 238      80.098  29.966 118.899  1.00 59.01           C  
+ATOM   3286  C   LEU A 238      80.024  30.629 120.282  1.00 67.45           C  
+ATOM   3287  O   LEU A 238      80.726  30.222 121.209  1.00 69.82           O  
+ATOM   3288  CB  LEU A 238      81.057  30.713 117.967  1.00 56.59           C  
+ATOM   3289  CG  LEU A 238      82.351  31.136 118.671  1.00 58.91           C  
+ATOM   3290  CD1 LEU A 238      83.279  29.947 118.893  1.00 58.41           C  
+ATOM   3291  CD2 LEU A 238      83.054  32.318 117.996  1.00 57.32           C  
+ATOM   3292  N   PHE A 239      79.184  31.652 120.410  1.00 61.11           N  
+ATOM   3293  CA  PHE A 239      79.018  32.390 121.656  1.00 58.22           C  
+ATOM   3294  C   PHE A 239      77.876  31.924 122.545  1.00 64.13           C  
+ATOM   3295  O   PHE A 239      76.718  31.821 122.132  1.00 63.49           O  
+ATOM   3296  CB  PHE A 239      78.937  33.882 121.375  1.00 59.09           C  
+ATOM   3297  CG  PHE A 239      80.249  34.466 120.953  1.00 61.28           C  
+ATOM   3298  CD1 PHE A 239      80.415  34.995 119.685  1.00 64.46           C  
+ATOM   3299  CD2 PHE A 239      81.337  34.433 121.813  1.00 64.41           C  
+ATOM   3300  CE1 PHE A 239      81.638  35.513 119.292  1.00 67.26           C  
+ATOM   3301  CE2 PHE A 239      82.560  34.948 121.429  1.00 65.88           C  
+ATOM   3302  CZ  PHE A 239      82.712  35.485 120.165  1.00 65.67           C  
+ATOM   3303  N   CYS A 240      78.228  31.638 123.790  1.00 62.81           N  
+ATOM   3304  CA  CYS A 240      77.252  31.169 124.754  1.00 62.76           C  
+ATOM   3305  C   CYS A 240      77.342  31.938 126.064  1.00 61.57           C  
+ATOM   3306  O   CYS A 240      78.278  32.705 126.301  1.00 57.50           O  
+ATOM   3307  CB  CYS A 240      77.460  29.680 125.027  1.00 64.56           C  
+ATOM   3308  SG  CYS A 240      79.105  29.311 125.726  1.00 69.10           S  
+ATOM   3309  N   ARG A 241      76.349  31.700 126.914  1.00 58.87           N  
+ATOM   3310  CA  ARG A 241      76.277  32.323 128.227  1.00 57.40           C  
+ATOM   3311  C   ARG A 241      77.228  31.599 129.192  1.00 57.52           C  
+ATOM   3312  O   ARG A 241      77.467  30.394 129.065  1.00 55.76           O  
+ATOM   3313  CB  ARG A 241      74.823  32.373 128.734  1.00 54.96           C  
+ATOM   3314  CG  ARG A 241      74.166  31.009 128.944  1.00 60.83           C  
+ATOM   3315  CD  ARG A 241      72.663  31.110 129.199  1.00 54.64           C  
+ATOM   3316  NE  ARG A 241      72.346  31.624 130.528  1.00 61.26           N  
+ATOM   3317  CZ  ARG A 241      71.112  31.830 130.983  1.00 81.08           C  
+ATOM   3318  NH1 ARG A 241      70.056  31.549 130.222  1.00 69.73           N  
+ATOM   3319  NH2 ARG A 241      70.934  32.309 132.204  1.00 74.25           N  
+ATOM   3320  N   VAL A 242      77.804  32.375 130.111  1.00 52.03           N  
+ATOM   3321  CA  VAL A 242      78.728  31.897 131.140  1.00 50.86           C  
+ATOM   3322  C   VAL A 242      78.137  32.322 132.484  1.00 50.65           C  
+ATOM   3323  O   VAL A 242      77.977  33.511 132.765  1.00 46.77           O  
+ATOM   3324  CB  VAL A 242      80.147  32.508 130.968  1.00 55.06           C  
+ATOM   3325  CG1 VAL A 242      81.051  32.131 132.133  1.00 54.34           C  
+ATOM   3326  CG2 VAL A 242      80.773  32.058 129.660  1.00 55.08           C  
+ATOM   3327  N   ARG A 243      77.787  31.336 133.297  1.00 47.09           N  
+ATOM   3328  CA  ARG A 243      77.171  31.585 134.587  1.00 46.67           C  
+ATOM   3329  C   ARG A 243      78.091  32.209 135.617  1.00 52.79           C  
+ATOM   3330  O   ARG A 243      79.263  32.439 135.345  1.00 55.00           O  
+ATOM   3331  CB  ARG A 243      76.566  30.299 135.122  1.00 45.41           C  
+ATOM   3332  CG  ARG A 243      75.132  30.150 134.686  1.00 55.86           C  
+ATOM   3333  CD  ARG A 243      74.873  28.846 133.966  1.00 66.06           C  
+ATOM   3334  NE  ARG A 243      73.481  28.810 133.545  1.00 61.80           N  
+ATOM   3335  CZ  ARG A 243      73.044  28.285 132.408  1.00 77.93           C  
+ATOM   3336  NH1 ARG A 243      73.876  27.721 131.542  1.00 77.83           N  
+ATOM   3337  NH2 ARG A 243      71.747  28.318 132.150  1.00 68.67           N  
+ATOM   3338  N   LYS A 244      77.542  32.504 136.789  1.00 49.29           N  
+ATOM   3339  CA  LYS A 244      78.291  33.136 137.876  1.00 49.17           C  
+ATOM   3340  C   LYS A 244      79.509  32.346 138.360  1.00 48.50           C  
+ATOM   3341  O   LYS A 244      80.457  32.925 138.880  1.00 43.75           O  
+ATOM   3342  CB  LYS A 244      77.362  33.464 139.056  1.00 53.22           C  
+ATOM   3343  CG  LYS A 244      76.532  32.273 139.548  1.00 70.45           C  
+ATOM   3344  CD  LYS A 244      75.399  32.667 140.491  1.00 61.18           C  
+ATOM   3345  CE  LYS A 244      75.884  33.653 141.530  1.00 47.16           C  
+ATOM   3346  NZ  LYS A 244      74.786  34.110 142.413  1.00 48.03           N  
+ATOM   3347  N   ASN A 245      79.479  31.027 138.196  1.00 46.88           N  
+ATOM   3348  CA  ASN A 245      80.588  30.180 138.623  1.00 47.83           C  
+ATOM   3349  C   ASN A 245      81.674  30.207 137.566  1.00 60.35           C  
+ATOM   3350  O   ASN A 245      82.706  29.561 137.713  1.00 65.59           O  
+ATOM   3351  CB  ASN A 245      80.121  28.746 138.801  1.00 43.64           C  
+ATOM   3352  CG  ASN A 245      79.492  28.192 137.551  1.00 72.47           C  
+ATOM   3353  OD1 ASN A 245      79.099  27.034 137.521  1.00 68.54           O  
+ATOM   3354  ND2 ASN A 245      79.389  29.015 136.514  1.00 62.32           N  
+ATOM   3355  N   GLY A 246      81.411  30.899 136.467  1.00 57.08           N  
+ATOM   3356  CA  GLY A 246      82.408  30.987 135.417  1.00 55.75           C  
+ATOM   3357  C   GLY A 246      82.398  29.733 134.569  1.00 59.48           C  
+ATOM   3358  O   GLY A 246      83.364  29.445 133.869  1.00 61.11           O  
+ATOM   3359  N   VAL A 247      81.301  28.989 134.628  1.00 57.07           N  
+ATOM   3360  CA  VAL A 247      81.184  27.791 133.813  1.00 58.97           C  
+ATOM   3361  C   VAL A 247      80.363  28.064 132.550  1.00 70.42           C  
+ATOM   3362  O   VAL A 247      79.340  28.749 132.590  1.00 69.75           O  
+ATOM   3363  CB  VAL A 247      80.574  26.615 134.588  1.00 61.78           C  
+ATOM   3364  CG1 VAL A 247      80.151  25.512 133.623  1.00 61.08           C  
+ATOM   3365  CG2 VAL A 247      81.569  26.085 135.609  1.00 61.44           C  
+ATOM   3366  N   ALA A 248      80.819  27.512 131.431  1.00 72.00           N  
+ATOM   3367  CA  ALA A 248      80.159  27.695 130.142  1.00 73.53           C  
+ATOM   3368  C   ALA A 248      79.025  26.709 129.865  1.00 80.65           C  
+ATOM   3369  O   ALA A 248      78.934  25.654 130.496  1.00 83.95           O  
+ATOM   3370  CB  ALA A 248      81.181  27.666 129.018  1.00 74.63           C  
+ATOM   3371  N   ALA A 249      78.164  27.061 128.913  1.00 73.85           N  
+ATOM   3372  CA  ALA A 249      77.031  26.214 128.555  1.00 71.90           C  
+ATOM   3373  C   ALA A 249      76.664  26.357 127.083  1.00 72.46           C  
+ATOM   3374  O   ALA A 249      75.830  27.184 126.706  1.00 71.49           O  
+ATOM   3375  CB  ALA A 249      75.834  26.517 129.452  1.00 72.50           C  
+ATOM   3376  N   PRO A 250      77.311  25.544 126.257  1.00 66.15           N  
+ATOM   3377  CA  PRO A 250      77.091  25.569 124.819  1.00 64.36           C  
+ATOM   3378  C   PRO A 250      75.628  25.330 124.452  1.00 68.10           C  
+ATOM   3379  O   PRO A 250      74.796  25.072 125.321  1.00 71.25           O  
+ATOM   3380  CB  PRO A 250      78.001  24.447 124.323  1.00 65.92           C  
+ATOM   3381  CG  PRO A 250      79.147  24.434 125.319  1.00 70.43           C  
+ATOM   3382  CD  PRO A 250      78.683  25.117 126.585  1.00 66.08           C  
+ATOM   3383  N   SER A 251      75.307  25.433 123.169  1.00 61.28           N  
+ATOM   3384  CA  SER A 251      73.933  25.234 122.736  1.00 61.31           C  
+ATOM   3385  C   SER A 251      73.794  25.283 121.211  1.00 73.59           C  
+ATOM   3386  O   SER A 251      74.226  26.239 120.570  1.00 74.65           O  
+ATOM   3387  CB  SER A 251      73.035  26.297 123.381  1.00 61.92           C  
+ATOM   3388  OG  SER A 251      71.747  25.790 123.701  1.00 69.35           O  
+ATOM   3389  N   ALA A 252      73.185  24.263 120.618  1.00 72.14           N  
+ATOM   3390  CA  ALA A 252      72.990  24.297 119.178  1.00 71.65           C  
+ATOM   3391  C   ALA A 252      71.566  24.812 118.997  1.00 75.23           C  
+ATOM   3392  O   ALA A 252      71.047  24.922 117.887  1.00 77.47           O  
+ATOM   3393  CB  ALA A 252      73.132  22.890 118.596  1.00 72.34           C  
+ATOM   3394  N   THR A 253      70.937  25.145 120.118  1.00 69.24           N  
+ATOM   3395  CA  THR A 253      69.551  25.571 120.090  1.00 68.83           C  
+ATOM   3396  C   THR A 253      69.220  26.985 120.551  1.00 71.54           C  
+ATOM   3397  O   THR A 253      68.187  27.546 120.172  1.00 69.59           O  
+ATOM   3398  CB  THR A 253      68.692  24.557 120.851  1.00 86.64           C  
+ATOM   3399  OG1 THR A 253      68.102  23.652 119.914  1.00 92.25           O  
+ATOM   3400  CG2 THR A 253      67.596  25.248 121.648  1.00 90.43           C  
+ATOM   3401  N   SER A 254      70.083  27.556 121.382  1.00 66.56           N  
+ATOM   3402  CA  SER A 254      69.857  28.900 121.879  1.00 63.42           C  
+ATOM   3403  C   SER A 254      71.078  29.756 121.588  1.00 65.48           C  
+ATOM   3404  O   SER A 254      72.215  29.291 121.679  1.00 64.33           O  
+ATOM   3405  CB  SER A 254      69.599  28.857 123.381  1.00 65.39           C  
+ATOM   3406  OG  SER A 254      68.873  29.995 123.779  1.00 82.18           O  
+ATOM   3407  N   GLN A 255      70.841  31.004 121.205  1.00 60.26           N  
+ATOM   3408  CA  GLN A 255      71.967  31.872 120.946  1.00 60.26           C  
+ATOM   3409  C   GLN A 255      71.938  32.958 122.007  1.00 63.49           C  
+ATOM   3410  O   GLN A 255      70.910  33.187 122.656  1.00 63.02           O  
+ATOM   3411  CB  GLN A 255      71.987  32.426 119.516  1.00 61.86           C  
+ATOM   3412  CG  GLN A 255      70.635  32.750 118.916  1.00 64.25           C  
+ATOM   3413  CD  GLN A 255      70.813  33.396 117.566  1.00 66.81           C  
+ATOM   3414  OE1 GLN A 255      71.001  32.710 116.582  1.00 62.47           O  
+ATOM   3415  NE2 GLN A 255      70.703  34.721 117.543  1.00 59.05           N  
+ATOM   3416  N   LEU A 256      73.085  33.591 122.217  1.00 55.98           N  
+ATOM   3417  CA  LEU A 256      73.148  34.650 123.196  1.00 53.13           C  
+ATOM   3418  C   LEU A 256      72.214  35.727 122.663  1.00 55.57           C  
+ATOM   3419  O   LEU A 256      72.162  35.974 121.457  1.00 54.79           O  
+ATOM   3420  CB  LEU A 256      74.574  35.179 123.293  1.00 52.44           C  
+ATOM   3421  CG  LEU A 256      75.151  35.128 124.704  1.00 55.64           C  
+ATOM   3422  CD1 LEU A 256      76.363  36.042 124.790  1.00 55.62           C  
+ATOM   3423  CD2 LEU A 256      74.085  35.557 125.696  1.00 56.49           C  
+ATOM   3424  N   SER A 257      71.467  36.350 123.563  1.00 51.68           N  
+ATOM   3425  CA  SER A 257      70.547  37.419 123.206  1.00 48.87           C  
+ATOM   3426  C   SER A 257      71.379  38.594 122.684  1.00 52.69           C  
+ATOM   3427  O   SER A 257      72.568  38.714 123.003  1.00 51.49           O  
+ATOM   3428  CB  SER A 257      69.815  37.869 124.465  1.00 45.99           C  
+ATOM   3429  OG  SER A 257      70.651  38.738 125.202  1.00 41.61           O  
+ATOM   3430  N   THR A 258      70.760  39.454 121.878  1.00 49.35           N  
+ATOM   3431  CA  THR A 258      71.482  40.604 121.343  1.00 49.62           C  
+ATOM   3432  C   THR A 258      71.666  41.558 122.518  1.00 50.52           C  
+ATOM   3433  O   THR A 258      72.627  42.332 122.569  1.00 48.54           O  
+ATOM   3434  CB  THR A 258      70.718  41.277 120.172  1.00 50.40           C  
+ATOM   3435  OG1 THR A 258      69.311  41.200 120.430  1.00 53.83           O  
+ATOM   3436  CG2 THR A 258      71.022  40.584 118.840  1.00 36.78           C  
+ATOM   3437  N   ARG A 259      70.736  41.461 123.467  1.00 46.34           N  
+ATOM   3438  CA  ARG A 259      70.789  42.248 124.703  1.00 44.99           C  
+ATOM   3439  C   ARG A 259      72.096  41.929 125.450  1.00 47.25           C  
+ATOM   3440  O   ARG A 259      72.816  42.840 125.884  1.00 46.61           O  
+ATOM   3441  CB  ARG A 259      69.583  41.902 125.588  1.00 41.96           C  
+ATOM   3442  CG  ARG A 259      69.328  42.899 126.707  1.00 39.63           C  
+ATOM   3443  CD  ARG A 259      69.098  44.272 126.139  1.00 39.46           C  
+ATOM   3444  NE  ARG A 259      68.991  45.291 127.177  1.00 40.24           N  
+ATOM   3445  CZ  ARG A 259      70.023  46.005 127.610  1.00 60.52           C  
+ATOM   3446  NH1 ARG A 259      71.232  45.799 127.097  1.00 49.93           N  
+ATOM   3447  NH2 ARG A 259      69.847  46.913 128.561  1.00 57.50           N  
+ATOM   3448  N   ALA A 260      72.409  40.640 125.556  1.00 43.32           N  
+ATOM   3449  CA  ALA A 260      73.615  40.140 126.224  1.00 42.89           C  
+ATOM   3450  C   ALA A 260      74.915  40.655 125.572  1.00 52.25           C  
+ATOM   3451  O   ALA A 260      75.922  40.983 126.255  1.00 51.66           O  
+ATOM   3452  CB  ALA A 260      73.581  38.616 126.189  1.00 42.10           C  
+ATOM   3453  N   LEU A 261      74.862  40.786 124.255  1.00 50.36           N  
+ATOM   3454  CA  LEU A 261      76.000  41.264 123.446  1.00 48.41           C  
+ATOM   3455  C   LEU A 261      76.099  42.771 123.625  1.00 48.61           C  
+ATOM   3456  O   LEU A 261      77.189  43.341 123.589  1.00 47.45           O  
+ATOM   3457  CB  LEU A 261      75.801  40.888 121.973  1.00 48.25           C  
+ATOM   3458  CG  LEU A 261      75.680  39.387 121.696  1.00 53.49           C  
+ATOM   3459  CD1 LEU A 261      74.987  39.140 120.359  1.00 52.70           C  
+ATOM   3460  CD2 LEU A 261      77.055  38.713 121.742  1.00 58.02           C  
+ATOM   3461  N   GLU A 262      74.957  43.407 123.823  1.00 43.58           N  
+ATOM   3462  CA  GLU A 262      74.975  44.835 124.063  1.00 45.24           C  
+ATOM   3463  C   GLU A 262      75.578  44.996 125.461  1.00 50.51           C  
+ATOM   3464  O   GLU A 262      76.308  45.956 125.728  1.00 48.22           O  
+ATOM   3465  CB  GLU A 262      73.549  45.388 124.018  1.00 47.64           C  
+ATOM   3466  CG  GLU A 262      72.822  45.132 122.702  1.00 64.46           C  
+ATOM   3467  CD  GLU A 262      71.488  45.851 122.630  1.00 76.22           C  
+ATOM   3468  OE1 GLU A 262      70.622  45.609 123.496  1.00 72.83           O  
+ATOM   3469  OE2 GLU A 262      71.302  46.676 121.712  1.00 64.10           O  
+ATOM   3470  N   GLY A 263      75.273  44.039 126.339  1.00 47.53           N  
+ATOM   3471  CA  GLY A 263      75.780  44.015 127.712  1.00 47.05           C  
+ATOM   3472  C   GLY A 263      77.305  43.972 127.762  1.00 47.04           C  
+ATOM   3473  O   GLY A 263      77.934  44.803 128.417  1.00 47.81           O  
+ATOM   3474  N   ILE A 264      77.890  43.012 127.051  1.00 41.67           N  
+ATOM   3475  CA  ILE A 264      79.340  42.897 127.002  1.00 42.69           C  
+ATOM   3476  C   ILE A 264      79.974  44.218 126.586  1.00 52.52           C  
+ATOM   3477  O   ILE A 264      81.093  44.519 126.996  1.00 56.87           O  
+ATOM   3478  CB  ILE A 264      79.826  41.811 126.015  1.00 45.22           C  
+ATOM   3479  CG1 ILE A 264      79.165  40.453 126.299  1.00 45.02           C  
+ATOM   3480  CG2 ILE A 264      81.349  41.734 126.015  1.00 43.74           C  
+ATOM   3481  CD1 ILE A 264      79.336  39.410 125.196  1.00 34.69           C  
+ATOM   3482  N   PHE A 265      79.280  45.011 125.775  1.00 48.55           N  
+ATOM   3483  CA  PHE A 265      79.838  46.289 125.350  1.00 48.88           C  
+ATOM   3484  C   PHE A 265      79.738  47.307 126.465  1.00 51.50           C  
+ATOM   3485  O   PHE A 265      80.668  48.075 126.696  1.00 52.94           O  
+ATOM   3486  CB  PHE A 265      79.147  46.832 124.096  1.00 51.11           C  
+ATOM   3487  CG  PHE A 265      79.937  46.629 122.831  1.00 52.84           C  
+ATOM   3488  CD1 PHE A 265      79.448  45.814 121.825  1.00 55.03           C  
+ATOM   3489  CD2 PHE A 265      81.170  47.239 122.656  1.00 55.99           C  
+ATOM   3490  CE1 PHE A 265      80.169  45.608 120.668  1.00 57.55           C  
+ATOM   3491  CE2 PHE A 265      81.900  47.034 121.502  1.00 57.36           C  
+ATOM   3492  CZ  PHE A 265      81.401  46.211 120.509  1.00 55.93           C  
+ATOM   3493  N   GLU A 266      78.591  47.313 127.133  1.00 46.46           N  
+ATOM   3494  CA  GLU A 266      78.338  48.246 128.220  1.00 46.56           C  
+ATOM   3495  C   GLU A 266      79.220  47.913 129.414  1.00 51.34           C  
+ATOM   3496  O   GLU A 266      79.817  48.804 130.021  1.00 51.72           O  
+ATOM   3497  CB  GLU A 266      76.869  48.214 128.650  1.00 47.62           C  
+ATOM   3498  CG  GLU A 266      76.500  49.387 129.547  1.00 60.71           C  
+ATOM   3499  CD  GLU A 266      75.441  49.037 130.575  1.00 96.48           C  
+ATOM   3500  OE1 GLU A 266      74.344  48.603 130.175  1.00100.00           O  
+ATOM   3501  OE2 GLU A 266      75.704  49.188 131.786  1.00100.00           O  
+ATOM   3502  N   ALA A 267      79.269  46.625 129.747  1.00 45.60           N  
+ATOM   3503  CA  ALA A 267      80.081  46.122 130.852  1.00 44.38           C  
+ATOM   3504  C   ALA A 267      81.521  46.555 130.617  1.00 50.10           C  
+ATOM   3505  O   ALA A 267      82.164  47.188 131.457  1.00 49.15           O  
+ATOM   3506  CB  ALA A 267      80.004  44.604 130.892  1.00 44.11           C  
+ATOM   3507  N   THR A 268      82.015  46.201 129.444  1.00 49.46           N  
+ATOM   3508  CA  THR A 268      83.374  46.523 129.064  1.00 49.86           C  
+ATOM   3509  C   THR A 268      83.745  47.995 129.195  1.00 55.19           C  
+ATOM   3510  O   THR A 268      84.871  48.320 129.560  1.00 58.19           O  
+ATOM   3511  CB  THR A 268      83.687  45.999 127.660  1.00 58.99           C  
+ATOM   3512  OG1 THR A 268      83.892  44.578 127.715  1.00 58.92           O  
+ATOM   3513  CG2 THR A 268      84.926  46.681 127.112  1.00 59.76           C  
+ATOM   3514  N   HIS A 269      82.814  48.897 128.915  1.00 51.28           N  
+ATOM   3515  CA  HIS A 269      83.099  50.330 129.003  1.00 49.65           C  
+ATOM   3516  C   HIS A 269      83.058  50.792 130.448  1.00 54.71           C  
+ATOM   3517  O   HIS A 269      83.604  51.839 130.795  1.00 53.48           O  
+ATOM   3518  CB  HIS A 269      82.002  51.108 128.250  1.00 48.48           C  
+ATOM   3519  CG  HIS A 269      82.307  52.555 128.032  1.00 48.94           C  
+ATOM   3520  ND1 HIS A 269      81.724  53.564 128.770  1.00 48.71           N  
+ATOM   3521  CD2 HIS A 269      83.089  53.164 127.110  1.00 50.00           C  
+ATOM   3522  CE1 HIS A 269      82.149  54.732 128.325  1.00 48.35           C  
+ATOM   3523  NE2 HIS A 269      82.981  54.517 127.317  1.00 49.18           N  
+ATOM   3524  N   ARG A 270      82.342  50.039 131.272  1.00 53.84           N  
+ATOM   3525  CA  ARG A 270      82.211  50.405 132.672  1.00 58.09           C  
+ATOM   3526  C   ARG A 270      83.534  50.068 133.360  1.00 68.16           C  
+ATOM   3527  O   ARG A 270      84.068  50.861 134.145  1.00 68.26           O  
+ATOM   3528  CB  ARG A 270      81.005  49.690 133.298  1.00 60.35           C  
+ATOM   3529  CG  ARG A 270      81.254  49.027 134.644  1.00 68.95           C  
+ATOM   3530  CD  ARG A 270      80.277  49.534 135.689  1.00 81.70           C  
+ATOM   3531  NE  ARG A 270      80.141  48.619 136.820  1.00 98.79           N  
+ATOM   3532  CZ  ARG A 270      80.524  48.895 138.063  1.00100.00           C  
+ATOM   3533  NH1 ARG A 270      81.085  50.062 138.347  1.00100.00           N  
+ATOM   3534  NH2 ARG A 270      80.353  48.000 139.025  1.00 82.58           N  
+ATOM   3535  N   LEU A 271      84.093  48.922 132.989  1.00 64.79           N  
+ATOM   3536  CA  LEU A 271      85.364  48.485 133.532  1.00 64.36           C  
+ATOM   3537  C   LEU A 271      86.442  49.555 133.400  1.00 70.24           C  
+ATOM   3538  O   LEU A 271      87.315  49.679 134.258  1.00 73.34           O  
+ATOM   3539  CB  LEU A 271      85.828  47.234 132.798  1.00 63.86           C  
+ATOM   3540  CG  LEU A 271      87.262  46.806 133.104  1.00 67.52           C  
+ATOM   3541  CD1 LEU A 271      87.359  46.281 134.537  1.00 66.34           C  
+ATOM   3542  CD2 LEU A 271      87.712  45.762 132.087  1.00 67.60           C  
+ATOM   3543  N   ILE A 272      86.394  50.308 132.307  1.00 63.91           N  
+ATOM   3544  CA  ILE A 272      87.392  51.335 132.026  1.00 62.54           C  
+ATOM   3545  C   ILE A 272      86.968  52.726 132.474  1.00 71.26           C  
+ATOM   3546  O   ILE A 272      87.784  53.517 132.948  1.00 73.80           O  
+ATOM   3547  CB  ILE A 272      87.714  51.386 130.506  1.00 62.38           C  
+ATOM   3548  CG1 ILE A 272      88.471  50.132 130.060  1.00 61.64           C  
+ATOM   3549  CG2 ILE A 272      88.484  52.649 130.153  1.00 56.99           C  
+ATOM   3550  CD1 ILE A 272      89.104  50.266 128.686  1.00 58.78           C  
+ATOM   3551  N   TYR A 273      85.697  53.048 132.305  1.00 67.09           N  
+ATOM   3552  CA  TYR A 273      85.269  54.391 132.653  1.00 66.66           C  
+ATOM   3553  C   TYR A 273      84.330  54.509 133.850  1.00 70.49           C  
+ATOM   3554  O   TYR A 273      84.232  55.579 134.450  1.00 69.78           O  
+ATOM   3555  CB  TYR A 273      84.753  55.120 131.402  1.00 67.63           C  
+ATOM   3556  CG  TYR A 273      85.639  55.015 130.164  1.00 67.23           C  
+ATOM   3557  CD1 TYR A 273      85.635  53.875 129.367  1.00 68.20           C  
+ATOM   3558  CD2 TYR A 273      86.461  56.071 129.781  1.00 67.86           C  
+ATOM   3559  CE1 TYR A 273      86.432  53.778 128.234  1.00 69.31           C  
+ATOM   3560  CE2 TYR A 273      87.260  55.983 128.642  1.00 69.43           C  
+ATOM   3561  CZ  TYR A 273      87.243  54.835 127.868  1.00 78.00           C  
+ATOM   3562  OH  TYR A 273      88.036  54.751 126.738  1.00 77.32           O  
+ATOM   3563  N   GLY A 274      83.618  53.443 134.188  1.00 68.01           N  
+ATOM   3564  CA  GLY A 274      82.734  53.467 135.342  1.00 69.48           C  
+ATOM   3565  C   GLY A 274      81.255  53.739 135.148  1.00 78.58           C  
+ATOM   3566  O   GLY A 274      80.684  53.753 134.055  1.00 78.43           O  
+ATOM   3567  N   ALA A 275      80.671  53.998 136.308  1.00 79.63           N  
+ATOM   3568  CA  ALA A 275      79.260  54.260 136.511  1.00 80.58           C  
+ATOM   3569  C   ALA A 275      78.647  55.070 135.377  1.00 83.88           C  
+ATOM   3570  O   ALA A 275      79.225  56.060 134.917  1.00 80.37           O  
+ATOM   3571  CB  ALA A 275      79.045  54.956 137.872  1.00 82.42           C  
+ATOM   3572  N   LYS A 276      77.482  54.628 134.915  1.00 85.92           N  
+ATOM   3573  CA  LYS A 276      76.692  55.269 133.849  1.00 87.56           C  
+ATOM   3574  C   LYS A 276      76.864  56.776 134.016  1.00 91.52           C  
+ATOM   3575  O   LYS A 276      76.637  57.297 135.127  1.00 90.39           O  
+ATOM   3576  CB  LYS A 276      75.215  54.841 133.924  1.00 91.93           C  
+ATOM   3577  CG  LYS A 276      74.440  55.106 132.646  1.00100.00           C  
+ATOM   3578  CD  LYS A 276      75.079  54.391 131.467  1.00100.00           C  
+ATOM   3579  CE  LYS A 276      74.397  54.769 130.162  1.00 96.25           C  
+ATOM   3580  NZ  LYS A 276      73.874  53.568 129.440  1.00100.00           N  
+ATOM   3581  N   ASP A 277      77.116  57.490 132.944  1.00 90.20           N  
+ATOM   3582  CA  ASP A 277      77.451  58.892 133.068  1.00 91.39           C  
+ATOM   3583  C   ASP A 277      76.409  60.007 132.943  1.00 96.76           C  
+ATOM   3584  O   ASP A 277      75.412  60.111 133.669  1.00 96.47           O  
+ATOM   3585  CB  ASP A 277      78.589  59.089 132.067  1.00 93.80           C  
+ATOM   3586  CG  ASP A 277      79.039  57.757 131.441  1.00100.00           C  
+ATOM   3587  OD1 ASP A 277      79.152  56.751 132.190  1.00100.00           O  
+ATOM   3588  OD2 ASP A 277      79.262  57.711 130.205  1.00100.00           O  
+ATOM   3589  N   ASP A 278      76.729  60.827 131.942  1.00 94.60           N  
+ATOM   3590  CA  ASP A 278      76.043  62.025 131.433  1.00 95.36           C  
+ATOM   3591  C   ASP A 278      74.513  61.988 131.123  1.00 99.91           C  
+ATOM   3592  O   ASP A 278      74.160  62.099 129.953  1.00 99.49           O  
+ATOM   3593  CB  ASP A 278      76.708  62.432 130.083  1.00 97.64           C  
+ATOM   3594  CG  ASP A 278      77.887  63.468 130.210  1.00100.00           C  
+ATOM   3595  OD1 ASP A 278      78.551  63.541 131.272  1.00100.00           O  
+ATOM   3596  OD2 ASP A 278      78.155  64.182 129.197  1.00100.00           O  
+ATOM   3597  N   SER A 279      73.641  61.736 132.125  1.00 96.12           N  
+ATOM   3598  CA  SER A 279      72.156  61.841 132.089  1.00 95.63           C  
+ATOM   3599  C   SER A 279      70.975  60.879 132.021  1.00100.00           C  
+ATOM   3600  O   SER A 279      69.962  61.048 132.710  1.00100.00           O  
+ATOM   3601  CB  SER A 279      71.756  62.931 131.112  1.00 98.44           C  
+ATOM   3602  OG  SER A 279      70.702  63.757 131.594  1.00100.00           O  
+ATOM   3603  N   GLY A 280      71.059  59.934 131.094  1.00 95.73           N  
+ATOM   3604  CA  GLY A 280      69.922  59.050 130.820  1.00 94.21           C  
+ATOM   3605  C   GLY A 280      69.918  59.145 129.301  1.00 95.38           C  
+ATOM   3606  O   GLY A 280      69.036  58.600 128.648  1.00 95.70           O  
+ATOM   3607  N   GLN A 281      70.926  59.820 128.744  1.00 89.47           N  
+ATOM   3608  CA  GLN A 281      71.075  59.946 127.294  1.00 87.96           C  
+ATOM   3609  C   GLN A 281      71.420  58.573 126.727  1.00 88.07           C  
+ATOM   3610  O   GLN A 281      71.638  57.623 127.474  1.00 88.30           O  
+ATOM   3611  CB  GLN A 281      72.224  60.880 126.958  1.00 89.16           C  
+ATOM   3612  CG  GLN A 281      72.007  62.387 126.873  1.00 99.25           C  
+ATOM   3613  CD  GLN A 281      73.250  63.179 126.685  1.00100.00           C  
+ATOM   3614  OE1 GLN A 281      74.275  62.504 126.292  1.00100.00           O  
+ATOM   3615  NE2 GLN A 281      73.240  64.451 126.898  1.00 97.61           N  
+ATOM   3616  N   ARG A 282      71.497  58.497 125.404  1.00 80.39           N  
+ATOM   3617  CA  ARG A 282      71.848  57.244 124.745  1.00 78.16           C  
+ATOM   3618  C   ARG A 282      73.332  57.268 124.395  1.00 75.47           C  
+ATOM   3619  O   ARG A 282      73.979  58.315 124.481  1.00 72.70           O  
+ATOM   3620  CB  ARG A 282      71.003  57.031 123.485  1.00 77.45           C  
+ATOM   3621  CG  ARG A 282      69.667  56.347 123.742  1.00 85.97           C  
+ATOM   3622  CD  ARG A 282      69.075  55.831 122.447  1.00100.00           C  
+ATOM   3623  NE  ARG A 282      67.763  55.237 122.649  1.00100.00           N  
+ATOM   3624  CZ  ARG A 282      67.133  54.485 121.753  1.00 99.78           C  
+ATOM   3625  NH1 ARG A 282      67.676  54.239 120.568  1.00 74.24           N  
+ATOM   3626  NH2 ARG A 282      65.940  53.988 122.043  1.00 87.54           N  
+ATOM   3627  N   TYR A 283      73.863  56.107 124.018  1.00 69.57           N  
+ATOM   3628  CA  TYR A 283      75.265  55.980 123.629  1.00 68.26           C  
+ATOM   3629  C   TYR A 283      76.251  56.619 124.603  1.00 69.61           C  
+ATOM   3630  O   TYR A 283      77.260  57.182 124.176  1.00 69.84           O  
+ATOM   3631  CB  TYR A 283      75.492  56.587 122.242  1.00 69.34           C  
+ATOM   3632  CG  TYR A 283      74.576  56.052 121.169  1.00 70.94           C  
+ATOM   3633  CD1 TYR A 283      73.793  56.910 120.409  1.00 71.40           C  
+ATOM   3634  CD2 TYR A 283      74.490  54.686 120.920  1.00 72.61           C  
+ATOM   3635  CE1 TYR A 283      72.956  56.420 119.429  1.00 72.42           C  
+ATOM   3636  CE2 TYR A 283      73.657  54.188 119.944  1.00 71.28           C  
+ATOM   3637  CZ  TYR A 283      72.891  55.058 119.204  1.00 76.92           C  
+ATOM   3638  OH  TYR A 283      72.069  54.553 118.229  1.00 74.17           O  
+ATOM   3639  N   LEU A 284      75.974  56.547 125.901  1.00 62.09           N  
+ATOM   3640  CA  LEU A 284      76.893  57.129 126.872  1.00 59.06           C  
+ATOM   3641  C   LEU A 284      78.102  56.211 127.011  1.00 61.71           C  
+ATOM   3642  O   LEU A 284      79.211  56.661 127.311  1.00 62.55           O  
+ATOM   3643  CB  LEU A 284      76.190  57.405 128.201  1.00 58.02           C  
+ATOM   3644  CG  LEU A 284      75.279  58.633 128.053  1.00 60.34           C  
+ATOM   3645  CD1 LEU A 284      74.616  59.059 129.351  1.00 59.43           C  
+ATOM   3646  CD2 LEU A 284      75.975  59.813 127.378  1.00 58.55           C  
+ATOM   3647  N   ALA A 285      77.875  54.925 126.741  1.00 55.07           N  
+ATOM   3648  CA  ALA A 285      78.914  53.895 126.771  1.00 53.54           C  
+ATOM   3649  C   ALA A 285      79.061  53.302 125.374  1.00 60.89           C  
+ATOM   3650  O   ALA A 285      78.919  53.993 124.375  1.00 62.60           O  
+ATOM   3651  CB  ALA A 285      78.534  52.795 127.752  1.00 53.28           C  
+ATOM   3652  N   TRP A 286      79.355  52.003 125.304  1.00 58.43           N  
+ATOM   3653  CA  TRP A 286      79.464  51.343 124.012  1.00 57.90           C  
+ATOM   3654  C   TRP A 286      78.186  50.547 123.803  1.00 58.08           C  
+ATOM   3655  O   TRP A 286      77.579  50.087 124.771  1.00 55.97           O  
+ATOM   3656  CB  TRP A 286      80.677  50.414 123.969  1.00 57.51           C  
+ATOM   3657  CG  TRP A 286      81.975  51.152 123.827  1.00 59.82           C  
+ATOM   3658  CD1 TRP A 286      82.269  52.147 122.932  1.00 63.02           C  
+ATOM   3659  CD2 TRP A 286      83.145  50.975 124.628  1.00 59.90           C  
+ATOM   3660  NE1 TRP A 286      83.557  52.588 123.122  1.00 62.70           N  
+ATOM   3661  CE2 TRP A 286      84.116  51.887 124.159  1.00 64.38           C  
+ATOM   3662  CE3 TRP A 286      83.469  50.134 125.697  1.00 61.24           C  
+ATOM   3663  CZ2 TRP A 286      85.388  51.979 124.725  1.00 63.71           C  
+ATOM   3664  CZ3 TRP A 286      84.729  50.227 126.256  1.00 63.09           C  
+ATOM   3665  CH2 TRP A 286      85.678  51.138 125.764  1.00 63.72           C  
+ATOM   3666  N   SER A 287      77.768  50.410 122.546  1.00 52.10           N  
+ATOM   3667  CA  SER A 287      76.563  49.655 122.210  1.00 47.79           C  
+ATOM   3668  C   SER A 287      76.934  48.708 121.087  1.00 51.18           C  
+ATOM   3669  O   SER A 287      78.074  48.728 120.619  1.00 51.46           O  
+ATOM   3670  CB  SER A 287      75.403  50.559 121.806  1.00 43.64           C  
+ATOM   3671  OG  SER A 287      75.877  51.678 121.076  1.00 47.60           O  
+ATOM   3672  N   GLY A 288      75.995  47.857 120.687  1.00 48.45           N  
+ATOM   3673  CA  GLY A 288      76.240  46.860 119.649  1.00 48.22           C  
+ATOM   3674  C   GLY A 288      76.904  47.399 118.383  1.00 54.00           C  
+ATOM   3675  O   GLY A 288      77.689  46.716 117.726  1.00 53.32           O  
+ATOM   3676  N   HIS A 289      76.580  48.627 118.024  1.00 52.95           N  
+ATOM   3677  CA  HIS A 289      77.146  49.192 116.815  1.00 55.57           C  
+ATOM   3678  C   HIS A 289      78.511  49.871 116.915  1.00 61.00           C  
+ATOM   3679  O   HIS A 289      79.092  50.229 115.887  1.00 60.95           O  
+ATOM   3680  CB  HIS A 289      76.117  50.111 116.164  1.00 58.24           C  
+ATOM   3681  CG  HIS A 289      75.378  49.462 115.039  1.00 63.36           C  
+ATOM   3682  ND1 HIS A 289      75.101  48.111 115.012  1.00 66.10           N  
+ATOM   3683  CD2 HIS A 289      74.906  49.968 113.875  1.00 65.69           C  
+ATOM   3684  CE1 HIS A 289      74.473  47.815 113.887  1.00 65.38           C  
+ATOM   3685  NE2 HIS A 289      74.341  48.925 113.182  1.00 65.73           N  
+ATOM   3686  N   SER A 290      79.010  50.052 118.138  1.00 56.06           N  
+ATOM   3687  CA  SER A 290      80.290  50.714 118.393  1.00 52.53           C  
+ATOM   3688  C   SER A 290      81.469  50.169 117.594  1.00 53.29           C  
+ATOM   3689  O   SER A 290      82.230  50.931 117.000  1.00 51.43           O  
+ATOM   3690  CB  SER A 290      80.592  50.723 119.889  1.00 52.78           C  
+ATOM   3691  OG  SER A 290      79.570  51.427 120.580  1.00 57.45           O  
+ATOM   3692  N   ALA A 291      81.589  48.847 117.562  1.00 50.38           N  
+ATOM   3693  CA  ALA A 291      82.661  48.173 116.840  1.00 51.39           C  
+ATOM   3694  C   ALA A 291      82.663  48.494 115.347  1.00 56.60           C  
+ATOM   3695  O   ALA A 291      83.714  48.668 114.732  1.00 53.96           O  
+ATOM   3696  CB  ALA A 291      82.551  46.673 117.048  1.00 52.07           C  
+ATOM   3697  N   ARG A 292      81.474  48.533 114.758  1.00 56.98           N  
+ATOM   3698  CA  ARG A 292      81.351  48.837 113.341  1.00 56.52           C  
+ATOM   3699  C   ARG A 292      81.678  50.305 113.101  1.00 59.19           C  
+ATOM   3700  O   ARG A 292      82.228  50.658 112.068  1.00 58.63           O  
+ATOM   3701  CB  ARG A 292      79.957  48.492 112.819  1.00 51.90           C  
+ATOM   3702  CG  ARG A 292      79.802  47.015 112.534  1.00 50.28           C  
+ATOM   3703  CD  ARG A 292      78.360  46.683 112.295  1.00 57.89           C  
+ATOM   3704  NE  ARG A 292      77.737  47.632 111.378  1.00 57.31           N  
+ATOM   3705  CZ  ARG A 292      77.425  47.331 110.122  1.00 62.52           C  
+ATOM   3706  NH1 ARG A 292      77.700  46.125 109.645  1.00 51.12           N  
+ATOM   3707  NH2 ARG A 292      76.847  48.220 109.329  1.00 60.24           N  
+ATOM   3708  N   VAL A 293      81.357  51.158 114.071  1.00 54.48           N  
+ATOM   3709  CA  VAL A 293      81.626  52.583 113.949  1.00 53.10           C  
+ATOM   3710  C   VAL A 293      83.116  52.883 114.002  1.00 57.15           C  
+ATOM   3711  O   VAL A 293      83.631  53.678 113.216  1.00 56.26           O  
+ATOM   3712  CB  VAL A 293      80.945  53.365 115.085  1.00 55.74           C  
+ATOM   3713  CG1 VAL A 293      81.554  54.751 115.221  1.00 55.13           C  
+ATOM   3714  CG2 VAL A 293      79.439  53.437 114.878  1.00 55.00           C  
+ATOM   3715  N   GLY A 294      83.805  52.246 114.941  1.00 57.62           N  
+ATOM   3716  CA  GLY A 294      85.238  52.452 115.120  1.00 58.19           C  
+ATOM   3717  C   GLY A 294      86.083  51.806 114.027  1.00 62.47           C  
+ATOM   3718  O   GLY A 294      87.046  52.410 113.554  1.00 63.10           O  
+ATOM   3719  N   ALA A 295      85.732  50.577 113.651  1.00 59.61           N  
+ATOM   3720  CA  ALA A 295      86.437  49.835 112.608  1.00 59.17           C  
+ATOM   3721  C   ALA A 295      86.565  50.733 111.386  1.00 65.16           C  
+ATOM   3722  O   ALA A 295      87.637  50.845 110.786  1.00 66.59           O  
+ATOM   3723  CB  ALA A 295      85.654  48.576 112.253  1.00 59.91           C  
+ATOM   3724  N   ALA A 296      85.455  51.384 111.049  1.00 59.75           N  
+ATOM   3725  CA  ALA A 296      85.364  52.304 109.923  1.00 58.42           C  
+ATOM   3726  C   ALA A 296      86.363  53.450 110.016  1.00 64.47           C  
+ATOM   3727  O   ALA A 296      87.243  53.579 109.162  1.00 67.60           O  
+ATOM   3728  CB  ALA A 296      83.961  52.862 109.833  1.00 58.71           C  
+ATOM   3729  N   ARG A 297      86.200  54.301 111.025  1.00 58.18           N  
+ATOM   3730  CA  ARG A 297      87.105  55.430 111.206  1.00 58.27           C  
+ATOM   3731  C   ARG A 297      88.573  54.999 111.178  1.00 65.08           C  
+ATOM   3732  O   ARG A 297      89.432  55.678 110.612  1.00 66.62           O  
+ATOM   3733  CB  ARG A 297      86.783  56.164 112.505  1.00 55.54           C  
+ATOM   3734  CG  ARG A 297      85.306  56.481 112.667  1.00 59.46           C  
+ATOM   3735  CD  ARG A 297      85.019  57.144 113.992  1.00 64.05           C  
+ATOM   3736  NE  ARG A 297      85.945  58.233 114.324  1.00 71.28           N  
+ATOM   3737  CZ  ARG A 297      85.599  59.516 114.399  1.00100.00           C  
+ATOM   3738  NH1 ARG A 297      84.327  59.845 114.262  1.00 94.74           N  
+ATOM   3739  NH2 ARG A 297      86.467  60.432 114.754  1.00100.00           N  
+ATOM   3740  N   ASP A 298      88.869  53.870 111.804  1.00 59.86           N  
+ATOM   3741  CA  ASP A 298      90.244  53.417 111.806  1.00 59.46           C  
+ATOM   3742  C   ASP A 298      90.633  53.148 110.369  1.00 65.19           C  
+ATOM   3743  O   ASP A 298      91.695  53.567 109.919  1.00 64.95           O  
+ATOM   3744  CB  ASP A 298      90.388  52.187 112.685  1.00 61.01           C  
+ATOM   3745  CG  ASP A 298      89.898  52.447 114.081  1.00 77.03           C  
+ATOM   3746  OD1 ASP A 298      89.795  53.638 114.454  1.00 82.61           O  
+ATOM   3747  OD2 ASP A 298      89.604  51.466 114.796  1.00 78.92           O  
+ATOM   3748  N   MET A 299      89.730  52.478 109.657  1.00 64.87           N  
+ATOM   3749  CA  MET A 299      89.891  52.148 108.241  1.00 66.22           C  
+ATOM   3750  C   MET A 299      89.899  53.399 107.357  1.00 72.30           C  
+ATOM   3751  O   MET A 299      90.490  53.399 106.270  1.00 72.79           O  
+ATOM   3752  CB  MET A 299      88.837  51.128 107.775  1.00 69.02           C  
+ATOM   3753  CG  MET A 299      89.474  49.819 107.196  1.00 74.74           C  
+ATOM   3754  SD  MET A 299      88.228  48.603 106.810  1.00 80.19           S  
+ATOM   3755  CE  MET A 299      87.032  49.770 107.434  1.00 76.76           C  
+ATOM   3756  N   ALA A 300      89.277  54.480 107.827  1.00 67.19           N  
+ATOM   3757  CA  ALA A 300      89.264  55.729 107.078  1.00 66.58           C  
+ATOM   3758  C   ALA A 300      90.495  56.566 107.439  1.00 76.41           C  
+ATOM   3759  O   ALA A 300      91.031  57.304 106.609  1.00 78.85           O  
+ATOM   3760  CB  ALA A 300      87.985  56.495 107.368  1.00 66.59           C  
+ATOM   3761  N   ARG A 301      90.949  56.438 108.681  1.00 72.34           N  
+ATOM   3762  CA  ARG A 301      92.096  57.193 109.159  1.00 70.96           C  
+ATOM   3763  C   ARG A 301      93.394  56.794 108.479  1.00 81.37           C  
+ATOM   3764  O   ARG A 301      94.273  57.628 108.246  1.00 83.18           O  
+ATOM   3765  CB  ARG A 301      92.248  56.984 110.654  1.00 62.49           C  
+ATOM   3766  CG  ARG A 301      91.542  58.017 111.486  1.00 60.35           C  
+ATOM   3767  CD  ARG A 301      91.977  57.872 112.935  1.00 61.70           C  
+ATOM   3768  NE  ARG A 301      90.889  57.474 113.778  1.00 55.03           N  
+ATOM   3769  CZ  ARG A 301      90.087  58.318 114.375  1.00 76.17           C  
+ATOM   3770  NH1 ARG A 301      90.155  59.638 114.275  1.00 78.86           N  
+ATOM   3771  NH2 ARG A 301      89.144  57.660 114.988  1.00 73.51           N  
+ATOM   3772  N   ALA A 302      93.527  55.504 108.197  1.00 80.16           N  
+ATOM   3773  CA  ALA A 302      94.729  54.992 107.556  1.00 80.84           C  
+ATOM   3774  C   ALA A 302      94.480  55.026 106.059  1.00 86.29           C  
+ATOM   3775  O   ALA A 302      95.074  54.267 105.292  1.00 85.19           O  
+ATOM   3776  CB  ALA A 302      95.011  53.571 108.018  0.00 81.55           C  
+ATOM   3777  N   GLY A 303      93.555  55.893 105.664  1.00 84.30           N  
+ATOM   3778  CA  GLY A 303      93.198  56.033 104.264  1.00 84.90           C  
+ATOM   3779  C   GLY A 303      93.089  54.648 103.638  1.00 92.16           C  
+ATOM   3780  O   GLY A 303      94.072  54.083 103.160  1.00 91.09           O  
+ATOM   3781  N   VAL A 304      91.885  54.094 103.669  1.00 91.75           N  
+ATOM   3782  CA  VAL A 304      91.611  52.792 103.077  1.00 91.95           C  
+ATOM   3783  C   VAL A 304      90.332  52.971 102.254  1.00 97.07           C  
+ATOM   3784  O   VAL A 304      89.237  53.134 102.796  1.00 98.10           O  
+ATOM   3785  CB  VAL A 304      91.444  51.700 104.151  1.00 94.29           C  
+ATOM   3786  CG1 VAL A 304      91.316  50.329 103.509  1.00 94.09           C  
+ATOM   3787  CG2 VAL A 304      92.618  51.723 105.118  1.00 93.59           C  
+ATOM   3788  N   SER A 305      90.493  53.037 100.938  1.00 90.49           N  
+ATOM   3789  CA  SER A 305      89.390  53.227 100.016  1.00 88.02           C  
+ATOM   3790  C   SER A 305      87.984  53.008 100.540  1.00 88.22           C  
+ATOM   3791  O   SER A 305      87.721  52.055 101.275  1.00 87.53           O  
+ATOM   3792  CB  SER A 305      89.583  52.340  98.783  1.00 92.04           C  
+ATOM   3793  OG  SER A 305      89.871  50.995  99.138  1.00100.00           O  
+ATOM   3794  N   ILE A 306      87.064  53.844 100.068  1.00 83.82           N  
+ATOM   3795  CA  ILE A 306      85.651  53.648 100.378  1.00 82.92           C  
+ATOM   3796  C   ILE A 306      85.022  52.283  99.964  1.00 91.31           C  
+ATOM   3797  O   ILE A 306      83.803  52.115 100.020  1.00 90.12           O  
+ATOM   3798  CB  ILE A 306      84.768  54.898 100.106  1.00 84.03           C  
+ATOM   3799  CG1 ILE A 306      85.377  56.140 100.761  1.00 82.62           C  
+ATOM   3800  CG2 ILE A 306      83.432  54.766 100.806  1.00 85.36           C  
+ATOM   3801  CD1 ILE A 306      84.476  56.759 101.815  1.00 70.54           C  
+ATOM   3802  N   PRO A 307      85.846  51.306  99.549  1.00 92.28           N  
+ATOM   3803  CA  PRO A 307      85.418  49.940  99.287  1.00 93.12           C  
+ATOM   3804  C   PRO A 307      85.252  49.367 100.703  1.00100.00           C  
+ATOM   3805  O   PRO A 307      84.257  49.719 101.315  1.00100.00           O  
+ATOM   3806  CB  PRO A 307      86.610  49.382  98.508  0.00 94.41           C  
+ATOM   3807  CG  PRO A 307      87.163  50.638  97.762  0.00 98.20           C  
+ATOM   3808  CD  PRO A 307      86.396  51.835  98.292  0.00 93.12           C  
+ATOM   3809  N   GLU A 308      86.219  48.653 101.296  1.00 97.28           N  
+ATOM   3810  CA  GLU A 308      86.079  48.163 102.687  1.00 96.65           C  
+ATOM   3811  C   GLU A 308      85.762  49.240 103.722  1.00 99.71           C  
+ATOM   3812  O   GLU A 308      85.950  49.018 104.846  1.00100.00           O  
+ATOM   3813  CB  GLU A 308      87.262  47.286 103.130  1.00 97.70           C  
+ATOM   3814  CG  GLU A 308      87.470  45.993 102.338  1.00100.00           C  
+ATOM   3815  CD  GLU A 308      86.400  44.955 102.611  1.00100.00           C  
+ATOM   3816  OE1 GLU A 308      86.233  44.566 103.784  1.00100.00           O  
+ATOM   3817  OE2 GLU A 308      85.707  44.543 101.656  1.00100.00           O  
+ATOM   3818  N   ILE A 309      85.118  50.295 103.324  1.00 93.66           N  
+ATOM   3819  CA  ILE A 309      84.688  51.379 104.168  1.00 93.18           C  
+ATOM   3820  C   ILE A 309      83.189  51.416 103.877  1.00 96.74           C  
+ATOM   3821  O   ILE A 309      82.480  50.722 104.596  1.00 97.51           O  
+ATOM   3822  CB  ILE A 309      85.595  52.618 104.026  1.00 96.41           C  
+ATOM   3823  CG1 ILE A 309      87.000  52.249 104.517  1.00 96.69           C  
+ATOM   3824  CG2 ILE A 309      85.139  53.705 104.927  1.00 96.95           C  
+ATOM   3825  CD1 ILE A 309      87.681  53.355 105.311  1.00100.00           C  
+ATOM   3826  N   MET A 310      82.692  51.986 102.781  1.00 91.71           N  
+ATOM   3827  CA  MET A 310      81.251  51.856 102.543  1.00 90.57           C  
+ATOM   3828  C   MET A 310      80.926  50.436 102.051  1.00 93.53           C  
+ATOM   3829  O   MET A 310      79.906  50.181 101.410  1.00 94.25           O  
+ATOM   3830  CB  MET A 310      80.729  52.934 101.599  1.00 92.71           C  
+ATOM   3831  CG  MET A 310      80.983  52.655 100.145  1.00 96.42           C  
+ATOM   3832  SD  MET A 310      79.489  52.046  99.373  1.00100.00           S  
+ATOM   3833  CE  MET A 310      80.172  50.789  98.308  1.00 96.28           C  
+ATOM   3834  N   GLN A 311      81.797  49.497 102.401  1.00 87.12           N  
+ATOM   3835  CA  GLN A 311      81.599  48.115 101.992  1.00 85.48           C  
+ATOM   3836  C   GLN A 311      81.941  47.068 103.045  1.00 90.22           C  
+ATOM   3837  O   GLN A 311      81.114  46.209 103.342  1.00 92.45           O  
+ATOM   3838  CB  GLN A 311      82.337  47.839 100.688  0.00 86.46           C  
+ATOM   3839  CG  GLN A 311      82.173  46.491 100.108  0.00 91.78           C  
+ATOM   3840  CD  GLN A 311      82.204  46.544  98.608  0.00100.00           C  
+ATOM   3841  OE1 GLN A 311      82.559  47.551  97.989  0.00 95.69           O  
+ATOM   3842  NE2 GLN A 311      81.827  45.432  98.001  0.00 92.33           N  
+ATOM   3843  N   ALA A 312      83.148  47.116 103.598  0.00 84.64           N  
+ATOM   3844  CA  ALA A 312      83.553  46.131 104.600  0.00 83.68           C  
+ATOM   3845  C   ALA A 312      82.497  45.638 105.602  0.00 86.09           C  
+ATOM   3846  O   ALA A 312      82.513  44.469 105.996  0.00 85.69           O  
+ATOM   3847  CB  ALA A 312      84.832  46.533 105.302  0.00 84.39           C  
+ATOM   3848  N   GLY A 313      81.554  46.500 105.971  1.00 81.62           N  
+ATOM   3849  CA  GLY A 313      80.494  46.142 106.904  1.00 80.64           C  
+ATOM   3850  C   GLY A 313      79.221  46.170 106.088  1.00 81.91           C  
+ATOM   3851  O   GLY A 313      78.214  46.747 106.496  1.00 82.10           O  
+ATOM   3852  N   GLY A 314      79.323  45.571 104.905  1.00 76.05           N  
+ATOM   3853  CA  GLY A 314      78.241  45.471 103.935  1.00 74.24           C  
+ATOM   3854  C   GLY A 314      77.387  46.718 103.715  1.00 75.76           C  
+ATOM   3855  O   GLY A 314      76.170  46.609 103.616  1.00 76.24           O  
+ATOM   3856  N   TRP A 315      77.995  47.896 103.669  1.00 71.54           N  
+ATOM   3857  CA  TRP A 315      77.159  49.061 103.424  1.00 72.26           C  
+ATOM   3858  C   TRP A 315      77.132  49.352 101.925  1.00 85.95           C  
+ATOM   3859  O   TRP A 315      77.566  50.432 101.516  1.00 90.73           O  
+ATOM   3860  CB  TRP A 315      77.671  50.325 104.135  1.00 68.55           C  
+ATOM   3861  CG  TRP A 315      77.461  50.506 105.625  1.00 66.98           C  
+ATOM   3862  CD1 TRP A 315      76.349  50.968 106.266  1.00 69.76           C  
+ATOM   3863  CD2 TRP A 315      78.487  50.446 106.617  1.00 65.79           C  
+ATOM   3864  NE1 TRP A 315      76.595  51.110 107.613  1.00 69.01           N  
+ATOM   3865  CE2 TRP A 315      77.911  50.808 107.852  1.00 70.01           C  
+ATOM   3866  CE3 TRP A 315      79.838  50.102 106.581  1.00 66.43           C  
+ATOM   3867  CZ2 TRP A 315      78.646  50.826 109.041  1.00 68.97           C  
+ATOM   3868  CZ3 TRP A 315      80.563  50.108 107.758  1.00 67.58           C  
+ATOM   3869  CH2 TRP A 315      79.966  50.470 108.972  1.00 68.20           C  
+ATOM   3870  N   THR A 316      76.590  48.466 101.093  0.00 82.99           N  
+ATOM   3871  CA  THR A 316      76.494  48.790  99.668  0.00 83.22           C  
+ATOM   3872  C   THR A 316      75.410  49.872  99.632  0.00 88.49           C  
+ATOM   3873  O   THR A 316      74.340  49.661  99.058  0.00 88.08           O  
+ATOM   3874  CB  THR A 316      76.055  47.555  98.837  0.00 91.20           C  
+ATOM   3875  OG1 THR A 316      75.553  47.978  97.563  0.00 90.78           O  
+ATOM   3876  CG2 THR A 316      74.978  46.769  99.568  0.00 89.80           C  
+ATOM   3877  N   ASN A 317      75.686  51.022 100.258  1.00 86.31           N  
+ATOM   3878  CA  ASN A 317      74.679  52.062 100.412  1.00 86.17           C  
+ATOM   3879  C   ASN A 317      75.033  53.305 101.277  1.00 92.53           C  
+ATOM   3880  O   ASN A 317      74.370  53.537 102.281  1.00 91.30           O  
+ATOM   3881  CB  ASN A 317      73.505  51.364 101.107  0.00 85.42           C  
+ATOM   3882  CG  ASN A 317      72.247  52.180 101.075  0.00100.00           C  
+ATOM   3883  OD1 ASN A 317      71.459  52.167 102.019  0.00 94.42           O  
+ATOM   3884  ND2 ASN A 317      72.060  52.924  99.993  0.00 91.96           N  
+ATOM   3885  N   VAL A 318      76.029  54.116 100.911  1.00 91.80           N  
+ATOM   3886  CA  VAL A 318      76.501  55.318 101.671  1.00 91.44           C  
+ATOM   3887  C   VAL A 318      75.691  56.429 102.444  1.00 92.41           C  
+ATOM   3888  O   VAL A 318      74.520  56.684 102.167  1.00 91.40           O  
+ATOM   3889  CB  VAL A 318      77.774  55.924 100.998  1.00 95.11           C  
+ATOM   3890  CG1 VAL A 318      78.735  56.558 101.994  1.00 94.53           C  
+ATOM   3891  CG2 VAL A 318      78.509  54.866 100.199  1.00 94.62           C  
+ATOM   3892  N   ASN A 319      76.383  57.085 103.384  1.00 86.85           N  
+ATOM   3893  CA  ASN A 319      76.023  58.170 104.328  1.00 86.78           C  
+ATOM   3894  C   ASN A 319      76.373  57.449 105.597  1.00 90.75           C  
+ATOM   3895  O   ASN A 319      76.731  58.042 106.619  1.00 92.93           O  
+ATOM   3896  CB  ASN A 319      74.562  58.623 104.448  1.00 88.07           C  
+ATOM   3897  CG  ASN A 319      74.386  59.764 105.496  1.00100.00           C  
+ATOM   3898  OD1 ASN A 319      73.473  60.581 105.380  1.00100.00           O  
+ATOM   3899  ND2 ASN A 319      75.278  59.839 106.485  1.00 83.94           N  
+ATOM   3900  N   ILE A 320      76.202  56.139 105.522  1.00 82.76           N  
+ATOM   3901  CA  ILE A 320      76.538  55.378 106.690  1.00 79.52           C  
+ATOM   3902  C   ILE A 320      78.008  55.469 106.972  1.00 74.18           C  
+ATOM   3903  O   ILE A 320      78.396  56.208 107.871  1.00 73.28           O  
+ATOM   3904  CB  ILE A 320      75.741  54.098 106.980  1.00 82.78           C  
+ATOM   3905  CG1 ILE A 320      74.245  54.399 106.849  1.00 83.06           C  
+ATOM   3906  CG2 ILE A 320      75.959  53.699 108.434  1.00 81.82           C  
+ATOM   3907  CD1 ILE A 320      73.753  55.446 107.834  1.00 77.02           C  
+ATOM   3908  N   VAL A 321      78.846  54.877 106.142  1.00 67.29           N  
+ATOM   3909  CA  VAL A 321      80.252  55.065 106.409  1.00 68.36           C  
+ATOM   3910  C   VAL A 321      80.558  56.564 106.520  1.00 74.22           C  
+ATOM   3911  O   VAL A 321      81.536  56.962 107.140  1.00 73.58           O  
+ATOM   3912  CB  VAL A 321      81.097  54.482 105.295  1.00 72.47           C  
+ATOM   3913  CG1 VAL A 321      82.504  54.987 105.451  1.00 71.38           C  
+ATOM   3914  CG2 VAL A 321      81.029  52.981 105.340  1.00 72.43           C  
+ATOM   3915  N   MET A 322      79.721  57.402 105.913  1.00 73.35           N  
+ATOM   3916  CA  MET A 322      79.942  58.840 105.937  1.00 74.66           C  
+ATOM   3917  C   MET A 322      79.558  59.542 107.238  1.00 77.02           C  
+ATOM   3918  O   MET A 322      80.255  60.452 107.677  1.00 78.78           O  
+ATOM   3919  CB  MET A 322      79.260  59.488 104.733  1.00 78.95           C  
+ATOM   3920  CG  MET A 322      80.215  60.151 103.736  1.00 85.27           C  
+ATOM   3921  SD  MET A 322      81.715  59.229 103.289  1.00 91.27           S  
+ATOM   3922  CE  MET A 322      81.216  58.502 101.738  1.00 87.75           C  
+ATOM   3923  N   ASN A 323      78.458  59.130 107.857  1.00 72.56           N  
+ATOM   3924  CA  ASN A 323      78.016  59.748 109.109  1.00 73.14           C  
+ATOM   3925  C   ASN A 323      78.988  59.312 110.219  1.00 70.56           C  
+ATOM   3926  O   ASN A 323      79.063  59.933 111.281  1.00 68.33           O  
+ATOM   3927  CB  ASN A 323      76.574  59.298 109.433  1.00 81.60           C  
+ATOM   3928  CG  ASN A 323      75.679  60.427 109.964  0.00100.00           C  
+ATOM   3929  OD1 ASN A 323      74.501  60.516 109.611  0.00 94.39           O  
+ATOM   3930  ND2 ASN A 323      76.228  61.265 110.836  0.00 91.93           N  
+ATOM   3931  N   TYR A 324      79.748  58.255 109.942  1.00 63.18           N  
+ATOM   3932  CA  TYR A 324      80.687  57.701 110.919  1.00 61.33           C  
+ATOM   3933  C   TYR A 324      82.075  58.316 110.875  1.00 68.45           C  
+ATOM   3934  O   TYR A 324      82.759  58.386 111.890  1.00 72.97           O  
+ATOM   3935  CB  TYR A 324      80.860  56.183 110.739  1.00 58.13           C  
+ATOM   3936  CG  TYR A 324      79.632  55.347 111.020  1.00 53.73           C  
+ATOM   3937  CD1 TYR A 324      79.586  54.002 110.674  1.00 52.26           C  
+ATOM   3938  CD2 TYR A 324      78.512  55.910 111.621  1.00 54.74           C  
+ATOM   3939  CE1 TYR A 324      78.459  53.239 110.923  1.00 52.60           C  
+ATOM   3940  CE2 TYR A 324      77.379  55.162 111.871  1.00 54.35           C  
+ATOM   3941  CZ  TYR A 324      77.356  53.826 111.522  1.00 62.65           C  
+ATOM   3942  OH  TYR A 324      76.213  53.095 111.789  1.00 67.57           O  
+ATOM   3943  N   ILE A 325      82.522  58.714 109.696  1.00 60.87           N  
+ATOM   3944  CA  ILE A 325      83.863  59.246 109.575  1.00 59.03           C  
+ATOM   3945  C   ILE A 325      83.902  60.751 109.363  1.00 67.04           C  
+ATOM   3946  O   ILE A 325      84.929  61.302 108.978  1.00 70.31           O  
+ATOM   3947  CB  ILE A 325      84.556  58.539 108.426  1.00 60.11           C  
+ATOM   3948  CG1 ILE A 325      83.750  58.730 107.146  1.00 58.34           C  
+ATOM   3949  CG2 ILE A 325      84.610  57.053 108.710  1.00 61.31           C  
+ATOM   3950  CD1 ILE A 325      84.325  57.988 105.980  1.00 61.34           C  
+ATOM   3951  N   ARG A 326      82.798  61.429 109.650  1.00 63.71           N  
+ATOM   3952  CA  ARG A 326      82.692  62.876 109.449  1.00 63.95           C  
+ATOM   3953  C   ARG A 326      83.633  63.814 110.208  1.00 68.74           C  
+ATOM   3954  O   ARG A 326      84.106  64.789 109.633  1.00 68.25           O  
+ATOM   3955  CB  ARG A 326      81.264  63.336 109.720  1.00 64.74           C  
+ATOM   3956  CG  ARG A 326      80.983  63.351 111.214  1.00 83.83           C  
+ATOM   3957  CD  ARG A 326      79.742  64.136 111.590  1.00 94.66           C  
+ATOM   3958  NE  ARG A 326      78.905  63.389 112.529  1.00100.00           N  
+ATOM   3959  CZ  ARG A 326      77.589  63.532 112.650  1.00100.00           C  
+ATOM   3960  NH1 ARG A 326      76.930  64.388 111.881  1.00100.00           N  
+ATOM   3961  NH2 ARG A 326      76.937  62.796 113.540  1.00100.00           N  
+ATOM   3962  N   ASN A 327      83.833  63.595 111.507  1.00 66.37           N  
+ATOM   3963  CA  ASN A 327      84.679  64.492 112.299  1.00 64.32           C  
+ATOM   3964  C   ASN A 327      86.148  64.250 112.012  1.00 67.88           C  
+ATOM   3965  O   ASN A 327      87.012  65.034 112.399  1.00 67.35           O  
+ATOM   3966  CB  ASN A 327      84.386  64.395 113.805  1.00 60.64           C  
+ATOM   3967  CG  ASN A 327      84.181  62.970 114.279  1.00 69.96           C  
+ATOM   3968  OD1 ASN A 327      84.438  62.034 113.541  1.00 67.79           O  
+ATOM   3969  ND2 ASN A 327      83.700  62.809 115.509  1.00 68.79           N  
+ATOM   3970  N   LEU A 328      86.411  63.157 111.306  1.00 65.76           N  
+ATOM   3971  CA  LEU A 328      87.768  62.791 110.941  1.00 66.71           C  
+ATOM   3972  C   LEU A 328      88.436  63.920 110.157  1.00 75.52           C  
+ATOM   3973  O   LEU A 328      87.763  64.768 109.567  1.00 79.00           O  
+ATOM   3974  CB  LEU A 328      87.752  61.488 110.138  1.00 66.31           C  
+ATOM   3975  CG  LEU A 328      87.296  60.269 110.938  1.00 69.78           C  
+ATOM   3976  CD1 LEU A 328      87.770  58.983 110.294  1.00 70.18           C  
+ATOM   3977  CD2 LEU A 328      87.947  60.393 112.280  1.00 67.33           C  
+ATOM   3978  N   ASP A 329      89.766  63.937 110.170  1.00 69.35           N  
+ATOM   3979  CA  ASP A 329      90.527  64.969 109.474  1.00 67.02           C  
+ATOM   3980  C   ASP A 329      90.723  64.669 108.012  1.00 69.75           C  
+ATOM   3981  O   ASP A 329      90.927  65.583 107.215  1.00 68.23           O  
+ATOM   3982  CB  ASP A 329      91.883  65.177 110.129  1.00 67.79           C  
+ATOM   3983  CG  ASP A 329      91.782  66.066 111.321  1.00 70.70           C  
+ATOM   3984  OD1 ASP A 329      91.842  67.291 111.124  1.00 69.34           O  
+ATOM   3985  OD2 ASP A 329      91.595  65.564 112.449  1.00 82.24           O  
+ATOM   3986  N   SER A 330      90.672  63.388 107.663  1.00 66.84           N  
+ATOM   3987  CA  SER A 330      90.853  62.953 106.286  1.00 65.19           C  
+ATOM   3988  C   SER A 330      89.628  63.320 105.473  1.00 64.78           C  
+ATOM   3989  O   SER A 330      89.708  63.415 104.252  1.00 64.27           O  
+ATOM   3990  CB  SER A 330      91.074  61.441 106.222  1.00 71.97           C  
+ATOM   3991  OG  SER A 330      89.995  60.738 106.821  1.00 90.09           O  
+ATOM   3992  N   GLU A 331      88.504  63.511 106.163  1.00 61.34           N  
+ATOM   3993  CA  GLU A 331      87.205  63.864 105.573  1.00 60.21           C  
+ATOM   3994  C   GLU A 331      86.871  65.328 105.852  1.00 66.32           C  
+ATOM   3995  O   GLU A 331      85.721  65.662 106.142  1.00 68.52           O  
+ATOM   3996  CB  GLU A 331      86.106  63.003 106.199  1.00 59.96           C  
+ATOM   3997  CG  GLU A 331      86.370  61.521 106.090  1.00 65.81           C  
+ATOM   3998  CD  GLU A 331      86.557  61.071 104.653  1.00 82.78           C  
+ATOM   3999  OE1 GLU A 331      85.792  61.546 103.783  1.00 66.58           O  
+ATOM   4000  OE2 GLU A 331      87.470  60.256 104.400  1.00 61.68           O  
+ATOM   4001  N   THR A 332      87.873  66.198 105.783  1.00 60.51           N  
+ATOM   4002  CA  THR A 332      87.668  67.608 106.077  1.00 58.25           C  
+ATOM   4003  C   THR A 332      87.060  68.441 104.949  1.00 58.66           C  
+ATOM   4004  O   THR A 332      86.451  69.486 105.176  1.00 57.11           O  
+ATOM   4005  CB  THR A 332      88.949  68.253 106.582  1.00 62.53           C  
+ATOM   4006  OG1 THR A 332      88.607  69.404 107.367  1.00 67.27           O  
+ATOM   4007  CG2 THR A 332      89.829  68.654 105.406  1.00 60.66           C  
+ATOM   4008  N   GLY A 333      87.213  67.970 103.720  1.00 54.53           N  
+ATOM   4009  CA  GLY A 333      86.644  68.672 102.574  1.00 53.47           C  
+ATOM   4010  C   GLY A 333      87.661  69.450 101.750  1.00 57.08           C  
+ATOM   4011  O   GLY A 333      88.744  69.766 102.239  1.00 57.02           O  
+ATOM   4012  N   ALA A 334      87.293  69.780 100.513  1.00 53.27           N  
+ATOM   4013  CA  ALA A 334      88.156  70.521  99.587  1.00 50.41           C  
+ATOM   4014  C   ALA A 334      88.455  71.994  99.908  1.00 50.76           C  
+ATOM   4015  O   ALA A 334      89.411  72.557  99.375  1.00 49.43           O  
+ATOM   4016  CB  ALA A 334      87.636  70.391  98.157  1.00 50.51           C  
+ATOM   4017  N   MET A 335      87.636  72.629 100.741  1.00 45.99           N  
+ATOM   4018  CA  MET A 335      87.854  74.032 101.084  1.00 43.80           C  
+ATOM   4019  C   MET A 335      89.027  74.187 102.054  1.00 45.29           C  
+ATOM   4020  O   MET A 335      89.844  75.098 101.924  1.00 44.44           O  
+ATOM   4021  CB  MET A 335      86.581  74.629 101.692  1.00 44.78           C  
+ATOM   4022  CG  MET A 335      85.970  75.801 100.925  1.00 46.61           C  
+ATOM   4023  SD  MET A 335      86.430  75.928  99.171  1.00 49.07           S  
+ATOM   4024  CE  MET A 335      87.147  77.577  99.117  1.00 45.61           C  
+ATOM   4025  N   VAL A 336      89.105  73.274 103.019  1.00 42.78           N  
+ATOM   4026  CA  VAL A 336      90.159  73.265 104.035  1.00 42.77           C  
+ATOM   4027  C   VAL A 336      91.465  72.978 103.331  1.00 46.84           C  
+ATOM   4028  O   VAL A 336      92.490  73.606 103.587  1.00 47.01           O  
+ATOM   4029  CB  VAL A 336      89.952  72.124 105.050  1.00 45.63           C  
+ATOM   4030  CG1 VAL A 336      91.292  71.653 105.585  1.00 46.62           C  
+ATOM   4031  CG2 VAL A 336      89.044  72.563 106.192  1.00 44.21           C  
+ATOM   4032  N   ARG A 337      91.388  72.026 102.413  1.00 43.64           N  
+ATOM   4033  CA  ARG A 337      92.519  71.645 101.593  1.00 44.11           C  
+ATOM   4034  C   ARG A 337      93.053  72.811 100.743  1.00 48.94           C  
+ATOM   4035  O   ARG A 337      94.259  72.983 100.596  1.00 50.23           O  
+ATOM   4036  CB  ARG A 337      92.103  70.488 100.699  1.00 44.39           C  
+ATOM   4037  CG  ARG A 337      93.266  69.734 100.130  1.00 62.17           C  
+ATOM   4038  CD  ARG A 337      92.839  68.315  99.869  1.00 73.47           C  
+ATOM   4039  NE  ARG A 337      91.862  68.321  98.793  1.00 79.17           N  
+ATOM   4040  CZ  ARG A 337      90.648  67.794  98.882  1.00 77.64           C  
+ATOM   4041  NH1 ARG A 337      90.246  67.211  99.997  1.00 53.77           N  
+ATOM   4042  NH2 ARG A 337      89.833  67.860  97.844  1.00 56.42           N  
+ATOM   4043  N   LEU A 338      92.158  73.616 100.180  1.00 43.17           N  
+ATOM   4044  CA  LEU A 338      92.560  74.754  99.366  1.00 43.52           C  
+ATOM   4045  C   LEU A 338      93.057  75.895 100.236  1.00 45.57           C  
+ATOM   4046  O   LEU A 338      94.020  76.575  99.892  1.00 45.57           O  
+ATOM   4047  CB  LEU A 338      91.356  75.282  98.584  1.00 45.67           C  
+ATOM   4048  CG  LEU A 338      90.892  74.572  97.317  1.00 51.78           C  
+ATOM   4049  CD1 LEU A 338      90.557  75.623  96.275  1.00 50.25           C  
+ATOM   4050  CD2 LEU A 338      92.015  73.676  96.824  1.00 61.13           C  
+ATOM   4051  N   LEU A 339      92.362  76.155 101.337  1.00 42.55           N  
+ATOM   4052  CA  LEU A 339      92.759  77.251 102.224  1.00 41.69           C  
+ATOM   4053  C   LEU A 339      94.137  76.958 102.828  1.00 45.90           C  
+ATOM   4054  O   LEU A 339      94.944  77.857 103.086  1.00 44.61           O  
+ATOM   4055  CB  LEU A 339      91.722  77.480 103.333  1.00 39.10           C  
+ATOM   4056  CG  LEU A 339      90.431  78.231 102.993  1.00 37.22           C  
+ATOM   4057  CD1 LEU A 339      89.362  77.861 104.003  1.00 34.92           C  
+ATOM   4058  CD2 LEU A 339      90.668  79.725 102.996  1.00 35.77           C  
+ATOM   4059  N   GLU A 340      94.414  75.681 103.034  1.00 40.29           N  
+ATOM   4060  CA  GLU A 340      95.687  75.281 103.591  1.00 37.17           C  
+ATOM   4061  C   GLU A 340      96.721  74.972 102.522  1.00 50.92           C  
+ATOM   4062  O   GLU A 340      97.656  74.227 102.813  1.00 56.94           O  
+ATOM   4063  CB  GLU A 340      95.476  74.068 104.483  1.00 35.73           C  
+ATOM   4064  CG  GLU A 340      94.678  74.453 105.698  1.00 29.11           C  
+ATOM   4065  CD  GLU A 340      94.435  73.304 106.631  1.00 47.85           C  
+ATOM   4066  OE1 GLU A 340      94.968  72.208 106.389  1.00 41.26           O  
+ATOM   4067  OE2 GLU A 340      93.721  73.526 107.626  1.00 46.80           O  
+ATOM   4068  N   ASP A 341      96.524  75.532 101.323  1.00 48.11           N  
+ATOM   4069  CA  ASP A 341      97.363  75.380 100.124  1.00 61.21           C  
+ATOM   4070  C   ASP A 341      96.753  74.475  99.071  1.00100.00           C  
+ATOM   4071  O   ASP A 341      97.487  73.758  98.388  1.00100.00           O  
+ATOM   4072  CB  ASP A 341      98.792  74.898 100.386  1.00 63.80           C  
+ATOM   4073  CG  ASP A 341      99.816  75.989 100.204  1.00 94.75           C  
+ATOM   4074  OD1 ASP A 341     100.027  76.791 101.139  1.00100.00           O  
+ATOM   4075  OD2 ASP A 341     100.418  76.047  99.114  1.00100.00           O  
+TER    4076      ASP A 341                                                      
+ATOM   4077  N   THR B  19      34.292  47.507  80.892  1.00 80.87           N  
+ATOM   4078  CA  THR B  19      33.395  46.374  81.048  1.00 79.50           C  
+ATOM   4079  C   THR B  19      33.386  45.459  79.805  1.00 81.97           C  
+ATOM   4080  O   THR B  19      33.570  45.981  78.709  1.00 83.21           O  
+ATOM   4081  CB  THR B  19      31.985  46.886  81.449  1.00 92.22           C  
+ATOM   4082  OG1 THR B  19      31.489  47.796  80.455  1.00 94.08           O  
+ATOM   4083  CG2 THR B  19      32.058  47.605  82.790  1.00 91.06           C  
+ATOM   4084  N   SER B  20      33.278  44.139  79.995  1.00 76.20           N  
+ATOM   4085  CA  SER B  20      33.218  43.135  78.934  1.00 74.85           C  
+ATOM   4086  C   SER B  20      33.583  43.593  77.520  1.00 76.11           C  
+ATOM   4087  O   SER B  20      34.442  42.988  76.884  1.00 74.98           O  
+ATOM   4088  CB  SER B  20      31.813  42.536  78.931  1.00 79.26           C  
+ATOM   4089  OG  SER B  20      31.764  41.318  78.216  1.00 94.44           O  
+ATOM   4090  N   ASP B  21      32.904  44.624  77.015  1.00 72.64           N  
+ATOM   4091  CA  ASP B  21      33.164  45.180  75.684  1.00 71.36           C  
+ATOM   4092  C   ASP B  21      34.519  45.875  75.694  1.00 71.67           C  
+ATOM   4093  O   ASP B  21      35.351  45.691  74.803  1.00 72.88           O  
+ATOM   4094  CB  ASP B  21      32.067  46.180  75.289  1.00 74.03           C  
+ATOM   4095  CG  ASP B  21      30.807  45.493  74.780  1.00 88.84           C  
+ATOM   4096  OD1 ASP B  21      30.928  44.526  73.999  1.00 87.09           O  
+ATOM   4097  OD2 ASP B  21      29.696  45.913  75.170  1.00100.00           O  
+ATOM   4098  N   GLU B  22      34.702  46.673  76.744  1.00 63.94           N  
+ATOM   4099  CA  GLU B  22      35.910  47.451  77.047  1.00 63.30           C  
+ATOM   4100  C   GLU B  22      37.165  46.568  77.241  1.00 70.76           C  
+ATOM   4101  O   GLU B  22      38.276  46.950  76.852  1.00 73.89           O  
+ATOM   4102  CB  GLU B  22      35.646  48.298  78.309  1.00 64.37           C  
+ATOM   4103  CG  GLU B  22      36.089  49.768  78.311  0.00 74.87           C  
+ATOM   4104  CD  GLU B  22      35.621  50.526  79.557  0.00 95.22           C  
+ATOM   4105  OE1 GLU B  22      34.536  50.195  80.085  0.00 89.49           O  
+ATOM   4106  OE2 GLU B  22      36.333  51.448  80.002  0.00 89.23           O  
+ATOM   4107  N   VAL B  23      36.968  45.387  77.835  1.00 62.88           N  
+ATOM   4108  CA  VAL B  23      38.028  44.419  78.090  1.00 60.04           C  
+ATOM   4109  C   VAL B  23      38.421  43.780  76.774  1.00 61.97           C  
+ATOM   4110  O   VAL B  23      39.604  43.658  76.477  1.00 62.81           O  
+ATOM   4111  CB  VAL B  23      37.633  43.347  79.122  1.00 62.42           C  
+ATOM   4112  CG1 VAL B  23      38.568  42.155  79.022  1.00 62.47           C  
+ATOM   4113  CG2 VAL B  23      37.701  43.946  80.513  1.00 61.05           C  
+ATOM   4114  N   ARG B  24      37.422  43.410  75.980  1.00 57.20           N  
+ATOM   4115  CA  ARG B  24      37.644  42.803  74.679  1.00 56.38           C  
+ATOM   4116  C   ARG B  24      38.392  43.820  73.820  1.00 61.00           C  
+ATOM   4117  O   ARG B  24      39.210  43.444  72.986  1.00 63.98           O  
+ATOM   4118  CB  ARG B  24      36.298  42.441  74.037  1.00 56.05           C  
+ATOM   4119  CG  ARG B  24      36.303  41.174  73.193  1.00 75.52           C  
+ATOM   4120  CD  ARG B  24      35.648  41.408  71.834  1.00 91.02           C  
+ATOM   4121  NE  ARG B  24      34.207  41.634  71.937  1.00 96.37           N  
+ATOM   4122  CZ  ARG B  24      33.622  42.819  71.781  1.00100.00           C  
+ATOM   4123  NH1 ARG B  24      34.352  43.893  71.529  1.00100.00           N  
+ATOM   4124  NH2 ARG B  24      32.304  42.923  71.888  1.00100.00           N  
+ATOM   4125  N   LYS B  25      38.140  45.108  74.028  1.00 53.49           N  
+ATOM   4126  CA  LYS B  25      38.819  46.097  73.210  1.00 51.69           C  
+ATOM   4127  C   LYS B  25      40.216  46.459  73.650  1.00 54.76           C  
+ATOM   4128  O   LYS B  25      41.071  46.753  72.816  1.00 52.34           O  
+ATOM   4129  CB  LYS B  25      38.003  47.364  73.039  1.00 54.15           C  
+ATOM   4130  CG  LYS B  25      38.711  48.332  72.121  1.00 52.33           C  
+ATOM   4131  CD  LYS B  25      38.567  49.760  72.576  1.00 61.15           C  
+ATOM   4132  CE  LYS B  25      38.816  50.684  71.402  1.00 76.95           C  
+ATOM   4133  NZ  LYS B  25      40.138  51.351  71.473  1.00 86.53           N  
+ATOM   4134  N   ASN B  26      40.414  46.461  74.965  1.00 52.72           N  
+ATOM   4135  CA  ASN B  26      41.696  46.765  75.582  1.00 51.96           C  
+ATOM   4136  C   ASN B  26      42.634  45.624  75.216  1.00 58.64           C  
+ATOM   4137  O   ASN B  26      43.695  45.839  74.631  1.00 59.04           O  
+ATOM   4138  CB  ASN B  26      41.497  46.943  77.085  1.00 42.96           C  
+ATOM   4139  CG  ASN B  26      40.896  48.288  77.397  1.00 50.37           C  
+ATOM   4140  OD1 ASN B  26      40.127  48.465  78.342  1.00 56.16           O  
+ATOM   4141  ND2 ASN B  26      41.236  49.259  76.564  1.00 40.77           N  
+ATOM   4142  N   LEU B  27      42.175  44.400  75.449  1.00 55.24           N  
+ATOM   4143  CA  LEU B  27      42.950  43.226  75.084  1.00 54.29           C  
+ATOM   4144  C   LEU B  27      43.200  43.277  73.587  1.00 59.04           C  
+ATOM   4145  O   LEU B  27      44.333  43.135  73.146  1.00 61.43           O  
+ATOM   4146  CB  LEU B  27      42.219  41.931  75.446  1.00 54.15           C  
+ATOM   4147  CG  LEU B  27      42.905  41.132  76.556  1.00 59.92           C  
+ATOM   4148  CD1 LEU B  27      43.495  42.096  77.576  1.00 60.04           C  
+ATOM   4149  CD2 LEU B  27      41.938  40.175  77.239  1.00 65.12           C  
+ATOM   4150  N   MET B  28      42.148  43.508  72.803  1.00 53.21           N  
+ATOM   4151  CA  MET B  28      42.280  43.569  71.349  1.00 50.92           C  
+ATOM   4152  C   MET B  28      43.248  44.661  70.933  1.00 53.82           C  
+ATOM   4153  O   MET B  28      44.071  44.468  70.042  1.00 53.47           O  
+ATOM   4154  CB  MET B  28      40.926  43.775  70.672  0.00 53.13           C  
+ATOM   4155  CG  MET B  28      40.600  42.713  69.636  0.00 56.65           C  
+ATOM   4156  SD  MET B  28      38.943  42.037  69.838  0.00 60.79           S  
+ATOM   4157  CE  MET B  28      37.948  43.487  69.501  0.00 57.52           C  
+ATOM   4158  N   ASP B  29      43.168  45.804  71.597  1.00 49.89           N  
+ATOM   4159  CA  ASP B  29      44.063  46.898  71.261  1.00 51.32           C  
+ATOM   4160  C   ASP B  29      45.509  46.507  71.550  1.00 59.81           C  
+ATOM   4161  O   ASP B  29      46.458  47.039  70.972  1.00 62.41           O  
+ATOM   4162  CB  ASP B  29      43.674  48.134  72.062  1.00 52.66           C  
+ATOM   4163  CG  ASP B  29      42.535  48.905  71.429  1.00 55.77           C  
+ATOM   4164  OD1 ASP B  29      42.128  48.592  70.288  1.00 56.23           O  
+ATOM   4165  OD2 ASP B  29      42.047  49.836  72.092  1.00 61.98           O  
+ATOM   4166  N   MET B  30      45.673  45.567  72.468  1.00 56.00           N  
+ATOM   4167  CA  MET B  30      47.007  45.142  72.823  1.00 54.79           C  
+ATOM   4168  C   MET B  30      47.550  44.211  71.749  1.00 58.03           C  
+ATOM   4169  O   MET B  30      48.696  44.349  71.323  1.00 56.93           O  
+ATOM   4170  CB  MET B  30      46.988  44.451  74.181  1.00 57.29           C  
+ATOM   4171  CG  MET B  30      48.375  44.169  74.715  1.00 62.15           C  
+ATOM   4172  SD  MET B  30      48.439  43.850  76.489  1.00 66.90           S  
+ATOM   4173  CE  MET B  30      47.720  42.205  76.571  1.00 63.90           C  
+ATOM   4174  N   PHE B  31      46.722  43.271  71.301  1.00 55.16           N  
+ATOM   4175  CA  PHE B  31      47.140  42.327  70.274  1.00 54.65           C  
+ATOM   4176  C   PHE B  31      47.425  42.975  68.927  1.00 55.76           C  
+ATOM   4177  O   PHE B  31      48.222  42.465  68.145  1.00 56.77           O  
+ATOM   4178  CB  PHE B  31      46.140  41.186  70.104  1.00 57.47           C  
+ATOM   4179  CG  PHE B  31      46.357  40.398  68.847  1.00 61.55           C  
+ATOM   4180  CD1 PHE B  31      47.272  39.357  68.818  1.00 66.70           C  
+ATOM   4181  CD2 PHE B  31      45.690  40.731  67.682  1.00 66.64           C  
+ATOM   4182  CE1 PHE B  31      47.501  38.645  67.658  1.00 69.31           C  
+ATOM   4183  CE2 PHE B  31      45.910  40.022  66.518  1.00 71.69           C  
+ATOM   4184  CZ  PHE B  31      46.819  38.975  66.506  1.00 70.44           C  
+ATOM   4185  N   ARG B  32      46.765  44.093  68.655  1.00 50.45           N  
+ATOM   4186  CA  ARG B  32      46.974  44.776  67.391  1.00 49.77           C  
+ATOM   4187  C   ARG B  32      48.403  45.286  67.310  1.00 53.16           C  
+ATOM   4188  O   ARG B  32      49.116  45.001  66.349  1.00 54.14           O  
+ATOM   4189  CB  ARG B  32      45.993  45.935  67.223  1.00 51.52           C  
+ATOM   4190  CG  ARG B  32      45.864  46.395  65.783  1.00 47.98           C  
+ATOM   4191  CD  ARG B  32      44.948  47.587  65.658  1.00 38.88           C  
+ATOM   4192  NE  ARG B  32      44.947  48.406  66.864  1.00 44.60           N  
+ATOM   4193  CZ  ARG B  32      44.140  49.445  67.035  1.00 65.43           C  
+ATOM   4194  NH1 ARG B  32      43.285  49.776  66.075  1.00 44.95           N  
+ATOM   4195  NH2 ARG B  32      44.193  50.146  68.161  1.00 55.42           N  
+ATOM   4196  N   ASP B  33      48.820  46.060  68.306  1.00 49.17           N  
+ATOM   4197  CA  ASP B  33      50.169  46.616  68.321  1.00 48.87           C  
+ATOM   4198  C   ASP B  33      51.084  45.779  69.206  1.00 51.96           C  
+ATOM   4199  O   ASP B  33      51.725  46.290  70.132  1.00 46.60           O  
+ATOM   4200  CB  ASP B  33      50.160  48.065  68.805  1.00 51.47           C  
+ATOM   4201  CG  ASP B  33      49.660  49.030  67.749  1.00 59.85           C  
+ATOM   4202  OD1 ASP B  33      50.131  48.952  66.595  1.00 61.42           O  
+ATOM   4203  OD2 ASP B  33      48.785  49.862  68.070  1.00 67.72           O  
+ATOM   4204  N   ARG B  34      51.121  44.485  68.886  1.00 54.68           N  
+ATOM   4205  CA  ARG B  34      51.924  43.458  69.561  1.00 54.54           C  
+ATOM   4206  C   ARG B  34      53.372  43.915  69.712  1.00 54.95           C  
+ATOM   4207  O   ARG B  34      54.011  43.707  70.745  1.00 51.10           O  
+ATOM   4208  CB  ARG B  34      51.981  42.199  68.687  1.00 51.59           C  
+ATOM   4209  CG  ARG B  34      50.931  41.147  68.945  1.00 58.30           C  
+ATOM   4210  CD  ARG B  34      51.060  40.064  67.885  1.00 83.16           C  
+ATOM   4211  NE  ARG B  34      50.136  40.211  66.760  1.00 92.91           N  
+ATOM   4212  CZ  ARG B  34      50.473  40.064  65.480  1.00100.00           C  
+ATOM   4213  NH1 ARG B  34      51.728  39.787  65.140  1.00100.00           N  
+ATOM   4214  NH2 ARG B  34      49.548  40.202  64.540  1.00 95.00           N  
+ATOM   4215  N   GLN B  35      53.884  44.503  68.637  1.00 51.14           N  
+ATOM   4216  CA  GLN B  35      55.259  44.963  68.552  1.00 49.76           C  
+ATOM   4217  C   GLN B  35      55.670  45.946  69.615  1.00 52.40           C  
+ATOM   4218  O   GLN B  35      56.858  46.115  69.855  1.00 54.98           O  
+ATOM   4219  CB  GLN B  35      55.522  45.581  67.186  1.00 52.61           C  
+ATOM   4220  CG  GLN B  35      55.260  44.625  66.047  1.00 82.07           C  
+ATOM   4221  CD  GLN B  35      56.394  43.646  65.854  1.00100.00           C  
+ATOM   4222  OE1 GLN B  35      57.154  43.734  64.887  1.00 97.54           O  
+ATOM   4223  NE2 GLN B  35      56.538  42.704  66.783  1.00100.00           N  
+ATOM   4224  N   ALA B  36      54.706  46.617  70.230  1.00 47.22           N  
+ATOM   4225  CA  ALA B  36      54.997  47.588  71.280  1.00 44.78           C  
+ATOM   4226  C   ALA B  36      55.874  46.983  72.382  1.00 46.24           C  
+ATOM   4227  O   ALA B  36      56.629  47.692  73.051  1.00 47.34           O  
+ATOM   4228  CB  ALA B  36      53.697  48.127  71.862  1.00 45.01           C  
+ATOM   4229  N   PHE B  37      55.762  45.673  72.583  1.00 41.56           N  
+ATOM   4230  CA  PHE B  37      56.548  44.998  73.612  1.00 43.65           C  
+ATOM   4231  C   PHE B  37      57.447  43.916  73.015  1.00 46.53           C  
+ATOM   4232  O   PHE B  37      57.254  43.490  71.874  1.00 47.26           O  
+ATOM   4233  CB  PHE B  37      55.661  44.354  74.693  1.00 47.43           C  
+ATOM   4234  CG  PHE B  37      54.376  45.088  74.973  1.00 49.38           C  
+ATOM   4235  CD1 PHE B  37      53.270  44.901  74.157  1.00 52.13           C  
+ATOM   4236  CD2 PHE B  37      54.266  45.939  76.061  1.00 50.38           C  
+ATOM   4237  CE1 PHE B  37      52.088  45.568  74.400  1.00 54.16           C  
+ATOM   4238  CE2 PHE B  37      53.088  46.604  76.307  1.00 51.98           C  
+ATOM   4239  CZ  PHE B  37      52.002  46.428  75.469  1.00 52.24           C  
+ATOM   4240  N   SER B  38      58.394  43.441  73.822  1.00 40.31           N  
+ATOM   4241  CA  SER B  38      59.317  42.393  73.398  1.00 37.93           C  
+ATOM   4242  C   SER B  38      58.606  41.099  73.077  1.00 40.89           C  
+ATOM   4243  O   SER B  38      57.677  40.705  73.781  1.00 42.04           O  
+ATOM   4244  CB  SER B  38      60.300  42.036  74.515  1.00 41.91           C  
+ATOM   4245  OG  SER B  38      60.751  40.694  74.351  1.00 48.08           O  
+ATOM   4246  N   GLU B  39      59.121  40.391  72.080  1.00 36.01           N  
+ATOM   4247  CA  GLU B  39      58.614  39.076  71.706  1.00 36.40           C  
+ATOM   4248  C   GLU B  39      58.605  38.179  72.947  1.00 40.37           C  
+ATOM   4249  O   GLU B  39      57.756  37.291  73.075  1.00 38.40           O  
+ATOM   4250  CB  GLU B  39      59.598  38.446  70.719  1.00 38.55           C  
+ATOM   4251  CG  GLU B  39      60.977  38.240  71.355  1.00 53.64           C  
+ATOM   4252  CD  GLU B  39      62.026  37.667  70.419  1.00 83.98           C  
+ATOM   4253  OE1 GLU B  39      62.097  36.427  70.251  1.00 74.75           O  
+ATOM   4254  OE2 GLU B  39      62.793  38.484  69.876  1.00 92.59           O  
+ATOM   4255  N   HIS B  40      59.595  38.383  73.820  1.00 37.55           N  
+ATOM   4256  CA  HIS B  40      59.770  37.578  75.037  1.00 38.81           C  
+ATOM   4257  C   HIS B  40      58.733  37.817  76.122  1.00 38.86           C  
+ATOM   4258  O   HIS B  40      58.433  36.918  76.912  1.00 32.98           O  
+ATOM   4259  CB  HIS B  40      61.188  37.757  75.640  1.00 40.16           C  
+ATOM   4260  CG  HIS B  40      62.286  37.277  74.746  1.00 43.19           C  
+ATOM   4261  ND1 HIS B  40      63.243  38.120  74.220  1.00 43.57           N  
+ATOM   4262  CD2 HIS B  40      62.553  36.045  74.252  1.00 43.34           C  
+ATOM   4263  CE1 HIS B  40      64.073  37.421  73.470  1.00 42.49           C  
+ATOM   4264  NE2 HIS B  40      63.673  36.161  73.467  1.00 43.18           N  
+ATOM   4265  N   THR B  41      58.222  39.042  76.174  1.00 41.22           N  
+ATOM   4266  CA  THR B  41      57.202  39.406  77.147  1.00 41.40           C  
+ATOM   4267  C   THR B  41      55.949  38.607  76.791  1.00 44.53           C  
+ATOM   4268  O   THR B  41      55.284  38.034  77.664  1.00 45.29           O  
+ATOM   4269  CB  THR B  41      56.973  40.924  77.136  1.00 47.96           C  
+ATOM   4270  OG1 THR B  41      58.175  41.581  77.574  1.00 48.39           O  
+ATOM   4271  CG2 THR B  41      55.814  41.307  78.038  1.00 47.35           C  
+ATOM   4272  N   TRP B  42      55.691  38.505  75.491  1.00 38.78           N  
+ATOM   4273  CA  TRP B  42      54.568  37.746  74.966  1.00 40.82           C  
+ATOM   4274  C   TRP B  42      54.696  36.254  75.268  1.00 45.01           C  
+ATOM   4275  O   TRP B  42      53.716  35.601  75.642  1.00 43.58           O  
+ATOM   4276  CB  TRP B  42      54.461  37.955  73.457  1.00 43.32           C  
+ATOM   4277  CG  TRP B  42      53.681  39.159  73.142  1.00 49.29           C  
+ATOM   4278  CD1 TRP B  42      54.161  40.334  72.649  1.00 53.13           C  
+ATOM   4279  CD2 TRP B  42      52.283  39.373  73.409  1.00 52.11           C  
+ATOM   4280  NE1 TRP B  42      53.145  41.260  72.561  1.00 55.42           N  
+ATOM   4281  CE2 TRP B  42      51.986  40.699  73.034  1.00 58.51           C  
+ATOM   4282  CE3 TRP B  42      51.253  38.570  73.926  1.00 54.59           C  
+ATOM   4283  CZ2 TRP B  42      50.696  41.234  73.133  1.00 58.51           C  
+ATOM   4284  CZ3 TRP B  42      49.979  39.112  74.039  1.00 56.22           C  
+ATOM   4285  CH2 TRP B  42      49.711  40.425  73.639  1.00 56.78           C  
+ATOM   4286  N   LYS B  43      55.901  35.716  75.077  1.00 42.58           N  
+ATOM   4287  CA  LYS B  43      56.173  34.295  75.312  1.00 40.26           C  
+ATOM   4288  C   LYS B  43      55.907  33.989  76.778  1.00 36.46           C  
+ATOM   4289  O   LYS B  43      55.420  32.918  77.116  1.00 32.71           O  
+ATOM   4290  CB  LYS B  43      57.626  33.956  74.934  1.00 42.99           C  
+ATOM   4291  CG  LYS B  43      58.004  32.460  74.885  1.00 63.35           C  
+ATOM   4292  CD  LYS B  43      59.289  32.109  75.666  1.00 64.86           C  
+ATOM   4293  CE  LYS B  43      60.443  31.623  74.766  1.00 58.95           C  
+ATOM   4294  NZ  LYS B  43      60.483  30.166  74.407  1.00 35.17           N  
+ATOM   4295  N   MET B  44      56.238  34.937  77.648  1.00 32.84           N  
+ATOM   4296  CA  MET B  44      56.011  34.732  79.071  1.00 32.74           C  
+ATOM   4297  C   MET B  44      54.549  34.994  79.468  1.00 34.78           C  
+ATOM   4298  O   MET B  44      53.978  34.216  80.227  1.00 33.80           O  
+ATOM   4299  CB  MET B  44      57.040  35.483  79.924  1.00 35.42           C  
+ATOM   4300  CG  MET B  44      58.465  34.879  79.941  1.00 37.68           C  
+ATOM   4301  SD  MET B  44      58.634  33.058  79.972  1.00 41.46           S  
+ATOM   4302  CE  MET B  44      58.224  32.705  81.706  1.00 38.46           C  
+ATOM   4303  N   LEU B  45      53.939  36.052  78.934  1.00 32.09           N  
+ATOM   4304  CA  LEU B  45      52.518  36.314  79.167  1.00 32.68           C  
+ATOM   4305  C   LEU B  45      51.849  34.951  78.948  1.00 38.55           C  
+ATOM   4306  O   LEU B  45      51.225  34.370  79.836  1.00 38.55           O  
+ATOM   4307  CB  LEU B  45      52.008  37.292  78.094  1.00 33.15           C  
+ATOM   4308  CG  LEU B  45      50.554  37.772  77.997  1.00 40.36           C  
+ATOM   4309  CD1 LEU B  45      49.898  37.689  79.375  1.00 40.83           C  
+ATOM   4310  CD2 LEU B  45      50.464  39.197  77.437  1.00 41.53           C  
+ATOM   4311  N   LEU B  46      52.015  34.421  77.746  1.00 38.86           N  
+ATOM   4312  CA  LEU B  46      51.408  33.146  77.400  1.00 39.23           C  
+ATOM   4313  C   LEU B  46      51.833  31.947  78.230  1.00 39.22           C  
+ATOM   4314  O   LEU B  46      51.020  31.046  78.456  1.00 37.53           O  
+ATOM   4315  CB  LEU B  46      51.587  32.839  75.908  1.00 40.55           C  
+ATOM   4316  CG  LEU B  46      50.926  33.724  74.836  1.00 46.04           C  
+ATOM   4317  CD1 LEU B  46      50.121  34.890  75.395  1.00 46.54           C  
+ATOM   4318  CD2 LEU B  46      51.929  34.216  73.802  1.00 47.48           C  
+ATOM   4319  N   SER B  47      53.102  31.883  78.633  1.00 34.98           N  
+ATOM   4320  CA  SER B  47      53.544  30.721  79.396  1.00 31.39           C  
+ATOM   4321  C   SER B  47      52.916  30.736  80.770  1.00 32.07           C  
+ATOM   4322  O   SER B  47      52.550  29.694  81.298  1.00 32.91           O  
+ATOM   4323  CB  SER B  47      55.060  30.638  79.519  1.00 35.04           C  
+ATOM   4324  OG  SER B  47      55.444  29.383  80.052  1.00 38.62           O  
+ATOM   4325  N   VAL B  48      52.798  31.932  81.335  1.00 30.98           N  
+ATOM   4326  CA  VAL B  48      52.199  32.096  82.657  1.00 32.06           C  
+ATOM   4327  C   VAL B  48      50.713  31.733  82.561  1.00 34.28           C  
+ATOM   4328  O   VAL B  48      50.236  30.858  83.285  1.00 31.60           O  
+ATOM   4329  CB  VAL B  48      52.429  33.528  83.238  1.00 33.09           C  
+ATOM   4330  CG1 VAL B  48      51.553  33.776  84.478  1.00 30.73           C  
+ATOM   4331  CG2 VAL B  48      53.935  33.781  83.529  1.00 31.62           C  
+ATOM   4332  N   CYS B  49      50.007  32.359  81.618  1.00 34.13           N  
+ATOM   4333  CA  CYS B  49      48.589  32.084  81.395  1.00 33.42           C  
+ATOM   4334  C   CYS B  49      48.393  30.591  81.194  1.00 38.76           C  
+ATOM   4335  O   CYS B  49      47.508  29.967  81.778  1.00 37.61           O  
+ATOM   4336  CB  CYS B  49      48.055  32.882  80.207  1.00 32.95           C  
+ATOM   4337  SG  CYS B  49      47.948  34.663  80.553  1.00 38.29           S  
+ATOM   4338  N   ARG B  50      49.260  29.961  80.411  1.00 39.04           N  
+ATOM   4339  CA  ARG B  50      49.101  28.511  80.260  1.00 39.92           C  
+ATOM   4340  C   ARG B  50      49.126  27.841  81.627  1.00 46.01           C  
+ATOM   4341  O   ARG B  50      48.252  27.030  81.945  1.00 47.21           O  
+ATOM   4342  CB  ARG B  50      50.258  27.935  79.461  1.00 41.27           C  
+ATOM   4343  CG  ARG B  50      50.008  27.611  77.996  1.00 44.95           C  
+ATOM   4344  CD  ARG B  50      51.311  27.136  77.301  1.00 41.25           C  
+ATOM   4345  NE  ARG B  50      51.738  28.062  76.249  1.00 44.31           N  
+ATOM   4346  CZ  ARG B  50      52.953  28.591  76.122  1.00 55.46           C  
+ATOM   4347  NH1 ARG B  50      53.934  28.282  76.959  1.00 38.23           N  
+ATOM   4348  NH2 ARG B  50      53.189  29.441  75.132  1.00 65.47           N  
+ATOM   4349  N   SER B  51      50.124  28.198  82.436  1.00 41.30           N  
+ATOM   4350  CA  SER B  51      50.266  27.674  83.801  1.00 37.92           C  
+ATOM   4351  C   SER B  51      49.041  27.918  84.707  1.00 34.28           C  
+ATOM   4352  O   SER B  51      48.550  26.973  85.332  1.00 32.79           O  
+ATOM   4353  CB  SER B  51      51.523  28.264  84.449  1.00 42.53           C  
+ATOM   4354  OG  SER B  51      51.875  27.561  85.628  1.00 64.33           O  
+ATOM   4355  N   TRP B  52      48.608  29.172  84.804  1.00 28.27           N  
+ATOM   4356  CA  TRP B  52      47.483  29.611  85.632  1.00 28.00           C  
+ATOM   4357  C   TRP B  52      46.183  28.952  85.203  1.00 36.64           C  
+ATOM   4358  O   TRP B  52      45.391  28.494  86.036  1.00 36.71           O  
+ATOM   4359  CB  TRP B  52      47.368  31.123  85.440  1.00 26.18           C  
+ATOM   4360  CG  TRP B  52      46.150  31.789  85.970  1.00 26.73           C  
+ATOM   4361  CD1 TRP B  52      45.272  32.548  85.261  1.00 29.55           C  
+ATOM   4362  CD2 TRP B  52      45.761  31.898  87.345  1.00 26.27           C  
+ATOM   4363  NE1 TRP B  52      44.313  33.063  86.101  1.00 29.41           N  
+ATOM   4364  CE2 TRP B  52      44.580  32.666  87.384  1.00 30.65           C  
+ATOM   4365  CE3 TRP B  52      46.229  31.337  88.530  1.00 27.05           C  
+ATOM   4366  CZ2 TRP B  52      43.885  32.912  88.563  1.00 28.44           C  
+ATOM   4367  CZ3 TRP B  52      45.534  31.578  89.692  1.00 28.85           C  
+ATOM   4368  CH2 TRP B  52      44.379  32.361  89.702  1.00 28.69           C  
+ATOM   4369  N   ALA B  53      45.979  28.905  83.886  1.00 34.01           N  
+ATOM   4370  CA  ALA B  53      44.775  28.317  83.310  1.00 33.11           C  
+ATOM   4371  C   ALA B  53      44.725  26.845  83.671  1.00 35.55           C  
+ATOM   4372  O   ALA B  53      43.669  26.280  83.952  1.00 37.82           O  
+ATOM   4373  CB  ALA B  53      44.747  28.506  81.795  1.00 33.14           C  
+ATOM   4374  N   ALA B  54      45.902  26.244  83.707  1.00 30.01           N  
+ATOM   4375  CA  ALA B  54      46.003  24.842  84.055  1.00 28.93           C  
+ATOM   4376  C   ALA B  54      45.670  24.646  85.514  1.00 39.58           C  
+ATOM   4377  O   ALA B  54      44.909  23.738  85.860  1.00 43.66           O  
+ATOM   4378  CB  ALA B  54      47.390  24.319  83.753  1.00 29.48           C  
+ATOM   4379  N   TRP B  55      46.250  25.479  86.370  1.00 34.82           N  
+ATOM   4380  CA  TRP B  55      45.993  25.364  87.795  1.00 33.34           C  
+ATOM   4381  C   TRP B  55      44.509  25.629  88.041  1.00 37.45           C  
+ATOM   4382  O   TRP B  55      43.889  25.040  88.926  1.00 32.72           O  
+ATOM   4383  CB  TRP B  55      46.811  26.395  88.567  1.00 31.08           C  
+ATOM   4384  CG  TRP B  55      46.608  26.265  90.034  1.00 31.01           C  
+ATOM   4385  CD1 TRP B  55      47.230  25.388  90.873  1.00 33.29           C  
+ATOM   4386  CD2 TRP B  55      45.673  26.993  90.834  1.00 30.92           C  
+ATOM   4387  NE1 TRP B  55      46.770  25.551  92.153  1.00 33.20           N  
+ATOM   4388  CE2 TRP B  55      45.813  26.532  92.158  1.00 33.79           C  
+ATOM   4389  CE3 TRP B  55      44.783  28.044  90.572  1.00 32.33           C  
+ATOM   4390  CZ2 TRP B  55      45.069  27.044  93.202  1.00 33.03           C  
+ATOM   4391  CZ3 TRP B  55      44.036  28.541  91.608  1.00 33.72           C  
+ATOM   4392  CH2 TRP B  55      44.169  28.028  92.905  1.00 34.17           C  
+ATOM   4393  N   CYS B  56      43.952  26.542  87.256  1.00 37.00           N  
+ATOM   4394  CA  CYS B  56      42.545  26.906  87.388  1.00 35.46           C  
+ATOM   4395  C   CYS B  56      41.572  25.784  87.036  1.00 40.34           C  
+ATOM   4396  O   CYS B  56      40.600  25.535  87.751  1.00 36.76           O  
+ATOM   4397  CB  CYS B  56      42.251  28.125  86.521  1.00 34.73           C  
+ATOM   4398  SG  CYS B  56      42.647  29.686  87.358  1.00 38.11           S  
+ATOM   4399  N   LYS B  57      41.831  25.109  85.926  1.00 42.33           N  
+ATOM   4400  CA  LYS B  57      40.977  24.015  85.497  1.00 43.39           C  
+ATOM   4401  C   LYS B  57      40.930  22.900  86.545  1.00 50.07           C  
+ATOM   4402  O   LYS B  57      39.871  22.384  86.896  1.00 53.49           O  
+ATOM   4403  CB  LYS B  57      41.522  23.471  84.172  1.00 45.16           C  
+ATOM   4404  CG  LYS B  57      40.875  22.183  83.678  1.00 62.81           C  
+ATOM   4405  CD  LYS B  57      41.270  21.870  82.246  1.00 80.51           C  
+ATOM   4406  CE  LYS B  57      40.102  21.309  81.443  1.00 96.86           C  
+ATOM   4407  NZ  LYS B  57      39.791  22.104  80.211  1.00100.00           N  
+ATOM   4408  N   LEU B  58      42.095  22.516  87.033  1.00 46.22           N  
+ATOM   4409  CA  LEU B  58      42.209  21.439  88.001  1.00 47.08           C  
+ATOM   4410  C   LEU B  58      41.453  21.652  89.299  1.00 51.59           C  
+ATOM   4411  O   LEU B  58      41.323  20.747  90.125  1.00 51.90           O  
+ATOM   4412  CB  LEU B  58      43.672  21.363  88.375  1.00 48.09           C  
+ATOM   4413  CG  LEU B  58      44.185  19.992  88.769  1.00 55.07           C  
+ATOM   4414  CD1 LEU B  58      44.496  19.229  87.474  1.00 57.72           C  
+ATOM   4415  CD2 LEU B  58      45.444  20.315  89.537  1.00 56.60           C  
+ATOM   4416  N   ASN B  59      41.044  22.895  89.511  1.00 48.50           N  
+ATOM   4417  CA  ASN B  59      40.406  23.311  90.757  1.00 48.18           C  
+ATOM   4418  C   ASN B  59      39.078  23.972  90.469  1.00 51.54           C  
+ATOM   4419  O   ASN B  59      38.487  24.607  91.341  1.00 56.09           O  
+ATOM   4420  CB  ASN B  59      41.289  24.352  91.469  1.00 45.42           C  
+ATOM   4421  CG  ASN B  59      42.522  23.743  92.111  1.00 51.00           C  
+ATOM   4422  OD1 ASN B  59      42.424  22.945  93.045  1.00 47.89           O  
+ATOM   4423  ND2 ASN B  59      43.691  24.133  91.619  1.00 39.77           N  
+ATOM   4424  N   ASN B  60      38.624  23.824  89.241  1.00 41.49           N  
+ATOM   4425  CA  ASN B  60      37.431  24.502  88.826  1.00 40.37           C  
+ATOM   4426  C   ASN B  60      37.264  25.952  89.155  1.00 42.97           C  
+ATOM   4427  O   ASN B  60      36.322  26.312  89.856  1.00 46.79           O  
+ATOM   4428  CB  ASN B  60      36.160  23.747  89.094  1.00 45.84           C  
+ATOM   4429  CG  ASN B  60      35.388  23.644  87.830  1.00100.00           C  
+ATOM   4430  OD1 ASN B  60      34.363  24.296  87.646  1.00100.00           O  
+ATOM   4431  ND2 ASN B  60      35.898  22.827  86.914  1.00 86.45           N  
+ATOM   4432  N   ARG B  61      38.201  26.790  88.701  1.00 35.28           N  
+ATOM   4433  CA  ARG B  61      38.149  28.226  88.963  1.00 30.92           C  
+ATOM   4434  C   ARG B  61      38.253  28.981  87.663  1.00 37.33           C  
+ATOM   4435  O   ARG B  61      38.804  28.477  86.689  1.00 39.25           O  
+ATOM   4436  CB  ARG B  61      39.257  28.691  89.909  1.00 27.11           C  
+ATOM   4437  CG  ARG B  61      39.710  27.647  90.906  1.00 26.68           C  
+ATOM   4438  CD  ARG B  61      38.733  27.497  92.071  1.00 26.96           C  
+ATOM   4439  NE  ARG B  61      38.363  28.769  92.683  1.00 33.24           N  
+ATOM   4440  CZ  ARG B  61      37.385  28.922  93.574  1.00 45.67           C  
+ATOM   4441  NH1 ARG B  61      36.648  27.897  93.968  1.00 31.58           N  
+ATOM   4442  NH2 ARG B  61      37.134  30.117  94.078  1.00 26.45           N  
+ATOM   4443  N   LYS B  62      37.702  30.185  87.650  1.00 35.90           N  
+ATOM   4444  CA  LYS B  62      37.705  30.990  86.444  1.00 36.41           C  
+ATOM   4445  C   LYS B  62      39.064  31.649  86.348  1.00 45.01           C  
+ATOM   4446  O   LYS B  62      39.484  32.363  87.257  1.00 47.03           O  
+ATOM   4447  CB  LYS B  62      36.603  32.049  86.518  1.00 39.47           C  
+ATOM   4448  CG  LYS B  62      36.355  32.809  85.228  1.00 53.13           C  
+ATOM   4449  CD  LYS B  62      34.867  32.917  84.909  1.00 67.35           C  
+ATOM   4450  CE  LYS B  62      34.587  34.041  83.920  1.00 86.39           C  
+ATOM   4451  NZ  LYS B  62      34.371  35.367  84.578  1.00 91.88           N  
+ATOM   4452  N   TRP B  63      39.760  31.419  85.243  1.00 42.90           N  
+ATOM   4453  CA  TRP B  63      41.060  32.048  85.096  1.00 44.80           C  
+ATOM   4454  C   TRP B  63      41.068  33.553  84.773  1.00 43.85           C  
+ATOM   4455  O   TRP B  63      42.038  34.236  85.097  1.00 44.55           O  
+ATOM   4456  CB  TRP B  63      42.064  31.211  84.289  1.00 45.64           C  
+ATOM   4457  CG  TRP B  63      41.997  31.463  82.826  1.00 49.55           C  
+ATOM   4458  CD1 TRP B  63      41.227  30.794  81.925  1.00 53.46           C  
+ATOM   4459  CD2 TRP B  63      42.693  32.482  82.083  1.00 50.27           C  
+ATOM   4460  NE1 TRP B  63      41.390  31.334  80.671  1.00 54.13           N  
+ATOM   4461  CE2 TRP B  63      42.281  32.373  80.741  1.00 55.98           C  
+ATOM   4462  CE3 TRP B  63      43.626  33.472  82.419  1.00 50.66           C  
+ATOM   4463  CZ2 TRP B  63      42.779  33.207  79.733  1.00 54.95           C  
+ATOM   4464  CZ3 TRP B  63      44.116  34.298  81.418  1.00 51.59           C  
+ATOM   4465  CH2 TRP B  63      43.695  34.157  80.092  1.00 52.44           C  
+ATOM   4466  N   PHE B  64      40.004  34.099  84.182  1.00 36.06           N  
+ATOM   4467  CA  PHE B  64      39.980  35.539  83.890  1.00 35.12           C  
+ATOM   4468  C   PHE B  64      38.574  36.154  83.907  1.00 41.92           C  
+ATOM   4469  O   PHE B  64      37.702  35.644  83.210  1.00 44.15           O  
+ATOM   4470  CB  PHE B  64      40.687  35.831  82.559  1.00 36.18           C  
+ATOM   4471  CG  PHE B  64      40.880  37.296  82.287  1.00 38.09           C  
+ATOM   4472  CD1 PHE B  64      41.850  38.023  82.957  1.00 42.68           C  
+ATOM   4473  CD2 PHE B  64      40.072  37.957  81.377  1.00 42.25           C  
+ATOM   4474  CE1 PHE B  64      42.014  39.383  82.719  1.00 43.44           C  
+ATOM   4475  CE2 PHE B  64      40.224  39.316  81.143  1.00 44.07           C  
+ATOM   4476  CZ  PHE B  64      41.195  40.031  81.817  1.00 41.77           C  
+ATOM   4477  N   PRO B  65      38.335  37.233  84.668  1.00 37.33           N  
+ATOM   4478  CA  PRO B  65      39.340  37.869  85.520  1.00 36.52           C  
+ATOM   4479  C   PRO B  65      39.679  36.973  86.692  1.00 47.29           C  
+ATOM   4480  O   PRO B  65      38.852  36.179  87.154  1.00 47.32           O  
+ATOM   4481  CB  PRO B  65      38.616  39.107  86.045  1.00 34.86           C  
+ATOM   4482  CG  PRO B  65      37.735  39.484  84.931  1.00 39.28           C  
+ATOM   4483  CD  PRO B  65      37.351  38.221  84.199  1.00 35.80           C  
+ATOM   4484  N   ALA B  66      40.923  37.095  87.140  1.00 43.65           N  
+ATOM   4485  CA  ALA B  66      41.438  36.295  88.230  1.00 42.43           C  
+ATOM   4486  C   ALA B  66      40.985  36.867  89.566  1.00 42.46           C  
+ATOM   4487  O   ALA B  66      40.898  38.082  89.744  1.00 42.57           O  
+ATOM   4488  CB  ALA B  66      42.960  36.219  88.151  1.00 43.32           C  
+ATOM   4489  N   GLU B  67      40.677  35.976  90.495  1.00 35.48           N  
+ATOM   4490  CA  GLU B  67      40.232  36.381  91.812  1.00 33.75           C  
+ATOM   4491  C   GLU B  67      41.472  36.383  92.703  1.00 32.52           C  
+ATOM   4492  O   GLU B  67      42.206  35.390  92.743  1.00 29.71           O  
+ATOM   4493  CB  GLU B  67      39.253  35.319  92.333  1.00 35.75           C  
+ATOM   4494  CG  GLU B  67      37.813  35.464  91.875  1.00 39.63           C  
+ATOM   4495  CD  GLU B  67      37.188  36.743  92.368  1.00 46.41           C  
+ATOM   4496  OE1 GLU B  67      37.530  37.212  93.487  1.00 40.07           O  
+ATOM   4497  OE2 GLU B  67      36.358  37.277  91.623  1.00 41.66           O  
+ATOM   4498  N   PRO B  68      41.688  37.475  93.432  1.00 30.87           N  
+ATOM   4499  CA  PRO B  68      42.827  37.572  94.332  1.00 29.00           C  
+ATOM   4500  C   PRO B  68      43.045  36.296  95.125  1.00 32.12           C  
+ATOM   4501  O   PRO B  68      44.121  35.712  95.071  1.00 33.84           O  
+ATOM   4502  CB  PRO B  68      42.422  38.717  95.251  1.00 30.32           C  
+ATOM   4503  CG  PRO B  68      41.716  39.641  94.314  1.00 35.09           C  
+ATOM   4504  CD  PRO B  68      40.998  38.770  93.302  1.00 31.07           C  
+ATOM   4505  N   GLU B  69      42.033  35.837  95.849  1.00 28.47           N  
+ATOM   4506  CA  GLU B  69      42.194  34.619  96.638  1.00 27.27           C  
+ATOM   4507  C   GLU B  69      42.705  33.430  95.831  1.00 32.43           C  
+ATOM   4508  O   GLU B  69      43.370  32.540  96.367  1.00 33.68           O  
+ATOM   4509  CB  GLU B  69      40.882  34.245  97.333  1.00 28.58           C  
+ATOM   4510  CG  GLU B  69      40.429  35.244  98.381  1.00 27.25           C  
+ATOM   4511  CD  GLU B  69      41.320  35.203  99.601  1.00 41.17           C  
+ATOM   4512  OE1 GLU B  69      41.759  34.098  99.970  1.00 29.37           O  
+ATOM   4513  OE2 GLU B  69      41.586  36.273 100.184  1.00 50.45           O  
+ATOM   4514  N   ASP B  70      42.329  33.396  94.556  1.00 31.72           N  
+ATOM   4515  CA  ASP B  70      42.710  32.317  93.647  1.00 32.44           C  
+ATOM   4516  C   ASP B  70      44.175  32.499  93.226  1.00 30.69           C  
+ATOM   4517  O   ASP B  70      44.952  31.551  93.109  1.00 26.35           O  
+ATOM   4518  CB  ASP B  70      41.796  32.354  92.415  1.00 35.68           C  
+ATOM   4519  CG  ASP B  70      40.520  31.566  92.609  1.00 43.09           C  
+ATOM   4520  OD1 ASP B  70      40.290  31.017  93.715  1.00 45.03           O  
+ATOM   4521  OD2 ASP B  70      39.749  31.517  91.629  1.00 51.07           O  
+ATOM   4522  N   VAL B  71      44.532  33.751  92.978  1.00 29.61           N  
+ATOM   4523  CA  VAL B  71      45.887  34.106  92.592  1.00 29.92           C  
+ATOM   4524  C   VAL B  71      46.793  33.701  93.767  1.00 32.92           C  
+ATOM   4525  O   VAL B  71      47.820  33.033  93.583  1.00 32.83           O  
+ATOM   4526  CB  VAL B  71      45.965  35.619  92.254  1.00 32.37           C  
+ATOM   4527  CG1 VAL B  71      47.404  36.055  92.015  1.00 33.77           C  
+ATOM   4528  CG2 VAL B  71      45.104  35.929  91.028  1.00 29.60           C  
+ATOM   4529  N   ARG B  72      46.352  34.028  94.978  1.00 26.58           N  
+ATOM   4530  CA  ARG B  72      47.105  33.694  96.175  1.00 24.77           C  
+ATOM   4531  C   ARG B  72      47.381  32.202  96.338  1.00 32.37           C  
+ATOM   4532  O   ARG B  72      48.524  31.813  96.547  1.00 34.29           O  
+ATOM   4533  CB  ARG B  72      46.490  34.361  97.408  1.00 20.73           C  
+ATOM   4534  CG  ARG B  72      46.980  33.840  98.737  1.00 20.59           C  
+ATOM   4535  CD  ARG B  72      46.343  34.583  99.915  1.00 27.15           C  
+ATOM   4536  NE  ARG B  72      47.034  34.198 101.142  1.00 29.94           N  
+ATOM   4537  CZ  ARG B  72      46.961  32.987 101.681  1.00 37.28           C  
+ATOM   4538  NH1 ARG B  72      46.149  32.083 101.149  1.00 33.95           N  
+ATOM   4539  NH2 ARG B  72      47.675  32.705 102.768  1.00 34.17           N  
+ATOM   4540  N   ASP B  73      46.379  31.343  96.181  1.00 31.27           N  
+ATOM   4541  CA  ASP B  73      46.639  29.904  96.294  1.00 32.00           C  
+ATOM   4542  C   ASP B  73      47.546  29.446  95.171  1.00 37.29           C  
+ATOM   4543  O   ASP B  73      48.152  28.379  95.247  1.00 38.51           O  
+ATOM   4544  CB  ASP B  73      45.355  29.095  96.129  1.00 34.97           C  
+ATOM   4545  CG  ASP B  73      44.331  29.427  97.176  1.00 44.02           C  
+ATOM   4546  OD1 ASP B  73      44.727  29.712  98.326  1.00 46.64           O  
+ATOM   4547  OD2 ASP B  73      43.127  29.439  96.837  1.00 43.55           O  
+ATOM   4548  N   TYR B  74      47.565  30.208  94.084  1.00 36.23           N  
+ATOM   4549  CA  TYR B  74      48.368  29.856  92.919  1.00 32.09           C  
+ATOM   4550  C   TYR B  74      49.839  30.127  93.216  1.00 33.49           C  
+ATOM   4551  O   TYR B  74      50.690  29.264  93.011  1.00 34.74           O  
+ATOM   4552  CB  TYR B  74      47.901  30.652  91.709  1.00 29.08           C  
+ATOM   4553  CG  TYR B  74      48.755  30.420  90.485  1.00 26.54           C  
+ATOM   4554  CD1 TYR B  74      48.937  29.143  89.973  1.00 27.37           C  
+ATOM   4555  CD2 TYR B  74      49.377  31.481  89.850  1.00 25.31           C  
+ATOM   4556  CE1 TYR B  74      49.711  28.935  88.858  1.00 23.97           C  
+ATOM   4557  CE2 TYR B  74      50.145  31.287  88.734  1.00 25.00           C  
+ATOM   4558  CZ  TYR B  74      50.314  30.013  88.256  1.00 28.69           C  
+ATOM   4559  OH  TYR B  74      51.108  29.820  87.156  1.00 32.24           O  
+ATOM   4560  N   LEU B  75      50.131  31.304  93.749  1.00 29.42           N  
+ATOM   4561  CA  LEU B  75      51.500  31.638  94.124  1.00 27.80           C  
+ATOM   4562  C   LEU B  75      51.973  30.622  95.161  1.00 30.02           C  
+ATOM   4563  O   LEU B  75      53.059  30.071  95.028  1.00 29.76           O  
+ATOM   4564  CB  LEU B  75      51.574  33.060  94.678  1.00 26.49           C  
+ATOM   4565  CG  LEU B  75      50.986  34.122  93.751  1.00 29.84           C  
+ATOM   4566  CD1 LEU B  75      51.161  35.511  94.345  1.00 30.68           C  
+ATOM   4567  CD2 LEU B  75      51.592  34.051  92.351  1.00 32.70           C  
+ATOM   4568  N   LEU B  76      51.145  30.317  96.160  1.00 27.87           N  
+ATOM   4569  CA  LEU B  76      51.525  29.338  97.184  1.00 27.05           C  
+ATOM   4570  C   LEU B  76      51.782  27.971  96.609  1.00 33.88           C  
+ATOM   4571  O   LEU B  76      52.581  27.197  97.136  1.00 36.91           O  
+ATOM   4572  CB  LEU B  76      50.502  29.224  98.320  1.00 26.19           C  
+ATOM   4573  CG  LEU B  76      50.438  30.408  99.284  1.00 29.44           C  
+ATOM   4574  CD1 LEU B  76      49.138  30.408 100.097  1.00 26.34           C  
+ATOM   4575  CD2 LEU B  76      51.684  30.473 100.169  1.00 27.59           C  
+ATOM   4576  N   TYR B  77      51.094  27.683  95.516  1.00 29.28           N  
+ATOM   4577  CA  TYR B  77      51.241  26.400  94.864  1.00 27.14           C  
+ATOM   4578  C   TYR B  77      52.570  26.378  94.085  1.00 32.07           C  
+ATOM   4579  O   TYR B  77      53.249  25.364  94.058  1.00 34.28           O  
+ATOM   4580  CB  TYR B  77      50.021  26.143  93.979  1.00 27.69           C  
+ATOM   4581  CG  TYR B  77      50.305  25.204  92.845  1.00 27.79           C  
+ATOM   4582  CD1 TYR B  77      50.214  23.838  93.023  1.00 30.05           C  
+ATOM   4583  CD2 TYR B  77      50.698  25.685  91.608  1.00 27.51           C  
+ATOM   4584  CE1 TYR B  77      50.497  22.980  91.980  1.00 32.51           C  
+ATOM   4585  CE2 TYR B  77      50.973  24.838  90.573  1.00 27.12           C  
+ATOM   4586  CZ  TYR B  77      50.880  23.487  90.764  1.00 32.73           C  
+ATOM   4587  OH  TYR B  77      51.134  22.652  89.707  1.00 45.79           O  
+ATOM   4588  N   LEU B  78      52.959  27.491  93.472  1.00 28.30           N  
+ATOM   4589  CA  LEU B  78      54.228  27.587  92.742  1.00 26.70           C  
+ATOM   4590  C   LEU B  78      55.331  27.442  93.788  1.00 36.07           C  
+ATOM   4591  O   LEU B  78      56.286  26.687  93.604  1.00 34.07           O  
+ATOM   4592  CB  LEU B  78      54.346  28.975  92.099  1.00 25.91           C  
+ATOM   4593  CG  LEU B  78      53.410  29.331  90.941  1.00 25.89           C  
+ATOM   4594  CD1 LEU B  78      53.710  30.715  90.377  1.00 21.58           C  
+ATOM   4595  CD2 LEU B  78      53.524  28.275  89.857  1.00 25.78           C  
+ATOM   4596  N   GLN B  79      55.174  28.171  94.889  1.00 35.59           N  
+ATOM   4597  CA  GLN B  79      56.115  28.100  95.995  1.00 34.77           C  
+ATOM   4598  C   GLN B  79      56.340  26.656  96.450  1.00 40.32           C  
+ATOM   4599  O   GLN B  79      57.472  26.217  96.628  1.00 43.84           O  
+ATOM   4600  CB  GLN B  79      55.620  28.933  97.169  1.00 35.70           C  
+ATOM   4601  CG  GLN B  79      56.723  29.168  98.175  1.00 47.98           C  
+ATOM   4602  CD  GLN B  79      56.221  29.397  99.577  1.00 61.82           C  
+ATOM   4603  OE1 GLN B  79      55.091  29.048  99.920  1.00 61.22           O  
+ATOM   4604  NE2 GLN B  79      57.066  29.989 100.406  1.00 50.56           N  
+ATOM   4605  N   ALA B  80      55.257  25.907  96.606  1.00 34.22           N  
+ATOM   4606  CA  ALA B  80      55.341  24.523  97.025  1.00 30.34           C  
+ATOM   4607  C   ALA B  80      55.928  23.631  95.952  1.00 38.22           C  
+ATOM   4608  O   ALA B  80      56.323  22.508  96.244  1.00 45.62           O  
+ATOM   4609  CB  ALA B  80      53.977  24.026  97.420  1.00 30.06           C  
+ATOM   4610  N   ARG B  81      55.958  24.090  94.707  1.00 34.63           N  
+ATOM   4611  CA  ARG B  81      56.520  23.276  93.628  1.00 35.85           C  
+ATOM   4612  C   ARG B  81      58.041  23.439  93.646  1.00 42.32           C  
+ATOM   4613  O   ARG B  81      58.750  22.811  92.863  1.00 44.81           O  
+ATOM   4614  CB  ARG B  81      55.985  23.705  92.251  1.00 36.85           C  
+ATOM   4615  CG  ARG B  81      54.568  23.265  91.923  1.00 39.73           C  
+ATOM   4616  CD  ARG B  81      54.358  23.246  90.425  1.00 42.24           C  
+ATOM   4617  NE  ARG B  81      55.554  22.722  89.783  1.00 67.26           N  
+ATOM   4618  CZ  ARG B  81      56.143  23.263  88.723  1.00 65.83           C  
+ATOM   4619  NH1 ARG B  81      55.634  24.344  88.148  1.00 41.30           N  
+ATOM   4620  NH2 ARG B  81      57.243  22.711  88.233  1.00 46.89           N  
+ATOM   4621  N   GLY B  82      58.519  24.296  94.544  1.00 34.77           N  
+ATOM   4622  CA  GLY B  82      59.933  24.558  94.722  1.00 32.12           C  
+ATOM   4623  C   GLY B  82      60.491  25.517  93.681  1.00 38.41           C  
+ATOM   4624  O   GLY B  82      61.658  25.409  93.324  1.00 42.89           O  
+ATOM   4625  N   LEU B  83      59.687  26.451  93.179  1.00 36.47           N  
+ATOM   4626  CA  LEU B  83      60.160  27.396  92.166  1.00 34.22           C  
+ATOM   4627  C   LEU B  83      60.806  28.577  92.863  1.00 36.49           C  
+ATOM   4628  O   LEU B  83      60.573  28.806  94.048  1.00 37.75           O  
+ATOM   4629  CB  LEU B  83      59.027  27.872  91.243  1.00 33.85           C  
+ATOM   4630  CG  LEU B  83      58.191  26.851  90.447  1.00 35.53           C  
+ATOM   4631  CD1 LEU B  83      57.334  27.551  89.405  1.00 34.21           C  
+ATOM   4632  CD2 LEU B  83      59.060  25.813  89.761  1.00 35.50           C  
+ATOM   4633  N   ALA B  84      61.605  29.326  92.112  1.00 31.38           N  
+ATOM   4634  CA  ALA B  84      62.330  30.484  92.619  1.00 28.40           C  
+ATOM   4635  C   ALA B  84      61.418  31.662  92.868  1.00 37.34           C  
+ATOM   4636  O   ALA B  84      60.417  31.840  92.182  1.00 43.87           O  
+ATOM   4637  CB  ALA B  84      63.389  30.893  91.627  1.00 28.23           C  
+ATOM   4638  N   VAL B  85      61.804  32.505  93.813  1.00 33.25           N  
+ATOM   4639  CA  VAL B  85      61.005  33.672  94.133  1.00 31.56           C  
+ATOM   4640  C   VAL B  85      60.791  34.478  92.858  1.00 39.97           C  
+ATOM   4641  O   VAL B  85      59.687  34.967  92.606  1.00 42.98           O  
+ATOM   4642  CB  VAL B  85      61.672  34.504  95.251  1.00 32.72           C  
+ATOM   4643  CG1 VAL B  85      61.074  35.892  95.325  1.00 33.11           C  
+ATOM   4644  CG2 VAL B  85      61.524  33.795  96.576  1.00 32.54           C  
+ATOM   4645  N   LYS B  86      61.848  34.586  92.053  1.00 34.83           N  
+ATOM   4646  CA  LYS B  86      61.814  35.334  90.796  1.00 32.70           C  
+ATOM   4647  C   LYS B  86      60.824  34.782  89.778  1.00 33.97           C  
+ATOM   4648  O   LYS B  86      60.175  35.530  89.046  1.00 33.01           O  
+ATOM   4649  CB  LYS B  86      63.204  35.387  90.169  1.00 34.07           C  
+ATOM   4650  CG  LYS B  86      64.149  36.349  90.862  1.00 36.16           C  
+ATOM   4651  CD  LYS B  86      63.941  37.751  90.316  1.00 42.66           C  
+ATOM   4652  CE  LYS B  86      65.253  38.410  89.910  1.00 53.98           C  
+ATOM   4653  NZ  LYS B  86      64.945  39.759  89.344  1.00 63.58           N  
+ATOM   4654  N   THR B  87      60.734  33.460  89.716  1.00 31.55           N  
+ATOM   4655  CA  THR B  87      59.792  32.819  88.808  1.00 32.26           C  
+ATOM   4656  C   THR B  87      58.366  33.069  89.315  1.00 37.13           C  
+ATOM   4657  O   THR B  87      57.467  33.414  88.540  1.00 36.73           O  
+ATOM   4658  CB  THR B  87      60.167  31.347  88.566  1.00 32.84           C  
+ATOM   4659  OG1 THR B  87      59.053  30.477  88.805  1.00 36.14           O  
+ATOM   4660  CG2 THR B  87      61.320  30.991  89.457  1.00 39.11           C  
+ATOM   4661  N   ILE B  88      58.198  32.980  90.632  1.00 34.35           N  
+ATOM   4662  CA  ILE B  88      56.910  33.255  91.245  1.00 33.12           C  
+ATOM   4663  C   ILE B  88      56.534  34.718  91.024  1.00 36.67           C  
+ATOM   4664  O   ILE B  88      55.390  35.039  90.744  1.00 37.10           O  
+ATOM   4665  CB  ILE B  88      56.885  32.891  92.722  1.00 33.96           C  
+ATOM   4666  CG1 ILE B  88      57.059  31.376  92.849  1.00 30.02           C  
+ATOM   4667  CG2 ILE B  88      55.601  33.430  93.368  1.00 34.16           C  
+ATOM   4668  CD1 ILE B  88      57.401  30.899  94.238  1.00 32.58           C  
+ATOM   4669  N   GLN B  89      57.511  35.609  91.102  1.00 34.96           N  
+ATOM   4670  CA  GLN B  89      57.216  37.010  90.854  1.00 36.72           C  
+ATOM   4671  C   GLN B  89      56.924  37.255  89.371  1.00 43.06           C  
+ATOM   4672  O   GLN B  89      56.302  38.259  89.037  1.00 46.95           O  
+ATOM   4673  CB  GLN B  89      58.347  37.924  91.329  1.00 37.48           C  
+ATOM   4674  CG  GLN B  89      58.844  37.653  92.724  1.00 39.82           C  
+ATOM   4675  CD  GLN B  89      59.792  38.754  93.164  1.00 88.66           C  
+ATOM   4676  OE1 GLN B  89      60.499  39.317  92.343  1.00 90.06           O  
+ATOM   4677  NE2 GLN B  89      59.767  39.049  94.454  1.00 99.54           N  
+ATOM   4678  N   GLN B  90      57.370  36.347  88.495  1.00 36.58           N  
+ATOM   4679  CA  GLN B  90      57.135  36.483  87.054  1.00 33.55           C  
+ATOM   4680  C   GLN B  90      55.681  36.139  86.735  1.00 33.19           C  
+ATOM   4681  O   GLN B  90      55.023  36.826  85.948  1.00 31.72           O  
+ATOM   4682  CB  GLN B  90      58.073  35.597  86.229  1.00 33.74           C  
+ATOM   4683  CG  GLN B  90      57.816  35.679  84.713  1.00 30.94           C  
+ATOM   4684  CD  GLN B  90      58.485  36.873  84.041  1.00 50.63           C  
+ATOM   4685  OE1 GLN B  90      59.569  37.309  84.430  1.00 72.79           O  
+ATOM   4686  NE2 GLN B  90      57.827  37.412  83.025  1.00 37.67           N  
+ATOM   4687  N   HIS B  91      55.188  35.081  87.374  1.00 31.34           N  
+ATOM   4688  CA  HIS B  91      53.795  34.644  87.236  1.00 28.83           C  
+ATOM   4689  C   HIS B  91      52.812  35.720  87.694  1.00 33.51           C  
+ATOM   4690  O   HIS B  91      51.877  36.071  86.972  1.00 32.70           O  
+ATOM   4691  CB  HIS B  91      53.580  33.304  87.927  1.00 26.97           C  
+ATOM   4692  CG  HIS B  91      54.254  32.179  87.212  1.00 31.53           C  
+ATOM   4693  ND1 HIS B  91      53.582  31.055  86.786  1.00 34.62           N  
+ATOM   4694  CD2 HIS B  91      55.541  32.019  86.818  1.00 32.66           C  
+ATOM   4695  CE1 HIS B  91      54.431  30.231  86.196  1.00 32.45           C  
+ATOM   4696  NE2 HIS B  91      55.626  30.796  86.198  1.00 32.10           N  
+ATOM   4697  N   LEU B  92      53.093  36.303  88.853  1.00 31.33           N  
+ATOM   4698  CA  LEU B  92      52.290  37.389  89.390  1.00 31.78           C  
+ATOM   4699  C   LEU B  92      52.379  38.618  88.474  1.00 40.22           C  
+ATOM   4700  O   LEU B  92      51.390  39.309  88.232  1.00 42.49           O  
+ATOM   4701  CB  LEU B  92      52.821  37.754  90.784  1.00 32.14           C  
+ATOM   4702  CG  LEU B  92      51.897  38.412  91.815  1.00 36.09           C  
+ATOM   4703  CD1 LEU B  92      52.661  39.159  92.898  1.00 33.30           C  
+ATOM   4704  CD2 LEU B  92      50.807  39.281  91.196  1.00 31.73           C  
+ATOM   4705  N   GLY B  93      53.575  38.934  87.988  1.00 34.96           N  
+ATOM   4706  CA  GLY B  93      53.728  40.106  87.135  1.00 33.12           C  
+ATOM   4707  C   GLY B  93      52.999  39.969  85.795  1.00 36.61           C  
+ATOM   4708  O   GLY B  93      52.455  40.947  85.283  1.00 34.07           O  
+ATOM   4709  N   GLN B  94      53.033  38.779  85.203  1.00 34.16           N  
+ATOM   4710  CA  GLN B  94      52.337  38.564  83.936  1.00 33.19           C  
+ATOM   4711  C   GLN B  94      50.823  38.741  84.156  1.00 34.57           C  
+ATOM   4712  O   GLN B  94      50.165  39.427  83.378  1.00 32.69           O  
+ATOM   4713  CB  GLN B  94      52.633  37.177  83.360  1.00 33.88           C  
+ATOM   4714  CG  GLN B  94      53.998  37.031  82.701  1.00 41.93           C  
+ATOM   4715  CD  GLN B  94      54.352  38.145  81.706  1.00 43.83           C  
+ATOM   4716  OE1 GLN B  94      53.484  38.764  81.114  1.00 39.29           O  
+ATOM   4717  NE2 GLN B  94      55.646  38.360  81.538  1.00 54.35           N  
+ATOM   4718  N   LEU B  95      50.287  38.123  85.217  1.00 31.30           N  
+ATOM   4719  CA  LEU B  95      48.869  38.223  85.590  1.00 28.76           C  
+ATOM   4720  C   LEU B  95      48.526  39.680  85.836  1.00 32.78           C  
+ATOM   4721  O   LEU B  95      47.483  40.155  85.409  1.00 33.96           O  
+ATOM   4722  CB  LEU B  95      48.563  37.422  86.870  1.00 26.90           C  
+ATOM   4723  CG  LEU B  95      48.520  35.901  86.697  1.00 28.64           C  
+ATOM   4724  CD1 LEU B  95      48.155  35.192  87.978  1.00 25.86           C  
+ATOM   4725  CD2 LEU B  95      47.563  35.499  85.577  1.00 28.55           C  
+ATOM   4726  N   ASN B  96      49.409  40.396  86.525  1.00 30.68           N  
+ATOM   4727  CA  ASN B  96      49.146  41.795  86.805  1.00 31.80           C  
+ATOM   4728  C   ASN B  96      49.031  42.584  85.504  1.00 40.65           C  
+ATOM   4729  O   ASN B  96      48.201  43.484  85.394  1.00 42.54           O  
+ATOM   4730  CB  ASN B  96      50.255  42.405  87.663  1.00 34.00           C  
+ATOM   4731  CG  ASN B  96      50.120  42.075  89.126  1.00 42.61           C  
+ATOM   4732  OD1 ASN B  96      49.084  41.592  89.588  1.00 38.16           O  
+ATOM   4733  ND2 ASN B  96      51.179  42.337  89.876  1.00 41.46           N  
+ATOM   4734  N   MET B  97      49.889  42.270  84.533  1.00 38.65           N  
+ATOM   4735  CA  MET B  97      49.902  42.973  83.252  1.00 36.79           C  
+ATOM   4736  C   MET B  97      48.652  42.671  82.456  1.00 34.63           C  
+ATOM   4737  O   MET B  97      48.078  43.566  81.853  1.00 34.01           O  
+ATOM   4738  CB  MET B  97      51.129  42.602  82.418  1.00 40.35           C  
+ATOM   4739  CG  MET B  97      51.366  43.534  81.230  1.00 46.43           C  
+ATOM   4740  SD  MET B  97      52.047  42.726  79.748  1.00 54.13           S  
+ATOM   4741  CE  MET B  97      53.434  41.863  80.427  1.00 52.36           C  
+ATOM   4742  N   LEU B  98      48.254  41.404  82.423  1.00 32.20           N  
+ATOM   4743  CA  LEU B  98      47.041  41.009  81.704  1.00 31.39           C  
+ATOM   4744  C   LEU B  98      45.863  41.840  82.188  1.00 36.01           C  
+ATOM   4745  O   LEU B  98      45.098  42.368  81.396  1.00 41.23           O  
+ATOM   4746  CB  LEU B  98      46.723  39.536  81.955  1.00 29.81           C  
+ATOM   4747  CG  LEU B  98      45.549  38.946  81.185  1.00 32.03           C  
+ATOM   4748  CD1 LEU B  98      45.828  39.119  79.710  1.00 32.21           C  
+ATOM   4749  CD2 LEU B  98      45.435  37.469  81.541  1.00 29.41           C  
+ATOM   4750  N   HIS B  99      45.733  41.953  83.502  1.00 29.26           N  
+ATOM   4751  CA  HIS B  99      44.655  42.710  84.119  1.00 27.28           C  
+ATOM   4752  C   HIS B  99      44.771  44.228  83.933  1.00 36.62           C  
+ATOM   4753  O   HIS B  99      43.868  44.841  83.363  1.00 37.14           O  
+ATOM   4754  CB  HIS B  99      44.508  42.286  85.593  1.00 26.62           C  
+ATOM   4755  CG  HIS B  99      44.012  40.881  85.756  1.00 31.63           C  
+ATOM   4756  ND1 HIS B  99      44.791  39.779  85.475  1.00 34.47           N  
+ATOM   4757  CD2 HIS B  99      42.798  40.396  86.114  1.00 35.73           C  
+ATOM   4758  CE1 HIS B  99      44.084  38.676  85.664  1.00 35.14           C  
+ATOM   4759  NE2 HIS B  99      42.870  39.023  86.051  1.00 35.65           N  
+ATOM   4760  N   ARG B 100      45.874  44.826  84.383  1.00 36.18           N  
+ATOM   4761  CA  ARG B 100      46.091  46.273  84.256  1.00 35.27           C  
+ATOM   4762  C   ARG B 100      45.871  46.719  82.810  1.00 43.00           C  
+ATOM   4763  O   ARG B 100      45.099  47.639  82.524  1.00 44.62           O  
+ATOM   4764  CB  ARG B 100      47.500  46.674  84.713  1.00 31.32           C  
+ATOM   4765  CG  ARG B 100      47.635  48.164  85.039  1.00 41.30           C  
+ATOM   4766  CD  ARG B 100      49.081  48.619  85.215  1.00 60.77           C  
+ATOM   4767  NE  ARG B 100      49.885  48.187  84.082  1.00 88.17           N  
+ATOM   4768  CZ  ARG B 100      50.645  47.102  84.057  1.00 97.82           C  
+ATOM   4769  NH1 ARG B 100      50.769  46.299  85.105  1.00 67.78           N  
+ATOM   4770  NH2 ARG B 100      51.282  46.809  82.945  1.00 84.87           N  
+ATOM   4771  N   ARG B 101      46.526  46.037  81.885  1.00 38.07           N  
+ATOM   4772  CA  ARG B 101      46.360  46.388  80.487  1.00 38.14           C  
+ATOM   4773  C   ARG B 101      44.969  46.033  80.046  1.00 45.21           C  
+ATOM   4774  O   ARG B 101      44.572  46.348  78.927  1.00 44.60           O  
+ATOM   4775  CB  ARG B 101      47.339  45.608  79.628  1.00 38.00           C  
+ATOM   4776  CG  ARG B 101      48.756  45.899  79.988  1.00 50.54           C  
+ATOM   4777  CD  ARG B 101      49.401  46.601  78.837  1.00 45.77           C  
+ATOM   4778  NE  ARG B 101      50.475  47.465  79.292  1.00 46.78           N  
+ATOM   4779  CZ  ARG B 101      50.776  48.605  78.690  1.00 65.06           C  
+ATOM   4780  NH1 ARG B 101      50.060  48.985  77.642  1.00 57.53           N  
+ATOM   4781  NH2 ARG B 101      51.776  49.361  79.130  1.00 41.58           N  
+ATOM   4782  N   SER B 102      44.243  45.326  80.898  1.00 43.79           N  
+ATOM   4783  CA  SER B 102      42.893  44.937  80.536  1.00 43.29           C  
+ATOM   4784  C   SER B 102      41.923  46.012  80.969  1.00 49.68           C  
+ATOM   4785  O   SER B 102      40.771  46.029  80.540  1.00 49.18           O  
+ATOM   4786  CB  SER B 102      42.509  43.628  81.209  1.00 44.08           C  
+ATOM   4787  OG  SER B 102      42.376  42.604  80.237  1.00 46.13           O  
+ATOM   4788  N   GLY B 103      42.399  46.908  81.821  1.00 48.33           N  
+ATOM   4789  CA  GLY B 103      41.570  47.972  82.350  1.00 48.78           C  
+ATOM   4790  C   GLY B 103      40.894  47.402  83.591  1.00 56.81           C  
+ATOM   4791  O   GLY B 103      39.911  47.963  84.067  1.00 60.89           O  
+ATOM   4792  N   LEU B 104      41.402  46.272  84.091  1.00 51.24           N  
+ATOM   4793  CA  LEU B 104      40.882  45.617  85.299  1.00 48.56           C  
+ATOM   4794  C   LEU B 104      41.892  45.742  86.441  1.00 54.14           C  
+ATOM   4795  O   LEU B 104      43.070  46.008  86.200  1.00 53.71           O  
+ATOM   4796  CB  LEU B 104      40.559  44.144  85.055  1.00 46.49           C  
+ATOM   4797  CG  LEU B 104      39.654  43.874  83.859  1.00 48.83           C  
+ATOM   4798  CD1 LEU B 104      39.714  42.407  83.452  1.00 48.81           C  
+ATOM   4799  CD2 LEU B 104      38.237  44.276  84.231  1.00 49.40           C  
+ATOM   4800  N   PRO B 105      41.429  45.595  87.682  1.00 52.69           N  
+ATOM   4801  CA  PRO B 105      42.327  45.723  88.833  1.00 51.50           C  
+ATOM   4802  C   PRO B 105      43.444  44.681  88.741  1.00 50.65           C  
+ATOM   4803  O   PRO B 105      43.237  43.640  88.126  1.00 46.88           O  
+ATOM   4804  CB  PRO B 105      41.416  45.395  90.024  1.00 53.72           C  
+ATOM   4805  CG  PRO B 105      39.994  45.442  89.511  1.00 58.03           C  
+ATOM   4806  CD  PRO B 105      40.016  45.800  88.056  1.00 53.67           C  
+ATOM   4807  N   ARG B 106      44.587  44.921  89.384  1.00 46.20           N  
+ATOM   4808  CA  ARG B 106      45.688  43.963  89.371  1.00 44.30           C  
+ATOM   4809  C   ARG B 106      45.612  43.075  90.596  1.00 52.66           C  
+ATOM   4810  O   ARG B 106      45.279  43.551  91.690  1.00 57.49           O  
+ATOM   4811  CB  ARG B 106      47.036  44.678  89.363  1.00 37.77           C  
+ATOM   4812  CG  ARG B 106      47.334  45.307  88.028  1.00 45.23           C  
+ATOM   4813  CD  ARG B 106      48.576  46.141  88.111  1.00 41.62           C  
+ATOM   4814  NE  ARG B 106      48.734  46.733  89.431  1.00 49.71           N  
+ATOM   4815  CZ  ARG B 106      49.726  46.433  90.264  1.00 88.13           C  
+ATOM   4816  NH1 ARG B 106      50.642  45.535  89.920  1.00 87.67           N  
+ATOM   4817  NH2 ARG B 106      49.796  47.024  91.448  1.00 84.20           N  
+ATOM   4818  N   PRO B 107      45.887  41.787  90.423  1.00 44.39           N  
+ATOM   4819  CA  PRO B 107      45.871  40.896  91.573  1.00 42.25           C  
+ATOM   4820  C   PRO B 107      46.666  41.547  92.705  1.00 39.84           C  
+ATOM   4821  O   PRO B 107      46.184  41.664  93.835  1.00 36.20           O  
+ATOM   4822  CB  PRO B 107      46.572  39.653  91.040  1.00 43.26           C  
+ATOM   4823  CG  PRO B 107      46.084  39.590  89.618  1.00 46.73           C  
+ATOM   4824  CD  PRO B 107      45.861  41.023  89.158  1.00 43.30           C  
+ATOM   4825  N   SER B 108      47.872  42.002  92.388  1.00 35.33           N  
+ATOM   4826  CA  SER B 108      48.688  42.641  93.405  1.00 37.14           C  
+ATOM   4827  C   SER B 108      47.983  43.800  94.110  1.00 45.02           C  
+ATOM   4828  O   SER B 108      48.444  44.293  95.139  1.00 43.52           O  
+ATOM   4829  CB  SER B 108      50.050  43.037  92.852  1.00 40.57           C  
+ATOM   4830  OG  SER B 108      50.920  41.920  92.911  1.00 53.31           O  
+ATOM   4831  N   ASP B 109      46.837  44.211  93.583  1.00 41.77           N  
+ATOM   4832  CA  ASP B 109      46.104  45.299  94.204  1.00 39.57           C  
+ATOM   4833  C   ASP B 109      45.331  44.827  95.415  1.00 41.92           C  
+ATOM   4834  O   ASP B 109      44.640  45.610  96.053  1.00 41.73           O  
+ATOM   4835  CB  ASP B 109      45.156  45.931  93.205  1.00 41.03           C  
+ATOM   4836  CG  ASP B 109      45.877  46.812  92.240  1.00 48.55           C  
+ATOM   4837  OD1 ASP B 109      46.923  47.356  92.643  1.00 49.02           O  
+ATOM   4838  OD2 ASP B 109      45.403  46.965  91.096  1.00 60.15           O  
+ATOM   4839  N   SER B 110      45.466  43.555  95.754  1.00 37.95           N  
+ATOM   4840  CA  SER B 110      44.751  43.043  96.905  1.00 37.88           C  
+ATOM   4841  C   SER B 110      45.700  42.550  97.983  1.00 40.46           C  
+ATOM   4842  O   SER B 110      46.637  41.797  97.714  1.00 44.93           O  
+ATOM   4843  CB  SER B 110      43.775  41.944  96.480  1.00 44.02           C  
+ATOM   4844  OG  SER B 110      44.441  40.728  96.198  1.00 63.85           O  
+ATOM   4845  N   ASN B 111      45.422  42.949  99.214  1.00 32.08           N  
+ATOM   4846  CA  ASN B 111      46.229  42.517 100.335  1.00 30.00           C  
+ATOM   4847  C   ASN B 111      46.532  41.045 100.194  1.00 34.56           C  
+ATOM   4848  O   ASN B 111      47.657  40.623 100.409  1.00 36.83           O  
+ATOM   4849  CB  ASN B 111      45.475  42.716 101.648  1.00 34.70           C  
+ATOM   4850  CG  ASN B 111      45.561  44.122 102.147  1.00 52.38           C  
+ATOM   4851  OD1 ASN B 111      46.428  44.875 101.724  1.00 51.81           O  
+ATOM   4852  ND2 ASN B 111      44.679  44.487 103.064  1.00 55.69           N  
+ATOM   4853  N   ALA B 112      45.525  40.224  99.905  1.00 33.44           N  
+ATOM   4854  CA  ALA B 112      45.812  38.799  99.828  1.00 33.88           C  
+ATOM   4855  C   ALA B 112      46.981  38.495  98.921  1.00 37.72           C  
+ATOM   4856  O   ALA B 112      47.789  37.629  99.235  1.00 39.06           O  
+ATOM   4857  CB  ALA B 112      44.599  37.985  99.410  1.00 33.75           C  
+ATOM   4858  N   VAL B 113      47.045  39.157  97.772  1.00 31.84           N  
+ATOM   4859  CA  VAL B 113      48.115  38.868  96.828  1.00 30.48           C  
+ATOM   4860  C   VAL B 113      49.398  39.602  97.190  1.00 33.45           C  
+ATOM   4861  O   VAL B 113      50.488  39.038  97.129  1.00 32.98           O  
+ATOM   4862  CB  VAL B 113      47.677  39.156  95.394  1.00 33.30           C  
+ATOM   4863  CG1 VAL B 113      48.754  38.704  94.427  1.00 32.57           C  
+ATOM   4864  CG2 VAL B 113      46.383  38.420  95.109  1.00 32.42           C  
+ATOM   4865  N   SER B 114      49.243  40.862  97.582  1.00 30.05           N  
+ATOM   4866  CA  SER B 114      50.347  41.700  98.026  1.00 27.43           C  
+ATOM   4867  C   SER B 114      51.141  41.012  99.125  1.00 35.32           C  
+ATOM   4868  O   SER B 114      52.343  40.812  99.000  1.00 38.24           O  
+ATOM   4869  CB  SER B 114      49.788  42.996  98.603  1.00 21.18           C  
+ATOM   4870  OG  SER B 114      49.222  43.741  97.551  1.00 45.44           O  
+ATOM   4871  N   LEU B 115      50.464  40.666 100.212  1.00 31.18           N  
+ATOM   4872  CA  LEU B 115      51.102  40.049 101.363  1.00 29.35           C  
+ATOM   4873  C   LEU B 115      51.631  38.647 101.169  1.00 31.03           C  
+ATOM   4874  O   LEU B 115      52.582  38.263 101.845  1.00 34.40           O  
+ATOM   4875  CB  LEU B 115      50.163  40.042 102.569  1.00 29.81           C  
+ATOM   4876  CG  LEU B 115      49.586  41.364 103.066  1.00 33.56           C  
+ATOM   4877  CD1 LEU B 115      48.410  41.133 104.020  1.00 32.18           C  
+ATOM   4878  CD2 LEU B 115      50.688  42.206 103.705  1.00 32.53           C  
+ATOM   4879  N   VAL B 116      50.986  37.838 100.335  1.00 26.13           N  
+ATOM   4880  CA  VAL B 116      51.454  36.461 100.163  1.00 26.25           C  
+ATOM   4881  C   VAL B 116      52.765  36.532  99.398  1.00 31.30           C  
+ATOM   4882  O   VAL B 116      53.649  35.706  99.607  1.00 30.44           O  
+ATOM   4883  CB  VAL B 116      50.442  35.548  99.399  1.00 28.90           C  
+ATOM   4884  CG1 VAL B 116      50.617  35.678  97.876  1.00 30.47           C  
+ATOM   4885  CG2 VAL B 116      50.629  34.091  99.808  1.00 27.23           C  
+ATOM   4886  N   MET B 117      52.878  37.507  98.499  1.00 30.79           N  
+ATOM   4887  CA  MET B 117      54.092  37.650  97.712  1.00 30.01           C  
+ATOM   4888  C   MET B 117      55.229  37.926  98.710  1.00 38.04           C  
+ATOM   4889  O   MET B 117      56.202  37.166  98.778  1.00 38.56           O  
+ATOM   4890  CB  MET B 117      53.938  38.740  96.644  1.00 29.45           C  
+ATOM   4891  CG  MET B 117      54.859  38.584  95.424  1.00 32.80           C  
+ATOM   4892  SD  MET B 117      55.138  36.925  94.704  1.00 39.52           S  
+ATOM   4893  CE  MET B 117      56.552  36.311  95.598  1.00 36.74           C  
+ATOM   4894  N   ARG B 118      55.070  38.973  99.520  1.00 34.22           N  
+ATOM   4895  CA  ARG B 118      56.045  39.343 100.541  1.00 30.33           C  
+ATOM   4896  C   ARG B 118      56.424  38.128 101.350  1.00 34.92           C  
+ATOM   4897  O   ARG B 118      57.588  37.786 101.494  1.00 39.13           O  
+ATOM   4898  CB  ARG B 118      55.418  40.337 101.501  1.00 24.21           C  
+ATOM   4899  CG  ARG B 118      55.341  41.736 100.963  1.00 28.86           C  
+ATOM   4900  CD  ARG B 118      55.301  42.702 102.138  1.00 37.63           C  
+ATOM   4901  NE  ARG B 118      56.466  43.587 102.172  1.00 71.21           N  
+ATOM   4902  CZ  ARG B 118      57.431  43.530 103.088  1.00 93.19           C  
+ATOM   4903  NH1 ARG B 118      57.375  42.629 104.059  1.00 79.89           N  
+ATOM   4904  NH2 ARG B 118      58.451  44.378 103.038  1.00 83.76           N  
+ATOM   4905  N   ARG B 119      55.413  37.448 101.855  1.00 30.23           N  
+ATOM   4906  CA  ARG B 119      55.624  36.267 102.659  1.00 31.55           C  
+ATOM   4907  C   ARG B 119      56.404  35.149 101.966  1.00 42.49           C  
+ATOM   4908  O   ARG B 119      57.252  34.502 102.582  1.00 42.62           O  
+ATOM   4909  CB  ARG B 119      54.266  35.759 103.152  1.00 29.23           C  
+ATOM   4910  CG  ARG B 119      54.250  34.322 103.636  1.00 33.84           C  
+ATOM   4911  CD  ARG B 119      52.848  33.919 104.025  1.00 43.28           C  
+ATOM   4912  NE  ARG B 119      52.803  32.621 104.676  1.00 45.77           N  
+ATOM   4913  CZ  ARG B 119      51.679  31.976 104.964  1.00 78.13           C  
+ATOM   4914  NH1 ARG B 119      50.503  32.509 104.650  1.00 69.36           N  
+ATOM   4915  NH2 ARG B 119      51.743  30.797 105.552  1.00 76.62           N  
+ATOM   4916  N   ILE B 120      56.089  34.876 100.706  1.00 41.72           N  
+ATOM   4917  CA  ILE B 120      56.776  33.798 100.006  1.00 41.17           C  
+ATOM   4918  C   ILE B 120      58.248  34.188  99.838  1.00 42.97           C  
+ATOM   4919  O   ILE B 120      59.154  33.381 100.050  1.00 39.72           O  
+ATOM   4920  CB  ILE B 120      56.149  33.514  98.630  1.00 44.20           C  
+ATOM   4921  CG1 ILE B 120      54.721  32.984  98.781  1.00 44.44           C  
+ATOM   4922  CG2 ILE B 120      56.969  32.471  97.894  1.00 44.95           C  
+ATOM   4923  CD1 ILE B 120      53.992  32.790  97.450  1.00 45.32           C  
+ATOM   4924  N   ARG B 121      58.470  35.436  99.440  1.00 38.36           N  
+ATOM   4925  CA  ARG B 121      59.819  35.960  99.254  1.00 40.71           C  
+ATOM   4926  C   ARG B 121      60.589  35.836 100.565  1.00 49.42           C  
+ATOM   4927  O   ARG B 121      61.638  35.191 100.638  1.00 50.45           O  
+ATOM   4928  CB  ARG B 121      59.741  37.430  98.849  1.00 40.45           C  
+ATOM   4929  CG  ARG B 121      61.045  37.987  98.342  1.00 44.59           C  
+ATOM   4930  CD  ARG B 121      61.125  39.469  98.636  1.00 60.29           C  
+ATOM   4931  NE  ARG B 121      61.147  40.302  97.435  1.00 76.06           N  
+ATOM   4932  CZ  ARG B 121      62.143  40.326  96.551  1.00 95.13           C  
+ATOM   4933  NH1 ARG B 121      63.199  39.542  96.717  1.00 98.19           N  
+ATOM   4934  NH2 ARG B 121      62.081  41.125  95.494  1.00 68.48           N  
+ATOM   4935  N   LYS B 122      60.010  36.433 101.606  1.00 44.83           N  
+ATOM   4936  CA  LYS B 122      60.542  36.428 102.965  1.00 42.44           C  
+ATOM   4937  C   LYS B 122      60.864  35.026 103.462  1.00 42.32           C  
+ATOM   4938  O   LYS B 122      61.959  34.784 103.956  1.00 43.03           O  
+ATOM   4939  CB  LYS B 122      59.580  37.138 103.922  1.00 44.16           C  
+ATOM   4940  CG  LYS B 122      60.259  38.172 104.789  1.00 41.88           C  
+ATOM   4941  CD  LYS B 122      59.292  39.167 105.387  1.00 44.71           C  
+ATOM   4942  CE  LYS B 122      59.822  39.653 106.725  1.00 69.47           C  
+ATOM   4943  NZ  LYS B 122      61.290  39.417 106.890  1.00 96.95           N  
+ATOM   4944  N   GLU B 123      59.944  34.082 103.304  1.00 38.62           N  
+ATOM   4945  CA  GLU B 123      60.193  32.712 103.751  1.00 39.12           C  
+ATOM   4946  C   GLU B 123      61.200  31.982 102.872  1.00 53.41           C  
+ATOM   4947  O   GLU B 123      61.850  31.036 103.317  1.00 56.31           O  
+ATOM   4948  CB  GLU B 123      58.911  31.886 103.730  1.00 39.61           C  
+ATOM   4949  CG  GLU B 123      57.847  32.308 104.704  1.00 48.03           C  
+ATOM   4950  CD  GLU B 123      56.596  31.498 104.493  1.00 70.93           C  
+ATOM   4951  OE1 GLU B 123      56.346  31.096 103.337  1.00 71.59           O  
+ATOM   4952  OE2 GLU B 123      55.882  31.249 105.482  1.00 77.28           O  
+ATOM   4953  N   ASN B 124      61.284  32.362 101.603  1.00 52.54           N  
+ATOM   4954  CA  ASN B 124      62.205  31.672 100.712  1.00 51.19           C  
+ATOM   4955  C   ASN B 124      63.653  32.071 100.940  1.00 49.58           C  
+ATOM   4956  O   ASN B 124      64.536  31.214 101.090  1.00 45.37           O  
+ATOM   4957  CB  ASN B 124      61.759  31.761  99.252  1.00 49.77           C  
+ATOM   4958  CG  ASN B 124      60.796  30.646  98.895  1.00 55.97           C  
+ATOM   4959  OD1 ASN B 124      60.159  30.071  99.783  1.00 48.35           O  
+ATOM   4960  ND2 ASN B 124      60.707  30.301  97.614  1.00 40.38           N  
+ATOM   4961  N   VAL B 125      63.870  33.379 101.068  1.00 45.79           N  
+ATOM   4962  CA  VAL B 125      65.200  33.907 101.338  1.00 47.75           C  
+ATOM   4963  C   VAL B 125      65.667  33.405 102.703  1.00 57.93           C  
+ATOM   4964  O   VAL B 125      66.752  32.833 102.822  1.00 60.81           O  
+ATOM   4965  CB  VAL B 125      65.234  35.438 101.357  1.00 51.74           C  
+ATOM   4966  CG1 VAL B 125      64.912  36.017  99.985  1.00 49.79           C  
+ATOM   4967  CG2 VAL B 125      64.240  35.873 102.321  1.00 52.80           C  
+ATOM   4968  N   ASP B 126      64.823  33.552 103.725  1.00 53.23           N  
+ATOM   4969  CA  ASP B 126      65.173  33.114 105.069  1.00 50.70           C  
+ATOM   4970  C   ASP B 126      65.374  31.612 105.142  1.00 54.61           C  
+ATOM   4971  O   ASP B 126      65.347  31.044 106.227  1.00 58.80           O  
+ATOM   4972  CB  ASP B 126      64.186  33.572 106.140  1.00 50.81           C  
+ATOM   4973  CG  ASP B 126      64.036  35.074 106.205  1.00 61.11           C  
+ATOM   4974  OD1 ASP B 126      64.742  35.790 105.459  1.00 61.83           O  
+ATOM   4975  OD2 ASP B 126      63.189  35.524 107.007  1.00 65.86           O  
+ATOM   4976  N   ALA B 127      65.439  30.958 103.997  1.00 46.90           N  
+ATOM   4977  CA  ALA B 127      65.710  29.530 104.004  1.00 46.43           C  
+ATOM   4978  C   ALA B 127      66.913  29.400 103.093  1.00 51.80           C  
+ATOM   4979  O   ALA B 127      67.391  28.306 102.817  1.00 53.09           O  
+ATOM   4980  CB  ALA B 127      64.532  28.730 103.485  1.00 46.27           C  
+ATOM   4981  N   GLY B 128      67.420  30.546 102.661  1.00 48.52           N  
+ATOM   4982  CA  GLY B 128      68.606  30.558 101.823  1.00 50.55           C  
+ATOM   4983  C   GLY B 128      68.391  31.305 100.524  1.00 59.78           C  
+ATOM   4984  O   GLY B 128      68.857  32.428 100.355  1.00 62.30           O  
+ATOM   4985  N   GLU B 129      67.679  30.659  99.612  1.00 55.32           N  
+ATOM   4986  CA  GLU B 129      67.424  31.214  98.302  1.00 53.83           C  
+ATOM   4987  C   GLU B 129      68.049  32.566  98.024  1.00 56.36           C  
+ATOM   4988  O   GLU B 129      67.749  33.554  98.691  1.00 50.75           O  
+ATOM   4989  CB  GLU B 129      65.931  31.223  97.962  1.00 55.35           C  
+ATOM   4990  CG  GLU B 129      65.581  32.033  96.713  1.00 61.01           C  
+ATOM   4991  CD  GLU B 129      64.493  31.396  95.858  1.00 60.81           C  
+ATOM   4992  OE1 GLU B 129      63.918  30.366  96.267  1.00 57.37           O  
+ATOM   4993  OE2 GLU B 129      64.222  31.926  94.760  1.00 51.64           O  
+ATOM   4994  N   ARG B 130      68.873  32.591  96.977  1.00 59.94           N  
+ATOM   4995  CA  ARG B 130      69.493  33.797  96.440  1.00 60.79           C  
+ATOM   4996  C   ARG B 130      69.513  33.695  94.908  1.00 59.73           C  
+ATOM   4997  O   ARG B 130      69.945  32.680  94.361  1.00 59.17           O  
+ATOM   4998  CB  ARG B 130      70.900  33.998  96.994  1.00 66.98           C  
+ATOM   4999  CG  ARG B 130      71.050  35.342  97.668  1.00 88.74           C  
+ATOM   5000  CD  ARG B 130      69.749  35.697  98.359  1.00100.00           C  
+ATOM   5001  NE  ARG B 130      69.981  36.384  99.617  1.00100.00           N  
+ATOM   5002  CZ  ARG B 130      69.608  35.902 100.792  1.00 98.83           C  
+ATOM   5003  NH1 ARG B 130      69.010  34.719 100.862  1.00 66.60           N  
+ATOM   5004  NH2 ARG B 130      69.852  36.587 101.900  1.00 89.85           N  
+ATOM   5005  N   ALA B 131      69.010  34.707  94.208  1.00 54.00           N  
+ATOM   5006  CA  ALA B 131      69.012  34.629  92.753  1.00 55.07           C  
+ATOM   5007  C   ALA B 131      70.466  34.542  92.314  1.00 63.65           C  
+ATOM   5008  O   ALA B 131      71.313  35.270  92.826  1.00 68.31           O  
+ATOM   5009  CB  ALA B 131      68.348  35.849  92.147  1.00 56.14           C  
+ATOM   5010  N   LYS B 132      70.757  33.661  91.361  1.00 57.55           N  
+ATOM   5011  CA  LYS B 132      72.123  33.468  90.898  1.00 55.40           C  
+ATOM   5012  C   LYS B 132      72.603  34.322  89.731  1.00 58.58           C  
+ATOM   5013  O   LYS B 132      71.814  34.917  88.992  1.00 61.05           O  
+ATOM   5014  CB  LYS B 132      72.370  31.994  90.559  1.00 55.44           C  
+ATOM   5015  CG  LYS B 132      71.762  30.976  91.528  1.00 62.08           C  
+ATOM   5016  CD  LYS B 132      71.557  29.616  90.853  1.00 73.49           C  
+ATOM   5017  CE  LYS B 132      70.926  28.634  91.827  1.00 87.17           C  
+ATOM   5018  NZ  LYS B 132      71.742  28.521  93.075  1.00 90.99           N  
+ATOM   5019  N   GLN B 133      73.927  34.349  89.595  1.00 51.52           N  
+ATOM   5020  CA  GLN B 133      74.618  35.041  88.519  1.00 49.43           C  
+ATOM   5021  C   GLN B 133      75.502  34.021  87.793  1.00 47.51           C  
+ATOM   5022  O   GLN B 133      75.880  32.993  88.355  1.00 45.72           O  
+ATOM   5023  CB  GLN B 133      75.351  36.314  88.990  1.00 51.30           C  
+ATOM   5024  CG  GLN B 133      76.605  36.122  89.844  1.00 77.01           C  
+ATOM   5025  CD  GLN B 133      77.293  37.440  90.203  1.00100.00           C  
+ATOM   5026  OE1 GLN B 133      78.376  37.751  89.705  1.00100.00           O  
+ATOM   5027  NE2 GLN B 133      76.665  38.212  91.080  1.00 95.83           N  
+ATOM   5028  N   ALA B 134      75.734  34.257  86.510  1.00 41.37           N  
+ATOM   5029  CA  ALA B 134      76.493  33.334  85.688  1.00 38.89           C  
+ATOM   5030  C   ALA B 134      77.961  33.230  86.048  1.00 42.57           C  
+ATOM   5031  O   ALA B 134      78.569  34.206  86.499  1.00 44.50           O  
+ATOM   5032  CB  ALA B 134      76.348  33.721  84.233  1.00 38.78           C  
+ATOM   5033  N   LEU B 135      78.506  32.031  85.845  1.00 36.37           N  
+ATOM   5034  CA  LEU B 135      79.924  31.743  86.035  1.00 31.63           C  
+ATOM   5035  C   LEU B 135      80.659  32.821  85.246  1.00 34.25           C  
+ATOM   5036  O   LEU B 135      80.377  33.030  84.064  1.00 33.38           O  
+ATOM   5037  CB  LEU B 135      80.237  30.412  85.356  1.00 29.28           C  
+ATOM   5038  CG  LEU B 135      81.536  29.738  85.766  1.00 30.32           C  
+ATOM   5039  CD1 LEU B 135      81.635  29.841  87.273  1.00 27.51           C  
+ATOM   5040  CD2 LEU B 135      81.526  28.289  85.319  1.00 32.37           C  
+ATOM   5041  N   ALA B 136      81.597  33.499  85.899  1.00 29.89           N  
+ATOM   5042  CA  ALA B 136      82.340  34.563  85.243  1.00 30.62           C  
+ATOM   5043  C   ALA B 136      83.310  34.057  84.172  1.00 33.24           C  
+ATOM   5044  O   ALA B 136      83.823  32.945  84.261  1.00 31.52           O  
+ATOM   5045  CB  ALA B 136      83.073  35.413  86.277  1.00 31.13           C  
+ATOM   5046  N   PHE B 137      83.547  34.886  83.163  1.00 27.45           N  
+ATOM   5047  CA  PHE B 137      84.495  34.574  82.103  1.00 24.46           C  
+ATOM   5048  C   PHE B 137      85.345  35.823  82.110  1.00 28.47           C  
+ATOM   5049  O   PHE B 137      84.918  36.860  81.620  1.00 27.42           O  
+ATOM   5050  CB  PHE B 137      83.753  34.449  80.765  1.00 26.23           C  
+ATOM   5051  CG  PHE B 137      84.643  34.221  79.565  1.00 26.57           C  
+ATOM   5052  CD1 PHE B 137      85.072  32.946  79.238  1.00 27.79           C  
+ATOM   5053  CD2 PHE B 137      84.985  35.272  78.727  1.00 25.74           C  
+ATOM   5054  CE1 PHE B 137      85.883  32.736  78.145  1.00 27.50           C  
+ATOM   5055  CE2 PHE B 137      85.787  35.063  77.622  1.00 27.78           C  
+ATOM   5056  CZ  PHE B 137      86.241  33.793  77.332  1.00 25.55           C  
+ATOM   5057  N   GLU B 138      86.527  35.754  82.709  1.00 31.36           N  
+ATOM   5058  CA  GLU B 138      87.362  36.949  82.761  1.00 33.69           C  
+ATOM   5059  C   GLU B 138      88.576  36.892  81.834  1.00 39.66           C  
+ATOM   5060  O   GLU B 138      88.711  35.960  81.046  1.00 39.99           O  
+ATOM   5061  CB  GLU B 138      87.737  37.272  84.200  1.00 36.08           C  
+ATOM   5062  CG  GLU B 138      87.333  36.105  85.034  1.00 49.97           C  
+ATOM   5063  CD  GLU B 138      86.998  36.428  86.474  1.00 74.64           C  
+ATOM   5064  OE1 GLU B 138      86.358  37.479  86.639  1.00 68.31           O  
+ATOM   5065  OE2 GLU B 138      87.288  35.631  87.410  1.00 71.05           O  
+ATOM   5066  N   ARG B 139      89.418  37.921  81.893  1.00 37.42           N  
+ATOM   5067  CA  ARG B 139      90.587  38.044  81.029  1.00 36.42           C  
+ATOM   5068  C   ARG B 139      91.436  36.780  81.029  1.00 39.07           C  
+ATOM   5069  O   ARG B 139      91.926  36.345  79.980  1.00 37.17           O  
+ATOM   5070  CB  ARG B 139      91.397  39.288  81.421  1.00 36.92           C  
+ATOM   5071  CG  ARG B 139      92.791  39.393  80.804  1.00 40.16           C  
+ATOM   5072  CD  ARG B 139      92.724  39.727  79.322  1.00 44.23           C  
+ATOM   5073  NE  ARG B 139      93.990  40.231  78.803  1.00 55.06           N  
+ATOM   5074  CZ  ARG B 139      94.370  41.500  78.874  1.00 67.89           C  
+ATOM   5075  NH1 ARG B 139      93.592  42.401  79.453  1.00 47.79           N  
+ATOM   5076  NH2 ARG B 139      95.534  41.869  78.363  1.00 65.91           N  
+ATOM   5077  N   THR B 140      91.563  36.162  82.198  1.00 35.15           N  
+ATOM   5078  CA  THR B 140      92.338  34.938  82.282  1.00 34.37           C  
+ATOM   5079  C   THR B 140      91.772  33.826  81.399  1.00 37.37           C  
+ATOM   5080  O   THR B 140      92.487  33.239  80.590  1.00 37.33           O  
+ATOM   5081  CB  THR B 140      92.556  34.500  83.740  1.00 36.69           C  
+ATOM   5082  OG1 THR B 140      93.503  35.381  84.330  1.00 39.50           O  
+ATOM   5083  CG2 THR B 140      93.145  33.107  83.793  1.00 33.97           C  
+ATOM   5084  N   ASP B 141      90.480  33.552  81.532  1.00 33.61           N  
+ATOM   5085  CA  ASP B 141      89.816  32.533  80.719  1.00 32.17           C  
+ATOM   5086  C   ASP B 141      89.889  32.935  79.255  1.00 31.78           C  
+ATOM   5087  O   ASP B 141      90.048  32.099  78.382  1.00 32.99           O  
+ATOM   5088  CB  ASP B 141      88.355  32.394  81.150  1.00 34.32           C  
+ATOM   5089  CG  ASP B 141      88.223  32.215  82.641  1.00 34.28           C  
+ATOM   5090  OD1 ASP B 141      88.764  31.210  83.143  1.00 33.17           O  
+ATOM   5091  OD2 ASP B 141      87.622  33.088  83.306  1.00 37.31           O  
+ATOM   5092  N   PHE B 142      89.764  34.224  78.973  1.00 29.23           N  
+ATOM   5093  CA  PHE B 142      89.847  34.660  77.587  1.00 30.40           C  
+ATOM   5094  C   PHE B 142      91.236  34.372  77.023  1.00 40.09           C  
+ATOM   5095  O   PHE B 142      91.368  33.854  75.909  1.00 40.46           O  
+ATOM   5096  CB  PHE B 142      89.552  36.154  77.465  1.00 31.54           C  
+ATOM   5097  CG  PHE B 142      89.650  36.664  76.052  1.00 32.05           C  
+ATOM   5098  CD1 PHE B 142      89.125  35.924  74.995  1.00 32.34           C  
+ATOM   5099  CD2 PHE B 142      90.265  37.874  75.780  1.00 32.29           C  
+ATOM   5100  CE1 PHE B 142      89.239  36.371  73.685  1.00 32.11           C  
+ATOM   5101  CE2 PHE B 142      90.371  38.343  74.477  1.00 35.17           C  
+ATOM   5102  CZ  PHE B 142      89.859  37.582  73.425  1.00 32.90           C  
+ATOM   5103  N   ASP B 143      92.259  34.734  77.797  1.00 35.08           N  
+ATOM   5104  CA  ASP B 143      93.655  34.537  77.409  1.00 34.23           C  
+ATOM   5105  C   ASP B 143      93.991  33.059  77.196  1.00 33.93           C  
+ATOM   5106  O   ASP B 143      94.683  32.692  76.244  1.00 37.38           O  
+ATOM   5107  CB  ASP B 143      94.584  35.130  78.474  1.00 37.26           C  
+ATOM   5108  CG  ASP B 143      94.650  36.640  78.414  1.00 53.97           C  
+ATOM   5109  OD1 ASP B 143      93.967  37.234  77.549  1.00 58.01           O  
+ATOM   5110  OD2 ASP B 143      95.389  37.223  79.233  1.00 63.60           O  
+ATOM   5111  N   GLN B 144      93.509  32.217  78.096  1.00 28.02           N  
+ATOM   5112  CA  GLN B 144      93.763  30.791  78.001  1.00 27.14           C  
+ATOM   5113  C   GLN B 144      93.058  30.185  76.804  1.00 36.01           C  
+ATOM   5114  O   GLN B 144      93.677  29.523  75.976  1.00 39.86           O  
+ATOM   5115  CB  GLN B 144      93.375  30.115  79.307  1.00 27.44           C  
+ATOM   5116  CG  GLN B 144      94.056  30.748  80.531  1.00 32.87           C  
+ATOM   5117  CD  GLN B 144      93.662  30.078  81.814  1.00 28.47           C  
+ATOM   5118  OE1 GLN B 144      92.694  29.311  81.830  1.00 33.92           O  
+ATOM   5119  NE2 GLN B 144      94.396  30.313  82.893  1.00 28.14           N  
+ATOM   5120  N   VAL B 145      91.767  30.456  76.698  1.00 33.54           N  
+ATOM   5121  CA  VAL B 145      90.956  29.986  75.576  1.00 34.50           C  
+ATOM   5122  C   VAL B 145      91.555  30.419  74.209  1.00 37.15           C  
+ATOM   5123  O   VAL B 145      91.682  29.628  73.267  1.00 35.48           O  
+ATOM   5124  CB  VAL B 145      89.486  30.482  75.746  1.00 39.04           C  
+ATOM   5125  CG1 VAL B 145      88.697  30.310  74.462  1.00 40.22           C  
+ATOM   5126  CG2 VAL B 145      88.792  29.757  76.896  1.00 37.27           C  
+ATOM   5127  N   ARG B 146      91.930  31.693  74.118  1.00 30.74           N  
+ATOM   5128  CA  ARG B 146      92.522  32.271  72.919  1.00 29.02           C  
+ATOM   5129  C   ARG B 146      93.885  31.649  72.671  1.00 37.99           C  
+ATOM   5130  O   ARG B 146      94.259  31.382  71.536  1.00 39.69           O  
+ATOM   5131  CB  ARG B 146      92.666  33.779  73.109  1.00 27.29           C  
+ATOM   5132  CG  ARG B 146      93.610  34.448  72.134  1.00 32.02           C  
+ATOM   5133  CD  ARG B 146      93.228  35.897  71.888  1.00 43.71           C  
+ATOM   5134  NE  ARG B 146      93.732  36.846  72.877  1.00 46.92           N  
+ATOM   5135  CZ  ARG B 146      93.917  38.135  72.615  1.00 66.40           C  
+ATOM   5136  NH1 ARG B 146      93.661  38.610  71.402  1.00 63.27           N  
+ATOM   5137  NH2 ARG B 146      94.364  38.946  73.563  1.00 65.67           N  
+ATOM   5138  N   SER B 147      94.626  31.412  73.747  1.00 34.71           N  
+ATOM   5139  CA  SER B 147      95.946  30.801  73.658  1.00 31.71           C  
+ATOM   5140  C   SER B 147      95.823  29.435  72.990  1.00 34.30           C  
+ATOM   5141  O   SER B 147      96.737  28.969  72.303  1.00 34.95           O  
+ATOM   5142  CB  SER B 147      96.551  30.659  75.062  1.00 28.15           C  
+ATOM   5143  OG  SER B 147      96.303  29.379  75.612  1.00 25.25           O  
+ATOM   5144  N   LEU B 148      94.683  28.787  73.185  1.00 29.55           N  
+ATOM   5145  CA  LEU B 148      94.488  27.469  72.602  1.00 28.73           C  
+ATOM   5146  C   LEU B 148      93.782  27.475  71.263  1.00 42.11           C  
+ATOM   5147  O   LEU B 148      94.053  26.631  70.411  1.00 44.43           O  
+ATOM   5148  CB  LEU B 148      93.645  26.606  73.529  1.00 27.25           C  
+ATOM   5149  CG  LEU B 148      94.298  26.120  74.813  1.00 30.94           C  
+ATOM   5150  CD1 LEU B 148      93.209  26.019  75.854  1.00 29.83           C  
+ATOM   5151  CD2 LEU B 148      94.921  24.763  74.566  1.00 28.49           C  
+ATOM   5152  N   MET B 149      92.824  28.376  71.098  1.00 42.13           N  
+ATOM   5153  CA  MET B 149      92.044  28.387  69.868  1.00 42.84           C  
+ATOM   5154  C   MET B 149      92.687  29.136  68.711  1.00 45.29           C  
+ATOM   5155  O   MET B 149      92.497  28.783  67.549  1.00 46.72           O  
+ATOM   5156  CB  MET B 149      90.604  28.817  70.140  1.00 45.35           C  
+ATOM   5157  CG  MET B 149      89.826  27.843  71.011  1.00 49.16           C  
+ATOM   5158  SD  MET B 149      88.401  28.675  71.751  1.00 54.80           S  
+ATOM   5159  CE  MET B 149      87.544  29.247  70.309  1.00 50.55           C  
+ATOM   5160  N   GLU B 150      93.453  30.157  69.068  1.00 40.04           N  
+ATOM   5161  CA  GLU B 150      94.233  30.988  68.157  1.00 40.18           C  
+ATOM   5162  C   GLU B 150      94.806  30.181  67.000  1.00 48.50           C  
+ATOM   5163  O   GLU B 150      94.810  30.614  65.850  1.00 49.67           O  
+ATOM   5164  CB  GLU B 150      95.456  31.460  68.933  1.00 40.83           C  
+ATOM   5165  CG  GLU B 150      95.833  32.889  68.752  1.00 39.82           C  
+ATOM   5166  CD  GLU B 150      96.882  33.285  69.758  1.00 59.20           C  
+ATOM   5167  OE1 GLU B 150      97.609  32.381  70.229  1.00 45.98           O  
+ATOM   5168  OE2 GLU B 150      96.978  34.491  70.085  1.00 63.54           O  
+ATOM   5169  N   ASN B 151      95.367  29.025  67.336  1.00 46.57           N  
+ATOM   5170  CA  ASN B 151      96.023  28.196  66.342  1.00 48.40           C  
+ATOM   5171  C   ASN B 151      95.120  27.324  65.496  1.00 55.73           C  
+ATOM   5172  O   ASN B 151      95.601  26.477  64.746  1.00 59.87           O  
+ATOM   5173  CB  ASN B 151      97.131  27.365  66.977  1.00 48.11           C  
+ATOM   5174  CG  ASN B 151      97.941  28.164  67.962  1.00 49.33           C  
+ATOM   5175  OD1 ASN B 151      98.430  29.243  67.637  1.00 46.61           O  
+ATOM   5176  ND2 ASN B 151      98.041  27.662  69.188  1.00 28.16           N  
+ATOM   5177  N   SER B 152      93.815  27.521  65.588  1.00 48.80           N  
+ATOM   5178  CA  SER B 152      92.956  26.693  64.767  1.00 45.38           C  
+ATOM   5179  C   SER B 152      92.642  27.402  63.483  1.00 44.37           C  
+ATOM   5180  O   SER B 152      92.603  28.624  63.420  1.00 44.18           O  
+ATOM   5181  CB  SER B 152      91.682  26.260  65.467  1.00 49.14           C  
+ATOM   5182  OG  SER B 152      90.892  25.518  64.550  1.00 49.21           O  
+ATOM   5183  N   ASP B 153      92.482  26.618  62.434  1.00 41.72           N  
+ATOM   5184  CA  ASP B 153      92.216  27.186  61.120  1.00 41.80           C  
+ATOM   5185  C   ASP B 153      90.789  26.833  60.740  1.00 40.68           C  
+ATOM   5186  O   ASP B 153      90.322  27.201  59.672  1.00 39.31           O  
+ATOM   5187  CB  ASP B 153      93.232  26.662  60.099  1.00 44.78           C  
+ATOM   5188  CG  ASP B 153      94.570  27.373  60.198  1.00 71.75           C  
+ATOM   5189  OD1 ASP B 153      94.607  28.515  60.702  1.00 76.98           O  
+ATOM   5190  OD2 ASP B 153      95.587  26.780  59.774  1.00 85.49           O  
+ATOM   5191  N   ARG B 154      90.130  26.132  61.664  1.00 38.15           N  
+ATOM   5192  CA  ARG B 154      88.726  25.745  61.530  1.00 37.80           C  
+ATOM   5193  C   ARG B 154      87.810  26.968  61.541  1.00 45.45           C  
+ATOM   5194  O   ARG B 154      88.031  27.910  62.303  1.00 46.52           O  
+ATOM   5195  CB  ARG B 154      88.315  24.902  62.727  1.00 32.23           C  
+ATOM   5196  CG  ARG B 154      88.469  23.433  62.528  1.00 33.05           C  
+ATOM   5197  CD  ARG B 154      87.931  22.728  63.741  1.00 49.12           C  
+ATOM   5198  NE  ARG B 154      86.572  22.227  63.572  1.00 71.49           N  
+ATOM   5199  CZ  ARG B 154      85.735  22.027  64.587  1.00 90.75           C  
+ATOM   5200  NH1 ARG B 154      86.106  22.322  65.830  1.00 64.50           N  
+ATOM   5201  NH2 ARG B 154      84.522  21.558  64.358  1.00 86.54           N  
+ATOM   5202  N   CYS B 155      86.780  26.949  60.703  1.00 43.77           N  
+ATOM   5203  CA  CYS B 155      85.860  28.070  60.626  1.00 44.62           C  
+ATOM   5204  C   CYS B 155      85.136  28.240  61.946  1.00 40.04           C  
+ATOM   5205  O   CYS B 155      85.086  29.355  62.470  1.00 35.86           O  
+ATOM   5206  CB  CYS B 155      84.862  27.904  59.480  1.00 48.01           C  
+ATOM   5207  SG  CYS B 155      84.173  29.485  58.867  1.00 53.29           S  
+ATOM   5208  N   GLN B 156      84.610  27.146  62.486  1.00 35.83           N  
+ATOM   5209  CA  GLN B 156      83.918  27.160  63.777  1.00 34.39           C  
+ATOM   5210  C   GLN B 156      84.730  27.865  64.856  1.00 39.22           C  
+ATOM   5211  O   GLN B 156      84.214  28.772  65.509  1.00 40.49           O  
+ATOM   5212  CB  GLN B 156      83.609  25.743  64.235  1.00 35.22           C  
+ATOM   5213  CG  GLN B 156      82.271  25.624  64.899  1.00 51.80           C  
+ATOM   5214  CD  GLN B 156      82.074  24.271  65.519  1.00 92.78           C  
+ATOM   5215  OE1 GLN B 156      82.933  23.393  65.424  1.00 93.12           O  
+ATOM   5216  NE2 GLN B 156      80.929  24.082  66.164  1.00100.00           N  
+ATOM   5217  N   ASP B 157      85.986  27.441  65.030  1.00 34.74           N  
+ATOM   5218  CA  ASP B 157      86.915  27.992  66.023  1.00 31.94           C  
+ATOM   5219  C   ASP B 157      87.191  29.470  65.852  1.00 32.63           C  
+ATOM   5220  O   ASP B 157      87.142  30.227  66.815  1.00 33.40           O  
+ATOM   5221  CB  ASP B 157      88.238  27.222  66.036  1.00 32.82           C  
+ATOM   5222  CG  ASP B 157      88.031  25.735  66.275  1.00 43.81           C  
+ATOM   5223  OD1 ASP B 157      86.966  25.380  66.824  1.00 42.29           O  
+ATOM   5224  OD2 ASP B 157      88.899  24.912  65.917  1.00 56.77           O  
+ATOM   5225  N   ILE B 158      87.487  29.883  64.628  1.00 31.18           N  
+ATOM   5226  CA  ILE B 158      87.756  31.292  64.350  1.00 33.20           C  
+ATOM   5227  C   ILE B 158      86.553  32.158  64.727  1.00 38.19           C  
+ATOM   5228  O   ILE B 158      86.716  33.250  65.275  1.00 36.43           O  
+ATOM   5229  CB  ILE B 158      88.108  31.508  62.850  1.00 35.72           C  
+ATOM   5230  CG1 ILE B 158      89.337  30.665  62.469  1.00 34.58           C  
+ATOM   5231  CG2 ILE B 158      88.178  33.011  62.495  1.00 32.32           C  
+ATOM   5232  CD1 ILE B 158      89.899  30.940  61.099  1.00 33.76           C  
+ATOM   5233  N   ARG B 159      85.358  31.656  64.417  1.00 34.97           N  
+ATOM   5234  CA  ARG B 159      84.109  32.350  64.721  1.00 34.33           C  
+ATOM   5235  C   ARG B 159      83.947  32.495  66.224  1.00 35.80           C  
+ATOM   5236  O   ARG B 159      83.744  33.599  66.735  1.00 36.93           O  
+ATOM   5237  CB  ARG B 159      82.880  31.592  64.186  1.00 30.56           C  
+ATOM   5238  CG  ARG B 159      81.569  32.416  64.295  1.00 38.32           C  
+ATOM   5239  CD  ARG B 159      80.260  31.602  64.258  1.00 28.78           C  
+ATOM   5240  NE  ARG B 159      80.254  30.467  65.177  1.00 24.08           N  
+ATOM   5241  CZ  ARG B 159      79.459  29.411  65.061  1.00 29.95           C  
+ATOM   5242  NH1 ARG B 159      78.582  29.325  64.065  1.00 28.09           N  
+ATOM   5243  NH2 ARG B 159      79.541  28.445  65.957  1.00 26.86           N  
+ATOM   5244  N   ASN B 160      84.014  31.349  66.895  1.00 27.81           N  
+ATOM   5245  CA  ASN B 160      83.865  31.224  68.332  1.00 26.99           C  
+ATOM   5246  C   ASN B 160      84.842  32.018  69.161  1.00 36.74           C  
+ATOM   5247  O   ASN B 160      84.544  32.366  70.296  1.00 41.33           O  
+ATOM   5248  CB  ASN B 160      83.932  29.759  68.741  1.00 23.03           C  
+ATOM   5249  CG  ASN B 160      82.794  28.972  68.162  1.00 38.67           C  
+ATOM   5250  OD1 ASN B 160      82.010  29.513  67.379  1.00 31.32           O  
+ATOM   5251  ND2 ASN B 160      82.679  27.703  68.544  1.00 30.21           N  
+ATOM   5252  N   LEU B 161      86.012  32.301  68.614  1.00 33.04           N  
+ATOM   5253  CA  LEU B 161      87.012  33.046  69.361  1.00 30.31           C  
+ATOM   5254  C   LEU B 161      86.739  34.529  69.167  1.00 32.34           C  
+ATOM   5255  O   LEU B 161      86.974  35.334  70.063  1.00 34.38           O  
+ATOM   5256  CB  LEU B 161      88.418  32.651  68.897  1.00 29.54           C  
+ATOM   5257  CG  LEU B 161      89.631  33.244  69.607  1.00 32.76           C  
+ATOM   5258  CD1 LEU B 161      89.513  32.955  71.103  1.00 33.17           C  
+ATOM   5259  CD2 LEU B 161      90.894  32.619  69.039  1.00 27.45           C  
+ATOM   5260  N   ALA B 162      86.231  34.881  67.987  1.00 27.99           N  
+ATOM   5261  CA  ALA B 162      85.862  36.254  67.653  1.00 28.44           C  
+ATOM   5262  C   ALA B 162      84.659  36.622  68.516  1.00 31.24           C  
+ATOM   5263  O   ALA B 162      84.594  37.710  69.092  1.00 31.38           O  
+ATOM   5264  CB  ALA B 162      85.497  36.356  66.181  1.00 29.34           C  
+ATOM   5265  N   PHE B 163      83.703  35.697  68.602  1.00 28.44           N  
+ATOM   5266  CA  PHE B 163      82.528  35.894  69.449  1.00 30.74           C  
+ATOM   5267  C   PHE B 163      82.908  36.145  70.907  1.00 33.41           C  
+ATOM   5268  O   PHE B 163      82.578  37.198  71.461  1.00 33.08           O  
+ATOM   5269  CB  PHE B 163      81.564  34.710  69.433  1.00 32.74           C  
+ATOM   5270  CG  PHE B 163      80.544  34.761  70.552  1.00 33.33           C  
+ATOM   5271  CD1 PHE B 163      79.582  35.765  70.594  1.00 33.41           C  
+ATOM   5272  CD2 PHE B 163      80.570  33.829  71.580  1.00 33.71           C  
+ATOM   5273  CE1 PHE B 163      78.646  35.814  71.621  1.00 32.55           C  
+ATOM   5274  CE2 PHE B 163      79.644  33.877  72.611  1.00 35.49           C  
+ATOM   5275  CZ  PHE B 163      78.677  34.869  72.631  1.00 32.33           C  
+ATOM   5276  N   LEU B 164      83.580  35.176  71.527  1.00 28.17           N  
+ATOM   5277  CA  LEU B 164      84.021  35.338  72.909  1.00 27.30           C  
+ATOM   5278  C   LEU B 164      84.760  36.665  73.114  1.00 35.46           C  
+ATOM   5279  O   LEU B 164      84.538  37.353  74.112  1.00 37.79           O  
+ATOM   5280  CB  LEU B 164      84.936  34.192  73.314  1.00 25.55           C  
+ATOM   5281  CG  LEU B 164      84.256  32.828  73.310  1.00 29.65           C  
+ATOM   5282  CD1 LEU B 164      85.307  31.732  73.289  1.00 30.09           C  
+ATOM   5283  CD2 LEU B 164      83.319  32.668  74.502  1.00 30.15           C  
+ATOM   5284  N   GLY B 165      85.613  37.026  72.157  1.00 30.60           N  
+ATOM   5285  CA  GLY B 165      86.387  38.261  72.223  1.00 29.77           C  
+ATOM   5286  C   GLY B 165      85.476  39.478  72.237  1.00 40.54           C  
+ATOM   5287  O   GLY B 165      85.703  40.421  72.990  1.00 42.33           O  
+ATOM   5288  N   ILE B 166      84.457  39.466  71.382  1.00 39.94           N  
+ATOM   5289  CA  ILE B 166      83.510  40.575  71.318  1.00 39.88           C  
+ATOM   5290  C   ILE B 166      82.665  40.620  72.599  1.00 45.38           C  
+ATOM   5291  O   ILE B 166      82.426  41.689  73.166  1.00 46.80           O  
+ATOM   5292  CB  ILE B 166      82.592  40.469  70.078  1.00 42.77           C  
+ATOM   5293  CG1 ILE B 166      83.294  41.056  68.856  1.00 42.56           C  
+ATOM   5294  CG2 ILE B 166      81.292  41.224  70.316  1.00 46.50           C  
+ATOM   5295  CD1 ILE B 166      82.504  40.960  67.563  1.00 39.44           C  
+ATOM   5296  N   ALA B 167      82.243  39.448  73.066  1.00 36.98           N  
+ATOM   5297  CA  ALA B 167      81.453  39.340  74.285  1.00 34.30           C  
+ATOM   5298  C   ALA B 167      82.199  39.919  75.483  1.00 38.96           C  
+ATOM   5299  O   ALA B 167      81.605  40.634  76.294  1.00 40.17           O  
+ATOM   5300  CB  ALA B 167      81.081  37.888  74.550  1.00 33.37           C  
+ATOM   5301  N   TYR B 168      83.489  39.595  75.609  1.00 31.13           N  
+ATOM   5302  CA  TYR B 168      84.295  40.084  76.736  1.00 28.70           C  
+ATOM   5303  C   TYR B 168      84.608  41.566  76.582  1.00 33.83           C  
+ATOM   5304  O   TYR B 168      84.439  42.355  77.504  1.00 35.48           O  
+ATOM   5305  CB  TYR B 168      85.608  39.289  76.913  1.00 30.51           C  
+ATOM   5306  CG  TYR B 168      86.452  39.757  78.093  1.00 31.13           C  
+ATOM   5307  CD1 TYR B 168      86.094  39.458  79.407  1.00 33.77           C  
+ATOM   5308  CD2 TYR B 168      87.577  40.555  77.897  1.00 31.16           C  
+ATOM   5309  CE1 TYR B 168      86.845  39.923  80.490  1.00 37.02           C  
+ATOM   5310  CE2 TYR B 168      88.330  41.021  78.976  1.00 30.61           C  
+ATOM   5311  CZ  TYR B 168      87.960  40.708  80.267  1.00 33.25           C  
+ATOM   5312  OH  TYR B 168      88.698  41.176  81.329  1.00 28.77           O  
+ATOM   5313  N   ASN B 169      85.081  41.939  75.402  1.00 30.11           N  
+ATOM   5314  CA  ASN B 169      85.439  43.319  75.138  1.00 29.35           C  
+ATOM   5315  C   ASN B 169      84.254  44.278  75.248  1.00 38.13           C  
+ATOM   5316  O   ASN B 169      84.344  45.296  75.928  1.00 38.87           O  
+ATOM   5317  CB  ASN B 169      86.079  43.424  73.741  1.00 25.58           C  
+ATOM   5318  CG  ASN B 169      86.937  44.682  73.559  1.00 52.13           C  
+ATOM   5319  OD1 ASN B 169      87.887  44.693  72.768  1.00 43.59           O  
+ATOM   5320  ND2 ASN B 169      86.582  45.754  74.262  1.00 49.14           N  
+ATOM   5321  N   THR B 170      83.153  43.977  74.561  1.00 38.24           N  
+ATOM   5322  CA  THR B 170      81.999  44.874  74.538  1.00 38.00           C  
+ATOM   5323  C   THR B 170      80.974  44.720  75.658  1.00 43.83           C  
+ATOM   5324  O   THR B 170      80.163  45.618  75.875  1.00 43.78           O  
+ATOM   5325  CB  THR B 170      81.206  44.674  73.244  1.00 33.68           C  
+ATOM   5326  OG1 THR B 170      80.564  43.399  73.313  1.00 35.39           O  
+ATOM   5327  CG2 THR B 170      82.117  44.691  72.019  1.00 30.00           C  
+ATOM   5328  N   LEU B 171      80.982  43.576  76.333  1.00 42.92           N  
+ATOM   5329  CA  LEU B 171      80.018  43.260  77.389  1.00 43.26           C  
+ATOM   5330  C   LEU B 171      78.573  43.223  76.902  1.00 43.63           C  
+ATOM   5331  O   LEU B 171      77.654  43.273  77.723  1.00 41.18           O  
+ATOM   5332  CB  LEU B 171      80.109  44.233  78.567  1.00 43.23           C  
+ATOM   5333  CG  LEU B 171      81.301  44.101  79.510  1.00 44.74           C  
+ATOM   5334  CD1 LEU B 171      82.457  44.896  78.922  1.00 43.92           C  
+ATOM   5335  CD2 LEU B 171      80.928  44.629  80.881  1.00 41.78           C  
+ATOM   5336  N   LEU B 172      78.366  43.175  75.586  1.00 38.70           N  
+ATOM   5337  CA  LEU B 172      77.012  43.148  75.038  1.00 37.72           C  
+ATOM   5338  C   LEU B 172      76.299  41.851  75.394  1.00 47.83           C  
+ATOM   5339  O   LEU B 172      76.924  40.804  75.589  1.00 50.53           O  
+ATOM   5340  CB  LEU B 172      77.029  43.274  73.514  1.00 36.25           C  
+ATOM   5341  CG  LEU B 172      77.476  44.575  72.847  1.00 39.25           C  
+ATOM   5342  CD1 LEU B 172      77.484  44.380  71.338  1.00 36.51           C  
+ATOM   5343  CD2 LEU B 172      76.602  45.758  73.235  1.00 40.83           C  
+ATOM   5344  N   ARG B 173      74.977  41.914  75.483  1.00 43.39           N  
+ATOM   5345  CA  ARG B 173      74.194  40.721  75.758  1.00 40.88           C  
+ATOM   5346  C   ARG B 173      74.216  39.897  74.475  1.00 40.45           C  
+ATOM   5347  O   ARG B 173      74.375  40.422  73.377  1.00 37.03           O  
+ATOM   5348  CB  ARG B 173      72.760  41.075  76.167  1.00 37.31           C  
+ATOM   5349  CG  ARG B 173      72.613  41.311  77.656  1.00 39.19           C  
+ATOM   5350  CD  ARG B 173      71.433  42.212  77.944  1.00 50.33           C  
+ATOM   5351  NE  ARG B 173      71.709  43.128  79.040  1.00 65.69           N  
+ATOM   5352  CZ  ARG B 173      71.703  44.447  78.917  1.00 85.10           C  
+ATOM   5353  NH1 ARG B 173      71.413  45.001  77.735  1.00 71.63           N  
+ATOM   5354  NH2 ARG B 173      71.939  45.206  79.966  1.00 81.67           N  
+ATOM   5355  N   ILE B 174      74.052  38.592  74.610  1.00 37.41           N  
+ATOM   5356  CA  ILE B 174      74.097  37.748  73.434  1.00 35.79           C  
+ATOM   5357  C   ILE B 174      73.160  38.199  72.312  1.00 41.08           C  
+ATOM   5358  O   ILE B 174      73.561  38.193  71.153  1.00 40.57           O  
+ATOM   5359  CB  ILE B 174      73.984  36.233  73.791  1.00 37.84           C  
+ATOM   5360  CG1 ILE B 174      72.734  35.975  74.645  1.00 37.33           C  
+ATOM   5361  CG2 ILE B 174      75.204  35.786  74.589  1.00 38.10           C  
+ATOM   5362  CD1 ILE B 174      72.456  34.521  75.024  1.00 25.79           C  
+ATOM   5363  N   ALA B 175      71.928  38.586  72.637  1.00 38.66           N  
+ATOM   5364  CA  ALA B 175      70.964  39.012  71.615  1.00 36.96           C  
+ATOM   5365  C   ALA B 175      71.384  40.273  70.870  1.00 36.77           C  
+ATOM   5366  O   ALA B 175      71.063  40.450  69.698  1.00 33.85           O  
+ATOM   5367  CB  ALA B 175      69.603  39.201  72.226  1.00 38.41           C  
+ATOM   5368  N   GLU B 176      72.150  41.123  71.542  1.00 34.60           N  
+ATOM   5369  CA  GLU B 176      72.653  42.319  70.891  1.00 34.24           C  
+ATOM   5370  C   GLU B 176      73.775  41.887  69.950  1.00 44.03           C  
+ATOM   5371  O   GLU B 176      73.897  42.404  68.844  1.00 47.80           O  
+ATOM   5372  CB  GLU B 176      73.165  43.320  71.922  1.00 35.53           C  
+ATOM   5373  CG  GLU B 176      72.053  43.898  72.763  1.00 46.54           C  
+ATOM   5374  CD  GLU B 176      72.444  44.078  74.207  1.00 59.35           C  
+ATOM   5375  OE1 GLU B 176      73.538  44.620  74.457  1.00 36.99           O  
+ATOM   5376  OE2 GLU B 176      71.633  43.702  75.084  1.00 61.67           O  
+ATOM   5377  N   ILE B 177      74.571  40.905  70.369  1.00 40.60           N  
+ATOM   5378  CA  ILE B 177      75.663  40.407  69.533  1.00 37.71           C  
+ATOM   5379  C   ILE B 177      75.135  39.725  68.274  1.00 38.86           C  
+ATOM   5380  O   ILE B 177      75.662  39.937  67.181  1.00 36.48           O  
+ATOM   5381  CB  ILE B 177      76.622  39.466  70.294  1.00 38.74           C  
+ATOM   5382  CG1 ILE B 177      77.514  40.261  71.253  1.00 39.21           C  
+ATOM   5383  CG2 ILE B 177      77.442  38.641  69.317  1.00 33.30           C  
+ATOM   5384  CD1 ILE B 177      78.097  39.432  72.406  1.00 39.22           C  
+ATOM   5385  N   ALA B 178      74.084  38.925  68.424  1.00 38.21           N  
+ATOM   5386  CA  ALA B 178      73.471  38.258  67.277  1.00 39.35           C  
+ATOM   5387  C   ALA B 178      72.858  39.271  66.292  1.00 45.32           C  
+ATOM   5388  O   ALA B 178      72.705  38.992  65.100  1.00 45.33           O  
+ATOM   5389  CB  ALA B 178      72.430  37.238  67.733  1.00 39.06           C  
+ATOM   5390  N   ARG B 179      72.507  40.451  66.793  1.00 43.42           N  
+ATOM   5391  CA  ARG B 179      71.909  41.484  65.949  1.00 44.52           C  
+ATOM   5392  C   ARG B 179      72.917  42.333  65.185  1.00 50.75           C  
+ATOM   5393  O   ARG B 179      72.542  43.129  64.332  1.00 53.48           O  
+ATOM   5394  CB  ARG B 179      71.030  42.409  66.787  1.00 45.04           C  
+ATOM   5395  CG  ARG B 179      69.600  41.940  66.929  1.00 54.10           C  
+ATOM   5396  CD  ARG B 179      68.708  43.105  67.277  1.00 49.21           C  
+ATOM   5397  NE  ARG B 179      69.143  43.792  68.485  1.00 38.55           N  
+ATOM   5398  CZ  ARG B 179      68.774  43.439  69.711  1.00 38.66           C  
+ATOM   5399  NH1 ARG B 179      67.979  42.394  69.883  1.00 34.27           N  
+ATOM   5400  NH2 ARG B 179      69.184  44.110  70.778  1.00 30.88           N  
+ATOM   5401  N   ILE B 180      74.195  42.202  65.510  1.00 47.63           N  
+ATOM   5402  CA  ILE B 180      75.200  43.004  64.822  1.00 47.30           C  
+ATOM   5403  C   ILE B 180      75.150  42.675  63.335  1.00 49.25           C  
+ATOM   5404  O   ILE B 180      75.174  41.503  62.958  1.00 48.44           O  
+ATOM   5405  CB  ILE B 180      76.627  42.767  65.386  1.00 48.56           C  
+ATOM   5406  CG1 ILE B 180      76.720  43.248  66.834  1.00 47.04           C  
+ATOM   5407  CG2 ILE B 180      77.685  43.447  64.521  1.00 44.55           C  
+ATOM   5408  CD1 ILE B 180      78.012  42.849  67.518  1.00 38.87           C  
+ATOM   5409  N   ARG B 181      75.149  43.696  62.490  1.00 44.79           N  
+ATOM   5410  CA  ARG B 181      75.162  43.426  61.061  1.00 45.48           C  
+ATOM   5411  C   ARG B 181      76.481  44.001  60.556  1.00 44.77           C  
+ATOM   5412  O   ARG B 181      77.029  44.924  61.163  1.00 44.20           O  
+ATOM   5413  CB  ARG B 181      73.973  44.075  60.352  1.00 47.16           C  
+ATOM   5414  CG  ARG B 181      72.792  43.154  60.037  1.00 51.21           C  
+ATOM   5415  CD  ARG B 181      71.713  43.986  59.326  1.00 56.98           C  
+ATOM   5416  NE  ARG B 181      70.325  43.624  59.611  1.00 38.89           N  
+ATOM   5417  CZ  ARG B 181      69.676  42.656  58.981  1.00 55.21           C  
+ATOM   5418  NH1 ARG B 181      70.296  41.935  58.055  1.00 55.38           N  
+ATOM   5419  NH2 ARG B 181      68.412  42.395  59.279  1.00 50.49           N  
+ATOM   5420  N   VAL B 182      77.011  43.441  59.475  1.00 39.00           N  
+ATOM   5421  CA  VAL B 182      78.271  43.931  58.932  1.00 37.30           C  
+ATOM   5422  C   VAL B 182      78.272  45.450  58.750  1.00 47.56           C  
+ATOM   5423  O   VAL B 182      79.213  46.128  59.162  1.00 48.89           O  
+ATOM   5424  CB  VAL B 182      78.634  43.246  57.621  1.00 37.88           C  
+ATOM   5425  CG1 VAL B 182      79.989  43.730  57.139  1.00 38.05           C  
+ATOM   5426  CG2 VAL B 182      78.640  41.735  57.806  1.00 36.69           C  
+ATOM   5427  N   LYS B 183      77.205  46.002  58.176  1.00 48.13           N  
+ATOM   5428  CA  LYS B 183      77.143  47.453  58.008  1.00 49.44           C  
+ATOM   5429  C   LYS B 183      77.291  48.239  59.311  1.00 56.37           C  
+ATOM   5430  O   LYS B 183      77.404  49.459  59.290  1.00 60.04           O  
+ATOM   5431  CB  LYS B 183      75.951  47.962  57.169  1.00 53.44           C  
+ATOM   5432  CG  LYS B 183      74.635  47.189  57.190  1.00 74.25           C  
+ATOM   5433  CD  LYS B 183      73.627  47.782  58.151  1.00 90.71           C  
+ATOM   5434  CE  LYS B 183      72.768  48.841  57.496  1.00100.00           C  
+ATOM   5435  NZ  LYS B 183      71.552  48.251  56.882  1.00100.00           N  
+ATOM   5436  N   ASP B 184      77.237  47.543  60.442  1.00 50.84           N  
+ATOM   5437  CA  ASP B 184      77.333  48.211  61.736  1.00 50.17           C  
+ATOM   5438  C   ASP B 184      78.759  48.437  62.187  1.00 53.23           C  
+ATOM   5439  O   ASP B 184      79.007  49.139  63.171  1.00 50.09           O  
+ATOM   5440  CB  ASP B 184      76.627  47.389  62.807  1.00 52.64           C  
+ATOM   5441  CG  ASP B 184      75.133  47.344  62.617  1.00 59.63           C  
+ATOM   5442  OD1 ASP B 184      74.573  48.299  62.030  1.00 60.59           O  
+ATOM   5443  OD2 ASP B 184      74.519  46.354  63.058  1.00 59.48           O  
+ATOM   5444  N   ILE B 185      79.697  47.810  61.486  1.00 51.60           N  
+ATOM   5445  CA  ILE B 185      81.091  47.943  61.876  1.00 53.36           C  
+ATOM   5446  C   ILE B 185      81.823  49.068  61.177  1.00 58.71           C  
+ATOM   5447  O   ILE B 185      81.712  49.237  59.962  1.00 58.92           O  
+ATOM   5448  CB  ILE B 185      81.916  46.649  61.689  1.00 56.67           C  
+ATOM   5449  CG1 ILE B 185      81.262  45.471  62.411  1.00 56.66           C  
+ATOM   5450  CG2 ILE B 185      83.337  46.854  62.199  1.00 57.23           C  
+ATOM   5451  CD1 ILE B 185      81.786  44.128  61.949  1.00 59.68           C  
+ATOM   5452  N   SER B 186      82.617  49.795  61.955  1.00 56.78           N  
+ATOM   5453  CA  SER B 186      83.425  50.881  61.420  1.00 56.89           C  
+ATOM   5454  C   SER B 186      84.838  50.829  61.972  1.00 61.47           C  
+ATOM   5455  O   SER B 186      85.251  49.802  62.504  1.00 61.68           O  
+ATOM   5456  CB  SER B 186      82.774  52.245  61.665  1.00 60.94           C  
+ATOM   5457  OG  SER B 186      82.557  52.490  63.042  1.00 70.06           O  
+ATOM   5458  N   ARG B 187      85.567  51.934  61.831  1.00 58.49           N  
+ATOM   5459  CA  ARG B 187      86.948  51.989  62.288  1.00 59.22           C  
+ATOM   5460  C   ARG B 187      87.270  53.252  63.074  1.00 68.53           C  
+ATOM   5461  O   ARG B 187      86.716  54.301  62.770  1.00 67.76           O  
+ATOM   5462  CB  ARG B 187      87.864  51.879  61.074  1.00 60.01           C  
+ATOM   5463  CG  ARG B 187      87.579  50.647  60.239  1.00 75.77           C  
+ATOM   5464  CD  ARG B 187      88.397  49.485  60.755  1.00 89.12           C  
+ATOM   5465  NE  ARG B 187      88.036  48.215  60.140  1.00 96.03           N  
+ATOM   5466  CZ  ARG B 187      88.809  47.138  60.193  1.00100.00           C  
+ATOM   5467  NH1 ARG B 187      89.975  47.199  60.829  1.00 72.41           N  
+ATOM   5468  NH2 ARG B 187      88.428  46.006  59.619  1.00 97.82           N  
+ATOM   5469  N   THR B 188      88.158  53.184  64.063  1.00 70.95           N  
+ATOM   5470  CA  THR B 188      88.473  54.390  64.828  1.00 73.62           C  
+ATOM   5471  C   THR B 188      89.454  55.379  64.237  1.00 80.23           C  
+ATOM   5472  O   THR B 188      89.341  56.553  64.595  1.00 83.26           O  
+ATOM   5473  CB  THR B 188      89.074  54.095  66.218  1.00 83.67           C  
+ATOM   5474  OG1 THR B 188      90.043  53.048  66.103  1.00 79.25           O  
+ATOM   5475  CG2 THR B 188      87.996  53.702  67.219  1.00 83.31           C  
+ATOM   5476  N   ASP B 189      90.388  54.898  63.413  1.00 73.31           N  
+ATOM   5477  CA  ASP B 189      91.531  55.632  62.825  1.00 72.19           C  
+ATOM   5478  C   ASP B 189      92.791  54.890  63.266  1.00 73.43           C  
+ATOM   5479  O   ASP B 189      93.702  54.668  62.470  1.00 74.88           O  
+ATOM   5480  CB  ASP B 189      91.704  57.082  63.308  1.00 74.17           C  
+ATOM   5481  CG  ASP B 189      91.233  58.100  62.285  1.00 90.45           C  
+ATOM   5482  OD1 ASP B 189      91.106  57.736  61.093  1.00 91.39           O  
+ATOM   5483  OD2 ASP B 189      90.967  59.262  62.659  1.00 99.46           O  
+ATOM   5484  N   GLY B 190      92.827  54.507  64.541  1.00 64.43           N  
+ATOM   5485  CA  GLY B 190      93.945  53.759  65.102  1.00 61.06           C  
+ATOM   5486  C   GLY B 190      93.858  52.364  64.504  1.00 58.70           C  
+ATOM   5487  O   GLY B 190      94.744  51.531  64.693  1.00 55.00           O  
+ATOM   5488  N   GLY B 191      92.773  52.143  63.767  1.00 55.45           N  
+ATOM   5489  CA  GLY B 191      92.507  50.873  63.106  1.00 55.63           C  
+ATOM   5490  C   GLY B 191      91.533  49.998  63.895  1.00 59.88           C  
+ATOM   5491  O   GLY B 191      91.091  48.962  63.396  1.00 60.86           O  
+ATOM   5492  N   ARG B 192      91.202  50.416  65.118  1.00 54.22           N  
+ATOM   5493  CA  ARG B 192      90.283  49.673  65.987  1.00 51.57           C  
+ATOM   5494  C   ARG B 192      88.854  49.586  65.464  1.00 53.92           C  
+ATOM   5495  O   ARG B 192      88.250  50.587  65.084  1.00 53.15           O  
+ATOM   5496  CB  ARG B 192      90.241  50.275  67.392  1.00 46.37           C  
+ATOM   5497  CG  ARG B 192      91.525  50.140  68.173  1.00 46.39           C  
+ATOM   5498  CD  ARG B 192      91.582  51.170  69.285  1.00 43.42           C  
+ATOM   5499  NE  ARG B 192      92.906  51.775  69.360  1.00 48.84           N  
+ATOM   5500  CZ  ARG B 192      93.929  51.227  69.994  1.00 51.13           C  
+ATOM   5501  NH1 ARG B 192      93.776  50.087  70.631  1.00 39.25           N  
+ATOM   5502  NH2 ARG B 192      95.103  51.830  70.016  1.00 45.20           N  
+ATOM   5503  N   MET B 193      88.295  48.384  65.474  1.00 51.17           N  
+ATOM   5504  CA  MET B 193      86.921  48.232  65.012  1.00 50.92           C  
+ATOM   5505  C   MET B 193      85.914  48.920  65.963  1.00 56.99           C  
+ATOM   5506  O   MET B 193      86.119  48.951  67.183  1.00 53.01           O  
+ATOM   5507  CB  MET B 193      86.570  46.752  64.786  1.00 53.21           C  
+ATOM   5508  CG  MET B 193      86.862  46.222  63.376  1.00 58.61           C  
+ATOM   5509  SD  MET B 193      86.513  44.452  63.117  1.00 65.50           S  
+ATOM   5510  CE  MET B 193      85.121  44.182  64.223  1.00 61.88           C  
+ATOM   5511  N   LEU B 194      84.848  49.489  65.391  1.00 56.89           N  
+ATOM   5512  CA  LEU B 194      83.767  50.160  66.135  1.00 55.57           C  
+ATOM   5513  C   LEU B 194      82.446  49.460  65.820  1.00 56.08           C  
+ATOM   5514  O   LEU B 194      82.019  49.422  64.661  1.00 54.95           O  
+ATOM   5515  CB  LEU B 194      83.637  51.645  65.754  1.00 55.71           C  
+ATOM   5516  CG  LEU B 194      84.507  52.636  66.535  1.00 62.83           C  
+ATOM   5517  CD1 LEU B 194      84.555  54.043  65.940  1.00 65.89           C  
+ATOM   5518  CD2 LEU B 194      84.130  52.664  68.009  1.00 65.59           C  
+ATOM   5519  N   ILE B 195      81.787  48.934  66.849  1.00 50.80           N  
+ATOM   5520  CA  ILE B 195      80.506  48.269  66.642  1.00 49.67           C  
+ATOM   5521  C   ILE B 195      79.328  49.122  67.076  1.00 49.29           C  
+ATOM   5522  O   ILE B 195      79.192  49.519  68.235  1.00 42.78           O  
+ATOM   5523  CB  ILE B 195      80.401  46.877  67.267  1.00 52.28           C  
+ATOM   5524  CG1 ILE B 195      81.567  46.005  66.806  1.00 52.89           C  
+ATOM   5525  CG2 ILE B 195      79.076  46.238  66.876  1.00 51.36           C  
+ATOM   5526  CD1 ILE B 195      81.599  44.651  67.473  1.00 57.23           C  
+ATOM   5527  N   HIS B 196      78.490  49.413  66.096  1.00 49.50           N  
+ATOM   5528  CA  HIS B 196      77.339  50.230  66.360  1.00 49.41           C  
+ATOM   5529  C   HIS B 196      76.189  49.425  66.925  1.00 49.15           C  
+ATOM   5530  O   HIS B 196      75.727  48.474  66.300  1.00 46.44           O  
+ATOM   5531  CB  HIS B 196      76.854  50.899  65.105  1.00 50.97           C  
+ATOM   5532  CG  HIS B 196      75.640  51.710  65.368  1.00 55.77           C  
+ATOM   5533  ND1 HIS B 196      75.704  52.905  66.047  1.00 58.39           N  
+ATOM   5534  CD2 HIS B 196      74.327  51.418  65.234  1.00 58.57           C  
+ATOM   5535  CE1 HIS B 196      74.479  53.359  66.241  1.00 58.04           C  
+ATOM   5536  NE2 HIS B 196      73.625  52.475  65.761  1.00 58.35           N  
+ATOM   5537  N   ILE B 197      75.702  49.823  68.094  1.00 47.19           N  
+ATOM   5538  CA  ILE B 197      74.601  49.092  68.708  1.00 49.57           C  
+ATOM   5539  C   ILE B 197      73.271  49.846  68.683  1.00 62.01           C  
+ATOM   5540  O   ILE B 197      73.169  50.947  69.225  1.00 62.61           O  
+ATOM   5541  CB  ILE B 197      74.912  48.642  70.164  1.00 52.00           C  
+ATOM   5542  CG1 ILE B 197      76.226  47.854  70.237  1.00 50.40           C  
+ATOM   5543  CG2 ILE B 197      73.763  47.804  70.699  1.00 52.75           C  
+ATOM   5544  CD1 ILE B 197      76.234  46.586  69.407  1.00 36.29           C  
+ATOM   5545  N   GLY B 198      72.257  49.251  68.055  1.00 63.38           N  
+ATOM   5546  CA  GLY B 198      70.924  49.844  68.003  1.00 65.30           C  
+ATOM   5547  C   GLY B 198      70.184  49.609  69.330  1.00 73.53           C  
+ATOM   5548  O   GLY B 198      70.396  50.343  70.298  1.00 75.44           O  
+ATOM   5549  N   ARG B 199      69.346  48.572  69.395  1.00 69.55           N  
+ATOM   5550  CA  ARG B 199      68.576  48.263  70.610  1.00 66.49           C  
+ATOM   5551  C   ARG B 199      69.209  47.305  71.639  1.00 63.78           C  
+ATOM   5552  O   ARG B 199      69.898  46.355  71.271  1.00 58.13           O  
+ATOM   5553  CB  ARG B 199      67.147  47.834  70.242  1.00 64.79           C  
+ATOM   5554  CG  ARG B 199      66.776  46.399  70.573  1.00 72.89           C  
+ATOM   5555  CD  ARG B 199      65.353  46.093  70.132  1.00 65.44           C  
+ATOM   5556  NE  ARG B 199      65.277  45.048  69.113  1.00 56.71           N  
+ATOM   5557  CZ  ARG B 199      64.680  43.875  69.315  1.00 68.83           C  
+ATOM   5558  NH1 ARG B 199      64.153  43.605  70.502  1.00 46.80           N  
+ATOM   5559  NH2 ARG B 199      64.631  42.974  68.342  1.00 66.68           N  
+ATOM   5560  N   THR B 200      68.958  47.549  72.926  1.00 63.43           N  
+ATOM   5561  CA  THR B 200      69.461  46.698  74.018  1.00 63.82           C  
+ATOM   5562  C   THR B 200      68.303  46.343  74.963  1.00 67.78           C  
+ATOM   5563  O   THR B 200      67.154  46.694  74.683  1.00 66.63           O  
+ATOM   5564  CB  THR B 200      70.578  47.411  74.803  1.00 70.97           C  
+ATOM   5565  OG1 THR B 200      70.004  48.361  75.707  1.00 69.54           O  
+ATOM   5566  CG2 THR B 200      71.504  48.132  73.829  1.00 69.07           C  
+ATOM   5567  N   LYS B 201      68.554  45.670  76.072  1.00 64.63           N  
+ATOM   5568  CA  LYS B 201      67.429  45.386  76.933  1.00 64.13           C  
+ATOM   5569  C   LYS B 201      67.046  46.660  77.640  1.00 70.24           C  
+ATOM   5570  O   LYS B 201      65.877  46.940  77.885  1.00 71.80           O  
+ATOM   5571  CB  LYS B 201      67.873  44.329  77.980  1.00 64.66           C  
+ATOM   5572  CG  LYS B 201      66.715  43.830  78.749  1.00 54.63           C  
+ATOM   5573  CD  LYS B 201      67.049  44.058  80.181  1.00 52.88           C  
+ATOM   5574  CE  LYS B 201      66.948  42.763  80.934  1.00 44.67           C  
+ATOM   5575  NZ  LYS B 201      66.990  43.117  82.362  1.00 62.76           N  
+ATOM   5576  N   THR B 202      68.055  47.454  77.924  1.00 66.36           N  
+ATOM   5577  CA  THR B 202      67.833  48.703  78.588  1.00 64.78           C  
+ATOM   5578  C   THR B 202      67.490  49.889  77.618  1.00 70.25           C  
+ATOM   5579  O   THR B 202      66.919  50.862  78.099  1.00 74.02           O  
+ATOM   5580  CB  THR B 202      68.979  48.892  79.624  1.00 74.89           C  
+ATOM   5581  OG1 THR B 202      70.217  49.079  78.925  1.00 84.61           O  
+ATOM   5582  CG2 THR B 202      69.097  47.625  80.491  1.00 72.23           C  
+ATOM   5583  N   LEU B 203      67.735  49.844  76.293  1.00 64.98           N  
+ATOM   5584  CA  LEU B 203      67.410  50.976  75.366  1.00 65.55           C  
+ATOM   5585  C   LEU B 203      67.055  50.721  73.871  1.00 70.61           C  
+ATOM   5586  O   LEU B 203      67.622  49.839  73.231  1.00 69.60           O  
+ATOM   5587  CB  LEU B 203      68.483  52.073  75.474  1.00 66.77           C  
+ATOM   5588  CG  LEU B 203      69.564  52.284  74.402  1.00 73.28           C  
+ATOM   5589  CD1 LEU B 203      69.261  53.533  73.589  1.00 73.32           C  
+ATOM   5590  CD2 LEU B 203      70.970  52.363  75.003  1.00 77.00           C  
+ATOM   5591  N   VAL B 204      66.112  51.501  73.337  1.00 69.50           N  
+ATOM   5592  CA  VAL B 204      65.622  51.408  71.955  1.00 70.02           C  
+ATOM   5593  C   VAL B 204      65.604  52.819  71.334  1.00 81.07           C  
+ATOM   5594  O   VAL B 204      64.560  53.467  71.208  1.00 82.26           O  
+ATOM   5595  CB  VAL B 204      64.203  50.789  71.923  1.00 71.10           C  
+ATOM   5596  CG1 VAL B 204      64.280  49.294  71.637  1.00 69.08           C  
+ATOM   5597  CG2 VAL B 204      63.491  51.030  73.248  1.00 71.64           C  
+ATOM   5598  N   SER B 205      66.800  53.279  70.972  1.00 79.34           N  
+ATOM   5599  CA  SER B 205      67.027  54.611  70.403  1.00 79.76           C  
+ATOM   5600  C   SER B 205      67.765  54.649  69.059  1.00 82.98           C  
+ATOM   5601  O   SER B 205      68.482  53.709  68.708  1.00 82.58           O  
+ATOM   5602  CB  SER B 205      67.849  55.443  71.384  1.00 85.14           C  
+ATOM   5603  OG  SER B 205      68.905  56.108  70.701  1.00 97.00           O  
+ATOM   5604  N   THR B 206      67.627  55.769  68.344  1.00 77.92           N  
+ATOM   5605  CA  THR B 206      68.273  55.981  67.043  1.00 75.73           C  
+ATOM   5606  C   THR B 206      69.695  56.485  67.195  1.00 71.91           C  
+ATOM   5607  O   THR B 206      70.465  56.478  66.236  1.00 68.74           O  
+ATOM   5608  CB  THR B 206      67.542  57.033  66.176  1.00 97.06           C  
+ATOM   5609  OG1 THR B 206      67.673  58.333  66.771  1.00100.00           O  
+ATOM   5610  CG2 THR B 206      66.073  56.681  66.020  1.00 99.54           C  
+ATOM   5611  N   ALA B 207      70.009  56.980  68.386  1.00 67.70           N  
+ATOM   5612  CA  ALA B 207      71.344  57.469  68.680  1.00 68.67           C  
+ATOM   5613  C   ALA B 207      72.067  56.155  68.898  1.00 77.34           C  
+ATOM   5614  O   ALA B 207      72.582  55.556  67.958  1.00 79.64           O  
+ATOM   5615  CB  ALA B 207      71.337  58.291  69.960  1.00 69.45           C  
+ATOM   5616  N   GLY B 208      72.051  55.639  70.114  1.00 73.72           N  
+ATOM   5617  CA  GLY B 208      72.682  54.346  70.276  1.00 74.42           C  
+ATOM   5618  C   GLY B 208      74.168  54.426  70.599  1.00 83.33           C  
+ATOM   5619  O   GLY B 208      74.761  55.506  70.558  1.00 84.77           O  
+ATOM   5620  N   VAL B 209      74.744  53.257  70.802  1.00 79.29           N  
+ATOM   5621  CA  VAL B 209      76.139  53.124  71.192  1.00 76.78           C  
+ATOM   5622  C   VAL B 209      77.153  52.750  70.130  1.00 74.01           C  
+ATOM   5623  O   VAL B 209      76.821  52.227  69.063  1.00 73.32           O  
+ATOM   5624  CB  VAL B 209      76.252  52.032  72.243  1.00 81.25           C  
+ATOM   5625  CG1 VAL B 209      77.532  52.199  73.039  1.00 81.82           C  
+ATOM   5626  CG2 VAL B 209      75.027  52.031  73.141  1.00 81.46           C  
+ATOM   5627  N   GLU B 210      78.414  52.971  70.472  1.00 65.99           N  
+ATOM   5628  CA  GLU B 210      79.509  52.610  69.593  1.00 63.46           C  
+ATOM   5629  C   GLU B 210      80.491  51.790  70.403  1.00 63.92           C  
+ATOM   5630  O   GLU B 210      81.341  52.327  71.104  1.00 65.31           O  
+ATOM   5631  CB  GLU B 210      80.168  53.836  68.972  1.00 63.85           C  
+ATOM   5632  CG  GLU B 210      79.380  54.381  67.800  1.00 67.22           C  
+ATOM   5633  CD  GLU B 210      79.433  53.474  66.590  1.00 76.64           C  
+ATOM   5634  OE1 GLU B 210      80.454  52.778  66.410  1.00 71.55           O  
+ATOM   5635  OE2 GLU B 210      78.469  53.480  65.799  1.00 56.64           O  
+ATOM   5636  N   LYS B 211      80.321  50.479  70.343  1.00 57.60           N  
+ATOM   5637  CA  LYS B 211      81.180  49.590  71.092  1.00 56.53           C  
+ATOM   5638  C   LYS B 211      82.491  49.401  70.334  1.00 58.92           C  
+ATOM   5639  O   LYS B 211      82.512  48.991  69.168  1.00 57.97           O  
+ATOM   5640  CB  LYS B 211      80.448  48.277  71.345  1.00 58.25           C  
+ATOM   5641  CG  LYS B 211      78.964  48.477  71.610  1.00 63.26           C  
+ATOM   5642  CD  LYS B 211      78.758  49.008  73.012  1.00 63.98           C  
+ATOM   5643  CE  LYS B 211      79.851  48.495  73.933  1.00 55.00           C  
+ATOM   5644  NZ  LYS B 211      79.633  48.769  75.371  1.00 68.85           N  
+ATOM   5645  N   ALA B 212      83.586  49.758  70.992  1.00 54.60           N  
+ATOM   5646  CA  ALA B 212      84.905  49.645  70.386  1.00 54.48           C  
+ATOM   5647  C   ALA B 212      85.612  48.347  70.784  1.00 57.06           C  
+ATOM   5648  O   ALA B 212      85.376  47.803  71.868  1.00 56.45           O  
+ATOM   5649  CB  ALA B 212      85.767  50.849  70.763  1.00 55.29           C  
+ATOM   5650  N   LEU B 213      86.495  47.875  69.906  1.00 50.40           N  
+ATOM   5651  CA  LEU B 213      87.271  46.663  70.148  1.00 47.44           C  
+ATOM   5652  C   LEU B 213      88.766  46.959  70.221  1.00 48.03           C  
+ATOM   5653  O   LEU B 213      89.268  47.848  69.531  1.00 47.35           O  
+ATOM   5654  CB  LEU B 213      87.047  45.673  69.008  1.00 47.25           C  
+ATOM   5655  CG  LEU B 213      85.600  45.386  68.614  1.00 49.06           C  
+ATOM   5656  CD1 LEU B 213      85.532  44.234  67.617  1.00 46.37           C  
+ATOM   5657  CD2 LEU B 213      84.812  45.053  69.864  1.00 51.24           C  
+ATOM   5658  N   SER B 214      89.475  46.182  71.031  1.00 42.47           N  
+ATOM   5659  CA  SER B 214      90.924  46.333  71.156  1.00 40.58           C  
+ATOM   5660  C   SER B 214      91.578  45.866  69.852  1.00 45.63           C  
+ATOM   5661  O   SER B 214      90.998  45.052  69.128  1.00 46.71           O  
+ATOM   5662  CB  SER B 214      91.437  45.443  72.288  1.00 36.38           C  
+ATOM   5663  OG  SER B 214      91.484  44.096  71.853  1.00 40.59           O  
+ATOM   5664  N   LEU B 215      92.783  46.347  69.564  1.00 38.13           N  
+ATOM   5665  CA  LEU B 215      93.481  45.924  68.355  1.00 37.18           C  
+ATOM   5666  C   LEU B 215      93.502  44.394  68.203  1.00 38.07           C  
+ATOM   5667  O   LEU B 215      93.282  43.855  67.124  1.00 38.75           O  
+ATOM   5668  CB  LEU B 215      94.904  46.463  68.368  1.00 38.34           C  
+ATOM   5669  CG  LEU B 215      95.018  47.981  68.387  1.00 43.02           C  
+ATOM   5670  CD1 LEU B 215      96.298  48.376  69.110  1.00 43.62           C  
+ATOM   5671  CD2 LEU B 215      95.015  48.488  66.951  1.00 37.93           C  
+ATOM   5672  N   GLY B 216      93.766  43.683  69.290  1.00 35.20           N  
+ATOM   5673  CA  GLY B 216      93.798  42.229  69.248  1.00 35.65           C  
+ATOM   5674  C   GLY B 216      92.444  41.588  68.922  1.00 39.89           C  
+ATOM   5675  O   GLY B 216      92.394  40.592  68.193  1.00 40.01           O  
+ATOM   5676  N   VAL B 217      91.361  42.116  69.501  1.00 36.42           N  
+ATOM   5677  CA  VAL B 217      89.998  41.602  69.269  1.00 33.18           C  
+ATOM   5678  C   VAL B 217      89.534  41.883  67.824  1.00 38.20           C  
+ATOM   5679  O   VAL B 217      88.860  41.059  67.207  1.00 35.86           O  
+ATOM   5680  CB  VAL B 217      88.977  42.078  70.362  1.00 32.93           C  
+ATOM   5681  CG1 VAL B 217      87.540  41.764  69.962  1.00 31.96           C  
+ATOM   5682  CG2 VAL B 217      89.270  41.388  71.673  1.00 32.00           C  
+ATOM   5683  N   THR B 218      89.941  43.037  67.283  1.00 37.13           N  
+ATOM   5684  CA  THR B 218      89.629  43.437  65.908  1.00 35.71           C  
+ATOM   5685  C   THR B 218      90.252  42.403  65.002  1.00 41.61           C  
+ATOM   5686  O   THR B 218      89.596  41.867  64.107  1.00 41.63           O  
+ATOM   5687  CB  THR B 218      90.260  44.794  65.535  1.00 40.84           C  
+ATOM   5688  OG1 THR B 218      89.817  45.784  66.467  1.00 39.44           O  
+ATOM   5689  CG2 THR B 218      89.851  45.205  64.128  1.00 50.36           C  
+ATOM   5690  N   LYS B 219      91.526  42.121  65.261  1.00 37.61           N  
+ATOM   5691  CA  LYS B 219      92.239  41.139  64.466  1.00 35.97           C  
+ATOM   5692  C   LYS B 219      91.346  39.919  64.393  1.00 35.55           C  
+ATOM   5693  O   LYS B 219      90.982  39.443  63.314  1.00 36.25           O  
+ATOM   5694  CB  LYS B 219      93.559  40.750  65.138  1.00 40.46           C  
+ATOM   5695  CG  LYS B 219      94.806  41.272  64.431  1.00 64.49           C  
+ATOM   5696  CD  LYS B 219      95.129  42.699  64.867  1.00 80.10           C  
+ATOM   5697  CE  LYS B 219      94.655  43.732  63.851  1.00 71.42           C  
+ATOM   5698  NZ  LYS B 219      94.615  45.096  64.457  1.00 69.60           N  
+ATOM   5699  N   LEU B 220      91.010  39.423  65.579  1.00 31.25           N  
+ATOM   5700  CA  LEU B 220      90.194  38.226  65.762  1.00 28.16           C  
+ATOM   5701  C   LEU B 220      88.945  38.283  64.906  1.00 34.53           C  
+ATOM   5702  O   LEU B 220      88.576  37.317  64.246  1.00 34.17           O  
+ATOM   5703  CB  LEU B 220      89.759  38.131  67.225  1.00 27.39           C  
+ATOM   5704  CG  LEU B 220      90.731  37.574  68.257  1.00 33.25           C  
+ATOM   5705  CD1 LEU B 220      90.063  37.556  69.621  1.00 31.81           C  
+ATOM   5706  CD2 LEU B 220      91.179  36.181  67.843  1.00 37.64           C  
+ATOM   5707  N   VAL B 221      88.265  39.419  64.975  1.00 34.96           N  
+ATOM   5708  CA  VAL B 221      87.026  39.629  64.244  1.00 37.16           C  
+ATOM   5709  C   VAL B 221      87.355  39.586  62.759  1.00 41.15           C  
+ATOM   5710  O   VAL B 221      86.705  38.886  61.978  1.00 37.51           O  
+ATOM   5711  CB  VAL B 221      86.412  41.002  64.609  1.00 42.16           C  
+ATOM   5712  CG1 VAL B 221      85.065  41.188  63.930  1.00 43.35           C  
+ATOM   5713  CG2 VAL B 221      86.280  41.151  66.113  1.00 40.53           C  
+ATOM   5714  N   GLU B 222      88.359  40.383  62.395  1.00 41.93           N  
+ATOM   5715  CA  GLU B 222      88.865  40.493  61.027  1.00 39.85           C  
+ATOM   5716  C   GLU B 222      89.099  39.086  60.482  1.00 40.34           C  
+ATOM   5717  O   GLU B 222      88.652  38.749  59.384  1.00 40.75           O  
+ATOM   5718  CB  GLU B 222      90.171  41.311  60.995  1.00 40.43           C  
+ATOM   5719  CG  GLU B 222      89.983  42.829  60.925  1.00 35.29           C  
+ATOM   5720  CD  GLU B 222      91.277  43.644  61.077  1.00 51.43           C  
+ATOM   5721  OE1 GLU B 222      92.359  43.086  61.384  1.00 55.52           O  
+ATOM   5722  OE2 GLU B 222      91.202  44.877  60.904  1.00 49.62           O  
+ATOM   5723  N   ARG B 223      89.745  38.239  61.270  1.00 35.28           N  
+ATOM   5724  CA  ARG B 223      89.948  36.904  60.752  1.00 34.84           C  
+ATOM   5725  C   ARG B 223      88.648  36.169  60.445  1.00 45.38           C  
+ATOM   5726  O   ARG B 223      88.580  35.440  59.452  1.00 48.15           O  
+ATOM   5727  CB  ARG B 223      90.911  36.066  61.592  1.00 30.16           C  
+ATOM   5728  CG  ARG B 223      91.078  34.641  61.063  1.00 29.05           C  
+ATOM   5729  CD  ARG B 223      92.010  33.815  61.933  1.00 36.35           C  
+ATOM   5730  NE  ARG B 223      92.843  32.925  61.133  1.00 54.77           N  
+ATOM   5731  CZ  ARG B 223      93.105  31.660  61.443  1.00 64.66           C  
+ATOM   5732  NH1 ARG B 223      92.596  31.123  62.542  1.00 52.58           N  
+ATOM   5733  NH2 ARG B 223      93.883  30.933  60.657  1.00 71.51           N  
+ATOM   5734  N   TRP B 224      87.623  36.366  61.273  1.00 42.18           N  
+ATOM   5735  CA  TRP B 224      86.334  35.709  61.077  1.00 39.76           C  
+ATOM   5736  C   TRP B 224      85.593  36.244  59.835  1.00 37.73           C  
+ATOM   5737  O   TRP B 224      85.057  35.485  59.031  1.00 33.56           O  
+ATOM   5738  CB  TRP B 224      85.461  35.861  62.336  1.00 37.36           C  
+ATOM   5739  CG  TRP B 224      83.984  35.841  62.043  1.00 36.81           C  
+ATOM   5740  CD1 TRP B 224      83.135  36.902  62.029  1.00 39.55           C  
+ATOM   5741  CD2 TRP B 224      83.219  34.710  61.631  1.00 35.16           C  
+ATOM   5742  NE1 TRP B 224      81.882  36.501  61.652  1.00 37.74           N  
+ATOM   5743  CE2 TRP B 224      81.907  35.156  61.403  1.00 37.49           C  
+ATOM   5744  CE3 TRP B 224      83.516  33.355  61.445  1.00 36.29           C  
+ATOM   5745  CZ2 TRP B 224      80.892  34.301  61.002  1.00 37.08           C  
+ATOM   5746  CZ3 TRP B 224      82.505  32.504  61.062  1.00 36.93           C  
+ATOM   5747  CH2 TRP B 224      81.204  32.979  60.821  1.00 37.12           C  
+ATOM   5748  N   ILE B 225      85.554  37.561  59.677  1.00 35.64           N  
+ATOM   5749  CA  ILE B 225      84.860  38.126  58.525  1.00 37.97           C  
+ATOM   5750  C   ILE B 225      85.481  37.547  57.261  1.00 49.41           C  
+ATOM   5751  O   ILE B 225      84.772  37.149  56.342  1.00 50.75           O  
+ATOM   5752  CB  ILE B 225      84.942  39.676  58.494  1.00 39.69           C  
+ATOM   5753  CG1 ILE B 225      84.276  40.274  59.741  1.00 39.80           C  
+ATOM   5754  CG2 ILE B 225      84.352  40.234  57.198  1.00 35.51           C  
+ATOM   5755  CD1 ILE B 225      84.620  41.728  59.999  1.00 38.09           C  
+ATOM   5756  N   SER B 226      86.808  37.482  57.243  1.00 47.33           N  
+ATOM   5757  CA  SER B 226      87.561  36.957  56.114  1.00 46.15           C  
+ATOM   5758  C   SER B 226      87.259  35.496  55.697  1.00 47.28           C  
+ATOM   5759  O   SER B 226      86.845  35.255  54.559  1.00 49.98           O  
+ATOM   5760  CB  SER B 226      89.057  37.261  56.299  1.00 48.89           C  
+ATOM   5761  OG  SER B 226      89.881  36.219  55.807  1.00 64.55           O  
+ATOM   5762  N   VAL B 227      87.437  34.532  56.604  1.00 39.75           N  
+ATOM   5763  CA  VAL B 227      87.208  33.106  56.319  1.00 36.64           C  
+ATOM   5764  C   VAL B 227      85.737  32.799  56.065  1.00 40.18           C  
+ATOM   5765  O   VAL B 227      85.384  31.767  55.495  1.00 37.89           O  
+ATOM   5766  CB  VAL B 227      87.719  32.225  57.495  1.00 37.74           C  
+ATOM   5767  CG1 VAL B 227      86.802  32.369  58.697  1.00 38.17           C  
+ATOM   5768  CG2 VAL B 227      87.850  30.749  57.098  1.00 36.43           C  
+ATOM   5769  N   SER B 228      84.869  33.694  56.520  1.00 42.85           N  
+ATOM   5770  CA  SER B 228      83.425  33.495  56.389  1.00 42.82           C  
+ATOM   5771  C   SER B 228      82.768  34.156  55.164  1.00 55.36           C  
+ATOM   5772  O   SER B 228      81.740  33.692  54.664  1.00 55.20           O  
+ATOM   5773  CB  SER B 228      82.734  34.002  57.657  1.00 35.44           C  
+ATOM   5774  OG  SER B 228      82.786  35.419  57.711  1.00 30.12           O  
+ATOM   5775  N   GLY B 229      83.316  35.281  54.716  1.00 55.24           N  
+ATOM   5776  CA  GLY B 229      82.724  35.993  53.591  1.00 55.90           C  
+ATOM   5777  C   GLY B 229      81.370  36.559  53.999  1.00 62.80           C  
+ATOM   5778  O   GLY B 229      80.402  36.488  53.248  1.00 66.06           O  
+ATOM   5779  N   VAL B 230      81.287  37.109  55.202  1.00 57.80           N  
+ATOM   5780  CA  VAL B 230      80.021  37.669  55.625  1.00 56.92           C  
+ATOM   5781  C   VAL B 230      79.999  39.078  55.091  1.00 58.22           C  
+ATOM   5782  O   VAL B 230      78.963  39.575  54.653  1.00 56.30           O  
+ATOM   5783  CB  VAL B 230      79.890  37.720  57.161  1.00 60.22           C  
+ATOM   5784  CG1 VAL B 230      79.396  36.389  57.705  1.00 59.55           C  
+ATOM   5785  CG2 VAL B 230      81.204  38.135  57.813  1.00 59.56           C  
+ATOM   5786  N   ALA B 231      81.181  39.686  55.047  1.00 55.14           N  
+ATOM   5787  CA  ALA B 231      81.333  41.052  54.558  1.00 55.48           C  
+ATOM   5788  C   ALA B 231      80.832  41.171  53.120  1.00 61.64           C  
+ATOM   5789  O   ALA B 231      80.847  42.250  52.540  1.00 62.63           O  
+ATOM   5790  CB  ALA B 231      82.783  41.496  54.682  1.00 56.21           C  
+ATOM   5791  N   ASP B 232      80.377  40.060  52.550  1.00 58.51           N  
+ATOM   5792  CA  ASP B 232      79.860  39.992  51.196  1.00 59.56           C  
+ATOM   5793  C   ASP B 232      78.750  40.977  50.945  1.00 72.15           C  
+ATOM   5794  O   ASP B 232      78.782  41.757  49.993  1.00 75.40           O  
+ATOM   5795  CB  ASP B 232      79.509  38.570  50.803  1.00 60.60           C  
+ATOM   5796  CG  ASP B 232      80.638  37.953  50.062  1.00 72.78           C  
+ATOM   5797  OD1 ASP B 232      81.660  38.657  49.955  1.00 72.82           O  
+ATOM   5798  OD2 ASP B 232      80.521  36.813  49.577  1.00 83.89           O  
+ATOM   5799  N   ASP B 233      77.819  40.974  51.892  1.00 70.34           N  
+ATOM   5800  CA  ASP B 233      76.665  41.881  51.985  1.00 69.49           C  
+ATOM   5801  C   ASP B 233      76.769  42.691  53.319  1.00 69.29           C  
+ATOM   5802  O   ASP B 233      76.825  42.066  54.387  1.00 67.55           O  
+ATOM   5803  CB  ASP B 233      75.402  40.999  52.002  1.00 72.10           C  
+ATOM   5804  CG  ASP B 233      74.123  41.757  51.646  1.00 91.51           C  
+ATOM   5805  OD1 ASP B 233      74.201  42.948  51.326  1.00 94.52           O  
+ATOM   5806  OD2 ASP B 233      73.040  41.127  51.729  1.00100.00           O  
+ATOM   5807  N   PRO B 234      76.761  44.046  53.279  1.00 64.66           N  
+ATOM   5808  CA  PRO B 234      76.886  44.881  54.500  1.00 63.25           C  
+ATOM   5809  C   PRO B 234      75.773  44.685  55.494  1.00 63.39           C  
+ATOM   5810  O   PRO B 234      75.924  44.769  56.718  1.00 58.47           O  
+ATOM   5811  CB  PRO B 234      76.803  46.349  53.969  1.00 64.70           C  
+ATOM   5812  CG  PRO B 234      77.046  46.237  52.527  1.00 69.56           C  
+ATOM   5813  CD  PRO B 234      77.439  44.804  52.222  1.00 65.03           C  
+ATOM   5814  N   ASN B 235      74.695  44.287  54.863  1.00 63.42           N  
+ATOM   5815  CA  ASN B 235      73.445  44.041  55.530  1.00 64.67           C  
+ATOM   5816  C   ASN B 235      73.354  42.633  56.118  1.00 69.40           C  
+ATOM   5817  O   ASN B 235      72.362  42.232  56.726  1.00 69.48           O  
+ATOM   5818  CB  ASN B 235      72.253  44.500  54.674  1.00 66.47           C  
+ATOM   5819  CG  ASN B 235      72.283  46.001  54.378  1.00100.00           C  
+ATOM   5820  OD1 ASN B 235      71.712  46.789  55.125  1.00 91.89           O  
+ATOM   5821  ND2 ASN B 235      72.934  46.391  53.289  1.00100.00           N  
+ATOM   5822  N   ASN B 236      74.467  41.925  56.010  1.00 64.09           N  
+ATOM   5823  CA  ASN B 236      74.604  40.583  56.553  1.00 61.68           C  
+ATOM   5824  C   ASN B 236      74.907  40.600  58.064  1.00 59.47           C  
+ATOM   5825  O   ASN B 236      75.610  41.488  58.563  1.00 53.99           O  
+ATOM   5826  CB  ASN B 236      75.770  39.893  55.851  1.00 59.95           C  
+ATOM   5827  CG  ASN B 236      75.328  38.738  55.007  1.00 72.76           C  
+ATOM   5828  OD1 ASN B 236      74.154  38.387  54.998  1.00 81.62           O  
+ATOM   5829  ND2 ASN B 236      76.268  38.132  54.303  1.00 65.02           N  
+ATOM   5830  N   TYR B 237      74.412  39.601  58.790  1.00 54.89           N  
+ATOM   5831  CA  TYR B 237      74.674  39.499  60.231  1.00 51.73           C  
+ATOM   5832  C   TYR B 237      76.134  39.101  60.422  1.00 46.19           C  
+ATOM   5833  O   TYR B 237      76.609  38.193  59.739  1.00 41.97           O  
+ATOM   5834  CB  TYR B 237      73.765  38.449  60.892  1.00 52.61           C  
+ATOM   5835  CG  TYR B 237      72.350  38.945  61.140  1.00 52.94           C  
+ATOM   5836  CD1 TYR B 237      71.254  38.320  60.545  1.00 51.86           C  
+ATOM   5837  CD2 TYR B 237      72.120  40.086  61.900  1.00 54.08           C  
+ATOM   5838  CE1 TYR B 237      69.968  38.798  60.738  1.00 50.85           C  
+ATOM   5839  CE2 TYR B 237      70.838  40.568  62.097  1.00 52.89           C  
+ATOM   5840  CZ  TYR B 237      69.769  39.921  61.509  1.00 57.47           C  
+ATOM   5841  OH  TYR B 237      68.494  40.397  61.714  1.00 61.52           O  
+ATOM   5842  N   LEU B 238      76.832  39.763  61.345  1.00 40.61           N  
+ATOM   5843  CA  LEU B 238      78.231  39.450  61.621  1.00 39.22           C  
+ATOM   5844  C   LEU B 238      78.478  37.981  61.914  1.00 39.78           C  
+ATOM   5845  O   LEU B 238      79.484  37.431  61.474  1.00 37.37           O  
+ATOM   5846  CB  LEU B 238      78.758  40.254  62.804  1.00 39.49           C  
+ATOM   5847  CG  LEU B 238      80.208  39.901  63.142  1.00 41.61           C  
+ATOM   5848  CD1 LEU B 238      81.023  39.749  61.872  1.00 40.60           C  
+ATOM   5849  CD2 LEU B 238      80.781  40.984  64.029  1.00 39.80           C  
+ATOM   5850  N   PHE B 239      77.554  37.347  62.637  1.00 35.66           N  
+ATOM   5851  CA  PHE B 239      77.688  35.938  63.011  1.00 35.94           C  
+ATOM   5852  C   PHE B 239      76.612  35.056  62.408  1.00 40.85           C  
+ATOM   5853  O   PHE B 239      75.448  35.432  62.435  1.00 44.54           O  
+ATOM   5854  CB  PHE B 239      77.640  35.807  64.535  1.00 38.49           C  
+ATOM   5855  CG  PHE B 239      78.920  36.214  65.213  1.00 39.92           C  
+ATOM   5856  CD1 PHE B 239      79.053  37.473  65.793  1.00 38.04           C  
+ATOM   5857  CD2 PHE B 239      80.001  35.346  65.230  1.00 42.96           C  
+ATOM   5858  CE1 PHE B 239      80.232  37.854  66.395  1.00 39.43           C  
+ATOM   5859  CE2 PHE B 239      81.190  35.729  65.813  1.00 42.77           C  
+ATOM   5860  CZ  PHE B 239      81.303  36.983  66.396  1.00 39.04           C  
+ATOM   5861  N   CYS B 240      76.989  33.877  61.912  1.00 35.86           N  
+ATOM   5862  CA  CYS B 240      76.044  32.967  61.262  1.00 36.19           C  
+ATOM   5863  C   CYS B 240      76.436  31.547  61.522  1.00 38.40           C  
+ATOM   5864  O   CYS B 240      77.503  31.307  62.081  1.00 41.59           O  
+ATOM   5865  CB  CYS B 240      76.132  33.153  59.747  1.00 38.97           C  
+ATOM   5866  SG  CYS B 240      77.826  32.978  59.073  1.00 43.95           S  
+ATOM   5867  N   ARG B 241      75.602  30.602  61.085  1.00 35.92           N  
+ATOM   5868  CA  ARG B 241      75.932  29.185  61.253  1.00 37.94           C  
+ATOM   5869  C   ARG B 241      77.204  28.811  60.485  1.00 39.39           C  
+ATOM   5870  O   ARG B 241      77.626  29.498  59.553  1.00 37.28           O  
+ATOM   5871  CB  ARG B 241      74.822  28.225  60.796  1.00 41.82           C  
+ATOM   5872  CG  ARG B 241      73.396  28.603  61.107  1.00 52.83           C  
+ATOM   5873  CD  ARG B 241      72.474  27.865  60.156  1.00 50.24           C  
+ATOM   5874  NE  ARG B 241      72.504  26.417  60.318  1.00 31.00           N  
+ATOM   5875  CZ  ARG B 241      71.411  25.665  60.357  1.00 52.50           C  
+ATOM   5876  NH1 ARG B 241      70.216  26.234  60.211  1.00 39.37           N  
+ATOM   5877  NH2 ARG B 241      71.530  24.352  60.522  1.00 41.81           N  
+ATOM   5878  N   VAL B 242      77.784  27.681  60.863  1.00 34.61           N  
+ATOM   5879  CA  VAL B 242      78.975  27.192  60.198  1.00 34.07           C  
+ATOM   5880  C   VAL B 242      78.790  25.700  60.257  1.00 40.49           C  
+ATOM   5881  O   VAL B 242      78.780  25.088  61.321  1.00 41.36           O  
+ATOM   5882  CB  VAL B 242      80.258  27.618  60.899  1.00 38.52           C  
+ATOM   5883  CG1 VAL B 242      81.439  26.946  60.239  1.00 39.67           C  
+ATOM   5884  CG2 VAL B 242      80.415  29.129  60.826  1.00 37.63           C  
+ATOM   5885  N   ARG B 243      78.524  25.128  59.094  1.00 38.09           N  
+ATOM   5886  CA  ARG B 243      78.232  23.720  59.023  1.00 36.37           C  
+ATOM   5887  C   ARG B 243      79.388  22.759  59.201  1.00 38.41           C  
+ATOM   5888  O   ARG B 243      80.549  23.157  59.161  1.00 39.12           O  
+ATOM   5889  CB  ARG B 243      77.402  23.421  57.788  1.00 38.01           C  
+ATOM   5890  CG  ARG B 243      76.154  24.282  57.685  1.00 42.27           C  
+ATOM   5891  CD  ARG B 243      75.259  23.710  56.613  1.00 45.41           C  
+ATOM   5892  NE  ARG B 243      73.833  23.775  56.927  1.00 36.68           N  
+ATOM   5893  CZ  ARG B 243      73.109  22.745  57.358  1.00 63.86           C  
+ATOM   5894  NH1 ARG B 243      73.679  21.565  57.574  1.00 58.43           N  
+ATOM   5895  NH2 ARG B 243      71.806  22.895  57.593  1.00 44.18           N  
+ATOM   5896  N   LYS B 244      79.061  21.494  59.470  1.00 35.66           N  
+ATOM   5897  CA  LYS B 244      80.082  20.482  59.712  1.00 37.84           C  
+ATOM   5898  C   LYS B 244      81.226  20.538  58.708  1.00 49.67           C  
+ATOM   5899  O   LYS B 244      82.389  20.348  59.060  1.00 50.80           O  
+ATOM   5900  CB  LYS B 244      79.481  19.076  59.758  1.00 36.54           C  
+ATOM   5901  CG  LYS B 244      79.041  18.582  58.395  1.00 37.79           C  
+ATOM   5902  CD  LYS B 244      77.723  17.824  58.441  1.00 52.38           C  
+ATOM   5903  CE  LYS B 244      77.914  16.388  58.884  1.00 69.37           C  
+ATOM   5904  NZ  LYS B 244      77.271  15.435  57.961  1.00 70.39           N  
+ATOM   5905  N   ASN B 245      80.896  20.820  57.455  1.00 48.17           N  
+ATOM   5906  CA  ASN B 245      81.906  20.896  56.408  1.00 48.22           C  
+ATOM   5907  C   ASN B 245      82.846  22.108  56.507  1.00 49.62           C  
+ATOM   5908  O   ASN B 245      83.781  22.264  55.719  1.00 48.56           O  
+ATOM   5909  CB  ASN B 245      81.273  20.667  55.021  1.00 53.22           C  
+ATOM   5910  CG  ASN B 245      80.953  21.958  54.254  1.00 66.80           C  
+ATOM   5911  OD1 ASN B 245      80.769  23.031  54.831  1.00 52.40           O  
+ATOM   5912  ND2 ASN B 245      80.858  21.834  52.931  1.00 56.48           N  
+ATOM   5913  N   GLY B 246      82.612  22.948  57.510  1.00 42.04           N  
+ATOM   5914  CA  GLY B 246      83.452  24.118  57.733  1.00 40.52           C  
+ATOM   5915  C   GLY B 246      83.014  25.334  56.932  1.00 46.02           C  
+ATOM   5916  O   GLY B 246      83.604  26.409  57.039  1.00 46.58           O  
+ATOM   5917  N   VAL B 247      81.976  25.155  56.123  1.00 41.69           N  
+ATOM   5918  CA  VAL B 247      81.454  26.245  55.308  1.00 40.83           C  
+ATOM   5919  C   VAL B 247      80.478  27.118  56.092  1.00 45.45           C  
+ATOM   5920  O   VAL B 247      79.457  26.638  56.596  1.00 47.12           O  
+ATOM   5921  CB  VAL B 247      80.767  25.709  54.031  1.00 44.25           C  
+ATOM   5922  CG1 VAL B 247      80.033  26.812  53.278  1.00 42.91           C  
+ATOM   5923  CG2 VAL B 247      81.786  25.015  53.145  1.00 44.02           C  
+ATOM   5924  N   ALA B 248      80.795  28.404  56.197  1.00 40.58           N  
+ATOM   5925  CA  ALA B 248      79.915  29.340  56.890  1.00 42.23           C  
+ATOM   5926  C   ALA B 248      78.614  29.429  56.079  1.00 49.37           C  
+ATOM   5927  O   ALA B 248      78.495  28.789  55.035  1.00 52.59           O  
+ATOM   5928  CB  ALA B 248      80.584  30.701  57.015  1.00 42.98           C  
+ATOM   5929  N   ALA B 249      77.629  30.179  56.560  1.00 41.10           N  
+ATOM   5930  CA  ALA B 249      76.356  30.279  55.856  1.00 36.88           C  
+ATOM   5931  C   ALA B 249      75.757  31.632  56.151  1.00 40.04           C  
+ATOM   5932  O   ALA B 249      74.761  31.758  56.856  1.00 44.42           O  
+ATOM   5933  CB  ALA B 249      75.412  29.171  56.300  1.00 35.56           C  
+ATOM   5934  N   PRO B 250      76.372  32.677  55.606  1.00 36.07           N  
+ATOM   5935  CA  PRO B 250      75.932  34.044  55.849  1.00 37.19           C  
+ATOM   5936  C   PRO B 250      74.466  34.273  55.566  1.00 47.07           C  
+ATOM   5937  O   PRO B 250      73.851  33.544  54.797  1.00 48.95           O  
+ATOM   5938  CB  PRO B 250      76.827  34.877  54.929  1.00 37.39           C  
+ATOM   5939  CG  PRO B 250      78.095  34.103  54.883  1.00 41.65           C  
+ATOM   5940  CD  PRO B 250      77.700  32.634  54.976  1.00 37.54           C  
+ATOM   5941  N   SER B 251      73.912  35.289  56.215  1.00 45.58           N  
+ATOM   5942  CA  SER B 251      72.509  35.604  56.045  1.00 45.80           C  
+ATOM   5943  C   SER B 251      72.213  37.013  56.496  1.00 49.17           C  
+ATOM   5944  O   SER B 251      72.804  37.489  57.463  1.00 47.99           O  
+ATOM   5945  CB  SER B 251      71.681  34.722  56.948  1.00 50.83           C  
+ATOM   5946  OG  SER B 251      70.352  35.225  56.961  1.00 57.38           O  
+ATOM   5947  N   ALA B 252      71.267  37.676  55.841  1.00 49.20           N  
+ATOM   5948  CA  ALA B 252      70.888  39.016  56.282  1.00 50.47           C  
+ATOM   5949  C   ALA B 252      69.456  38.948  56.818  1.00 50.77           C  
+ATOM   5950  O   ALA B 252      68.872  39.954  57.210  1.00 50.21           O  
+ATOM   5951  CB  ALA B 252      71.013  40.043  55.162  1.00 50.96           C  
+ATOM   5952  N   THR B 253      68.915  37.736  56.871  1.00 44.51           N  
+ATOM   5953  CA  THR B 253      67.566  37.531  57.382  1.00 45.44           C  
+ATOM   5954  C   THR B 253      67.504  36.660  58.641  1.00 50.27           C  
+ATOM   5955  O   THR B 253      66.652  36.873  59.497  1.00 50.56           O  
+ATOM   5956  CB  THR B 253      66.609  37.031  56.291  1.00 51.04           C  
+ATOM   5957  OG1 THR B 253      66.657  35.598  56.219  1.00 55.83           O  
+ATOM   5958  CG2 THR B 253      66.990  37.626  54.949  1.00 44.45           C  
+ATOM   5959  N   SER B 254      68.403  35.687  58.759  1.00 44.27           N  
+ATOM   5960  CA  SER B 254      68.454  34.852  59.956  1.00 41.62           C  
+ATOM   5961  C   SER B 254      69.724  35.099  60.783  1.00 46.18           C  
+ATOM   5962  O   SER B 254      70.838  35.138  60.254  1.00 48.06           O  
+ATOM   5963  CB  SER B 254      68.347  33.374  59.616  1.00 42.55           C  
+ATOM   5964  OG  SER B 254      68.950  32.631  60.673  1.00 58.19           O  
+ATOM   5965  N   GLN B 255      69.535  35.272  62.087  1.00 39.77           N  
+ATOM   5966  CA  GLN B 255      70.632  35.515  63.004  1.00 39.00           C  
+ATOM   5967  C   GLN B 255      71.114  34.167  63.502  1.00 43.06           C  
+ATOM   5968  O   GLN B 255      70.413  33.159  63.381  1.00 43.83           O  
+ATOM   5969  CB  GLN B 255      70.127  36.301  64.220  1.00 40.41           C  
+ATOM   5970  CG  GLN B 255      69.748  37.754  63.956  1.00 37.60           C  
+ATOM   5971  CD  GLN B 255      69.101  38.391  65.170  1.00 44.71           C  
+ATOM   5972  OE1 GLN B 255      68.918  37.738  66.214  1.00 31.92           O  
+ATOM   5973  NE2 GLN B 255      68.756  39.672  65.064  1.00 37.10           N  
+ATOM   5974  N   LEU B 256      72.305  34.145  64.084  1.00 37.29           N  
+ATOM   5975  CA  LEU B 256      72.767  32.901  64.680  1.00 34.92           C  
+ATOM   5976  C   LEU B 256      72.011  32.972  66.016  1.00 35.94           C  
+ATOM   5977  O   LEU B 256      72.039  34.004  66.688  1.00 38.31           O  
+ATOM   5978  CB  LEU B 256      74.294  32.910  64.855  1.00 33.32           C  
+ATOM   5979  CG  LEU B 256      75.004  31.814  65.660  1.00 32.51           C  
+ATOM   5980  CD1 LEU B 256      74.857  30.452  65.022  1.00 29.03           C  
+ATOM   5981  CD2 LEU B 256      76.465  32.138  65.904  1.00 28.25           C  
+ATOM   5982  N   SER B 257      71.254  31.935  66.351  1.00 27.34           N  
+ATOM   5983  CA  SER B 257      70.467  31.981  67.576  1.00 25.18           C  
+ATOM   5984  C   SER B 257      71.302  32.242  68.812  1.00 36.14           C  
+ATOM   5985  O   SER B 257      72.460  31.838  68.887  1.00 35.75           O  
+ATOM   5986  CB  SER B 257      69.658  30.703  67.758  1.00 23.25           C  
+ATOM   5987  OG  SER B 257      70.501  29.627  68.098  1.00 38.68           O  
+ATOM   5988  N   THR B 258      70.677  32.899  69.790  1.00 36.15           N  
+ATOM   5989  CA  THR B 258      71.314  33.227  71.055  1.00 32.88           C  
+ATOM   5990  C   THR B 258      71.500  31.903  71.759  1.00 26.83           C  
+ATOM   5991  O   THR B 258      72.350  31.757  72.635  1.00 29.08           O  
+ATOM   5992  CB  THR B 258      70.387  34.056  71.922  1.00 33.15           C  
+ATOM   5993  OG1 THR B 258      69.112  33.408  71.959  1.00 35.11           O  
+ATOM   5994  CG2 THR B 258      70.266  35.469  71.365  1.00 25.25           C  
+ATOM   5995  N   ARG B 259      70.686  30.929  71.375  1.00 20.97           N  
+ATOM   5996  CA  ARG B 259      70.804  29.593  71.947  1.00 23.92           C  
+ATOM   5997  C   ARG B 259      72.140  28.944  71.548  1.00 37.43           C  
+ATOM   5998  O   ARG B 259      72.737  28.198  72.322  1.00 40.62           O  
+ATOM   5999  CB  ARG B 259      69.653  28.702  71.484  1.00 21.41           C  
+ATOM   6000  CG  ARG B 259      69.728  27.276  72.021  1.00 32.03           C  
+ATOM   6001  CD  ARG B 259      69.303  27.290  73.473  1.00 36.00           C  
+ATOM   6002  NE  ARG B 259      69.613  26.074  74.215  1.00 34.17           N  
+ATOM   6003  CZ  ARG B 259      70.810  25.788  74.712  1.00 36.77           C  
+ATOM   6004  NH1 ARG B 259      71.843  26.588  74.492  1.00 27.80           N  
+ATOM   6005  NH2 ARG B 259      70.979  24.684  75.417  1.00 23.66           N  
+ATOM   6006  N   ALA B 260      72.577  29.205  70.318  1.00 34.92           N  
+ATOM   6007  CA  ALA B 260      73.830  28.684  69.789  1.00 33.77           C  
+ATOM   6008  C   ALA B 260      74.958  29.471  70.450  1.00 33.00           C  
+ATOM   6009  O   ALA B 260      75.939  28.887  70.912  1.00 32.05           O  
+ATOM   6010  CB  ALA B 260      73.863  28.858  68.271  1.00 34.86           C  
+ATOM   6011  N   LEU B 261      74.803  30.792  70.533  1.00 27.59           N  
+ATOM   6012  CA  LEU B 261      75.817  31.614  71.186  1.00 28.33           C  
+ATOM   6013  C   LEU B 261      76.025  31.076  72.586  1.00 36.11           C  
+ATOM   6014  O   LEU B 261      77.135  31.068  73.112  1.00 36.72           O  
+ATOM   6015  CB  LEU B 261      75.385  33.076  71.302  1.00 27.60           C  
+ATOM   6016  CG  LEU B 261      75.336  33.802  69.967  1.00 30.40           C  
+ATOM   6017  CD1 LEU B 261      74.899  35.239  70.152  1.00 28.49           C  
+ATOM   6018  CD2 LEU B 261      76.654  33.693  69.206  1.00 31.58           C  
+ATOM   6019  N   GLU B 262      74.932  30.671  73.215  1.00 32.04           N  
+ATOM   6020  CA  GLU B 262      75.044  30.138  74.552  1.00 31.50           C  
+ATOM   6021  C   GLU B 262      75.870  28.856  74.473  1.00 36.64           C  
+ATOM   6022  O   GLU B 262      76.664  28.574  75.375  1.00 34.02           O  
+ATOM   6023  CB  GLU B 262      73.667  29.822  75.112  1.00 33.49           C  
+ATOM   6024  CG  GLU B 262      72.888  31.023  75.589  1.00 45.21           C  
+ATOM   6025  CD  GLU B 262      71.550  30.594  76.136  1.00 46.36           C  
+ATOM   6026  OE1 GLU B 262      70.958  29.674  75.542  1.00 35.71           O  
+ATOM   6027  OE2 GLU B 262      71.097  31.142  77.164  1.00 37.68           O  
+ATOM   6028  N   GLY B 263      75.675  28.079  73.405  1.00 34.26           N  
+ATOM   6029  CA  GLY B 263      76.410  26.826  73.177  1.00 32.80           C  
+ATOM   6030  C   GLY B 263      77.920  27.054  72.998  1.00 32.61           C  
+ATOM   6031  O   GLY B 263      78.730  26.261  73.465  1.00 32.46           O  
+ATOM   6032  N   ILE B 264      78.310  28.145  72.337  1.00 27.95           N  
+ATOM   6033  CA  ILE B 264      79.728  28.448  72.179  1.00 27.96           C  
+ATOM   6034  C   ILE B 264      80.344  28.493  73.572  1.00 32.57           C  
+ATOM   6035  O   ILE B 264      81.282  27.758  73.838  1.00 34.56           O  
+ATOM   6036  CB  ILE B 264      79.999  29.783  71.429  1.00 31.61           C  
+ATOM   6037  CG1 ILE B 264      79.511  29.701  69.972  1.00 30.13           C  
+ATOM   6038  CG2 ILE B 264      81.491  30.120  71.460  1.00 28.51           C  
+ATOM   6039  CD1 ILE B 264      79.561  31.019  69.216  1.00 25.79           C  
+ATOM   6040  N   PHE B 265      79.794  29.321  74.466  1.00 31.79           N  
+ATOM   6041  CA  PHE B 265      80.250  29.479  75.861  1.00 29.58           C  
+ATOM   6042  C   PHE B 265      80.368  28.134  76.598  1.00 34.03           C  
+ATOM   6043  O   PHE B 265      81.342  27.878  77.316  1.00 34.15           O  
+ATOM   6044  CB  PHE B 265      79.284  30.399  76.643  1.00 28.32           C  
+ATOM   6045  CG  PHE B 265      79.629  31.872  76.594  1.00 25.59           C  
+ATOM   6046  CD1 PHE B 265      78.763  32.783  76.016  1.00 22.02           C  
+ATOM   6047  CD2 PHE B 265      80.795  32.355  77.170  1.00 25.91           C  
+ATOM   6048  CE1 PHE B 265      79.053  34.136  75.982  1.00 22.70           C  
+ATOM   6049  CE2 PHE B 265      81.084  33.709  77.152  1.00 24.28           C  
+ATOM   6050  CZ  PHE B 265      80.211  34.599  76.555  1.00 23.19           C  
+ATOM   6051  N   GLU B 266      79.361  27.285  76.415  1.00 29.63           N  
+ATOM   6052  CA  GLU B 266      79.316  25.978  77.054  1.00 27.86           C  
+ATOM   6053  C   GLU B 266      80.394  25.067  76.485  1.00 36.04           C  
+ATOM   6054  O   GLU B 266      81.097  24.397  77.235  1.00 37.75           O  
+ATOM   6055  CB  GLU B 266      77.938  25.323  76.912  1.00 27.59           C  
+ATOM   6056  CG  GLU B 266      77.807  24.103  77.816  1.00 37.38           C  
+ATOM   6057  CD  GLU B 266      76.514  23.333  77.631  1.00 57.20           C  
+ATOM   6058  OE1 GLU B 266      75.523  23.951  77.191  1.00 62.90           O  
+ATOM   6059  OE2 GLU B 266      76.467  22.125  77.946  1.00 45.52           O  
+ATOM   6060  N   ALA B 267      80.508  25.035  75.161  1.00 32.30           N  
+ATOM   6061  CA  ALA B 267      81.505  24.211  74.483  1.00 31.11           C  
+ATOM   6062  C   ALA B 267      82.939  24.634  74.847  1.00 37.90           C  
+ATOM   6063  O   ALA B 267      83.787  23.789  75.148  1.00 37.38           O  
+ATOM   6064  CB  ALA B 267      81.292  24.262  72.974  1.00 29.77           C  
+ATOM   6065  N   THR B 268      83.202  25.941  74.830  1.00 34.11           N  
+ATOM   6066  CA  THR B 268      84.507  26.478  75.192  1.00 32.15           C  
+ATOM   6067  C   THR B 268      84.881  26.072  76.617  1.00 36.63           C  
+ATOM   6068  O   THR B 268      86.055  25.826  76.907  1.00 37.06           O  
+ATOM   6069  CB  THR B 268      84.514  28.008  75.152  1.00 30.01           C  
+ATOM   6070  OG1 THR B 268      84.210  28.448  73.827  1.00 32.98           O  
+ATOM   6071  CG2 THR B 268      85.890  28.533  75.525  1.00 38.32           C  
+ATOM   6072  N   HIS B 269      83.887  26.034  77.506  1.00 29.00           N  
+ATOM   6073  CA  HIS B 269      84.081  25.661  78.910  1.00 25.97           C  
+ATOM   6074  C   HIS B 269      84.292  24.157  78.999  1.00 31.87           C  
+ATOM   6075  O   HIS B 269      85.040  23.677  79.838  1.00 34.86           O  
+ATOM   6076  CB  HIS B 269      82.859  26.099  79.798  1.00 25.58           C  
+ATOM   6077  CG  HIS B 269      83.067  25.920  81.282  1.00 28.69           C  
+ATOM   6078  ND1 HIS B 269      82.891  24.707  81.922  1.00 30.77           N  
+ATOM   6079  CD2 HIS B 269      83.469  26.787  82.244  1.00 30.28           C  
+ATOM   6080  CE1 HIS B 269      83.153  24.841  83.211  1.00 30.29           C  
+ATOM   6081  NE2 HIS B 269      83.505  26.095  83.433  1.00 30.60           N  
+ATOM   6082  N   ARG B 270      83.627  23.404  78.130  1.00 29.09           N  
+ATOM   6083  CA  ARG B 270      83.741  21.951  78.158  1.00 29.95           C  
+ATOM   6084  C   ARG B 270      85.127  21.574  77.647  1.00 38.40           C  
+ATOM   6085  O   ARG B 270      85.737  20.597  78.084  1.00 37.17           O  
+ATOM   6086  CB  ARG B 270      82.667  21.344  77.264  1.00 23.62           C  
+ATOM   6087  CG  ARG B 270      82.507  19.854  77.434  1.00 24.83           C  
+ATOM   6088  CD  ARG B 270      81.198  19.415  76.802  1.00 44.13           C  
+ATOM   6089  NE  ARG B 270      81.179  19.701  75.369  1.00 45.39           N  
+ATOM   6090  CZ  ARG B 270      80.321  20.508  74.753  1.00 64.32           C  
+ATOM   6091  NH1 ARG B 270      79.376  21.146  75.431  1.00 47.79           N  
+ATOM   6092  NH2 ARG B 270      80.419  20.692  73.444  1.00 61.17           N  
+ATOM   6093  N   LEU B 271      85.623  22.389  76.726  1.00 39.57           N  
+ATOM   6094  CA  LEU B 271      86.946  22.203  76.146  1.00 38.71           C  
+ATOM   6095  C   LEU B 271      88.029  22.244  77.217  1.00 36.28           C  
+ATOM   6096  O   LEU B 271      88.838  21.330  77.334  1.00 33.74           O  
+ATOM   6097  CB  LEU B 271      87.184  23.313  75.124  1.00 38.16           C  
+ATOM   6098  CG  LEU B 271      88.600  23.501  74.584  1.00 41.26           C  
+ATOM   6099  CD1 LEU B 271      88.824  22.554  73.412  1.00 42.46           C  
+ATOM   6100  CD2 LEU B 271      88.775  24.950  74.137  1.00 35.28           C  
+ATOM   6101  N   ILE B 272      87.988  23.281  78.040  1.00 32.78           N  
+ATOM   6102  CA  ILE B 272      88.970  23.460  79.099  1.00 35.04           C  
+ATOM   6103  C   ILE B 272      88.769  22.655  80.382  1.00 45.01           C  
+ATOM   6104  O   ILE B 272      89.705  22.083  80.908  1.00 47.27           O  
+ATOM   6105  CB  ILE B 272      89.112  24.957  79.444  1.00 37.41           C  
+ATOM   6106  CG1 ILE B 272      89.502  25.744  78.188  1.00 37.41           C  
+ATOM   6107  CG2 ILE B 272      90.084  25.163  80.605  1.00 33.53           C  
+ATOM   6108  CD1 ILE B 272      90.120  27.083  78.481  1.00 53.61           C  
+ATOM   6109  N   TYR B 273      87.532  22.566  80.859  1.00 35.96           N  
+ATOM   6110  CA  TYR B 273      87.254  21.903  82.120  1.00 28.72           C  
+ATOM   6111  C   TYR B 273      86.548  20.568  82.041  1.00 35.05           C  
+ATOM   6112  O   TYR B 273      86.355  19.907  83.053  1.00 38.10           O  
+ATOM   6113  CB  TYR B 273      86.516  22.859  83.054  1.00 25.12           C  
+ATOM   6114  CG  TYR B 273      87.215  24.185  83.204  1.00 25.73           C  
+ATOM   6115  CD1 TYR B 273      86.852  25.272  82.419  1.00 26.47           C  
+ATOM   6116  CD2 TYR B 273      88.250  24.355  84.124  1.00 26.45           C  
+ATOM   6117  CE1 TYR B 273      87.484  26.502  82.540  1.00 30.50           C  
+ATOM   6118  CE2 TYR B 273      88.886  25.587  84.256  1.00 27.66           C  
+ATOM   6119  CZ  TYR B 273      88.501  26.656  83.460  1.00 42.89           C  
+ATOM   6120  OH  TYR B 273      89.122  27.880  83.557  1.00 58.22           O  
+ATOM   6121  N   GLY B 274      86.189  20.139  80.840  1.00 31.21           N  
+ATOM   6122  CA  GLY B 274      85.528  18.849  80.684  1.00 29.67           C  
+ATOM   6123  C   GLY B 274      84.018  18.946  80.877  1.00 33.94           C  
+ATOM   6124  O   GLY B 274      83.469  20.033  81.026  1.00 30.41           O  
+ATOM   6125  N   ALA B 275      83.359  17.792  80.825  1.00 35.90           N  
+ATOM   6126  CA  ALA B 275      81.906  17.714  80.953  1.00 39.90           C  
+ATOM   6127  C   ALA B 275      81.427  18.114  82.333  1.00 47.53           C  
+ATOM   6128  O   ALA B 275      82.131  17.936  83.319  1.00 49.20           O  
+ATOM   6129  CB  ALA B 275      81.398  16.326  80.580  1.00 41.11           C  
+ATOM   6130  N   LYS B 276      80.219  18.656  82.398  1.00 46.50           N  
+ATOM   6131  CA  LYS B 276      79.690  19.121  83.666  1.00 47.76           C  
+ATOM   6132  C   LYS B 276      78.973  18.142  84.578  1.00 58.08           C  
+ATOM   6133  O   LYS B 276      78.533  17.074  84.156  1.00 57.13           O  
+ATOM   6134  CB  LYS B 276      78.864  20.394  83.486  1.00 50.20           C  
+ATOM   6135  CG  LYS B 276      77.577  20.226  82.696  1.00 50.74           C  
+ATOM   6136  CD  LYS B 276      76.875  21.562  82.562  1.00 48.63           C  
+ATOM   6137  CE  LYS B 276      75.519  21.403  81.911  1.00 42.99           C  
+ATOM   6138  NZ  LYS B 276      75.048  22.728  81.456  1.00 46.52           N  
+ATOM   6139  N   ASP B 277      78.888  18.551  85.845  1.00 61.61           N  
+ATOM   6140  CA  ASP B 277      78.220  17.847  86.941  1.00 64.00           C  
+ATOM   6141  C   ASP B 277      76.986  17.082  86.497  1.00 69.55           C  
+ATOM   6142  O   ASP B 277      76.565  17.151  85.344  1.00 67.91           O  
+ATOM   6143  CB  ASP B 277      77.698  18.898  87.925  1.00 67.04           C  
+ATOM   6144  CG  ASP B 277      78.187  18.676  89.336  1.00 85.24           C  
+ATOM   6145  OD1 ASP B 277      78.386  17.498  89.701  1.00 89.03           O  
+ATOM   6146  OD2 ASP B 277      78.380  19.680  90.065  1.00 87.69           O  
+ATOM   6147  N   ASP B 278      76.379  16.390  87.452  1.00 70.23           N  
+ATOM   6148  CA  ASP B 278      75.150  15.654  87.188  1.00 71.66           C  
+ATOM   6149  C   ASP B 278      74.089  16.272  88.094  1.00 72.93           C  
+ATOM   6150  O   ASP B 278      72.909  15.921  88.051  1.00 74.81           O  
+ATOM   6151  CB  ASP B 278      75.318  14.142  87.410  1.00 73.80           C  
+ATOM   6152  CG  ASP B 278      76.168  13.807  88.625  1.00 88.96           C  
+ATOM   6153  OD1 ASP B 278      76.889  14.698  89.121  1.00100.00           O  
+ATOM   6154  OD2 ASP B 278      76.121  12.645  89.081  1.00 87.66           O  
+ATOM   6155  N   SER B 279      74.529  17.249  88.877  1.00 63.91           N  
+ATOM   6156  CA  SER B 279      73.647  17.949  89.793  1.00 63.18           C  
+ATOM   6157  C   SER B 279      72.365  18.481  89.152  1.00 66.86           C  
+ATOM   6158  O   SER B 279      71.301  18.478  89.774  1.00 67.59           O  
+ATOM   6159  CB  SER B 279      74.404  19.086  90.474  1.00 64.99           C  
+ATOM   6160  OG  SER B 279      75.341  19.688  89.606  1.00 66.04           O  
+ATOM   6161  N   GLY B 280      72.470  18.947  87.913  1.00 60.86           N  
+ATOM   6162  CA  GLY B 280      71.321  19.516  87.229  1.00 58.46           C  
+ATOM   6163  C   GLY B 280      71.225  20.998  87.594  1.00 59.26           C  
+ATOM   6164  O   GLY B 280      70.244  21.658  87.260  1.00 61.10           O  
+ATOM   6165  N   GLN B 281      72.243  21.531  88.268  1.00 52.34           N  
+ATOM   6166  CA  GLN B 281      72.246  22.945  88.651  1.00 49.40           C  
+ATOM   6167  C   GLN B 281      72.596  23.831  87.467  1.00 50.86           C  
+ATOM   6168  O   GLN B 281      73.129  23.364  86.466  1.00 52.31           O  
+ATOM   6169  CB  GLN B 281      73.267  23.206  89.753  1.00 49.93           C  
+ATOM   6170  CG  GLN B 281      73.380  22.070  90.738  1.00 76.29           C  
+ATOM   6171  CD  GLN B 281      74.662  22.139  91.533  1.00100.00           C  
+ATOM   6172  OE1 GLN B 281      74.726  22.795  92.571  1.00 95.72           O  
+ATOM   6173  NE2 GLN B 281      75.706  21.487  91.035  1.00 94.82           N  
+ATOM   6174  N   ARG B 282      72.297  25.117  87.582  1.00 43.75           N  
+ATOM   6175  CA  ARG B 282      72.603  26.054  86.514  1.00 42.01           C  
+ATOM   6176  C   ARG B 282      73.967  26.673  86.764  1.00 47.05           C  
+ATOM   6177  O   ARG B 282      74.422  26.776  87.905  1.00 49.11           O  
+ATOM   6178  CB  ARG B 282      71.588  27.202  86.532  1.00 38.56           C  
+ATOM   6179  CG  ARG B 282      70.350  26.968  85.698  1.00 50.09           C  
+ATOM   6180  CD  ARG B 282      69.680  28.272  85.289  1.00 56.49           C  
+ATOM   6181  NE  ARG B 282      68.329  27.963  84.826  1.00 56.65           N  
+ATOM   6182  CZ  ARG B 282      67.359  28.826  84.519  1.00 57.22           C  
+ATOM   6183  NH1 ARG B 282      67.522  30.147  84.571  1.00 41.13           N  
+ATOM   6184  NH2 ARG B 282      66.192  28.332  84.124  1.00 33.06           N  
+ATOM   6185  N   TYR B 283      74.593  27.121  85.683  1.00 37.20           N  
+ATOM   6186  CA  TYR B 283      75.856  27.823  85.775  1.00 31.84           C  
+ATOM   6187  C   TYR B 283      77.036  26.942  86.135  1.00 34.79           C  
+ATOM   6188  O   TYR B 283      77.990  27.391  86.772  1.00 35.89           O  
+ATOM   6189  CB  TYR B 283      75.705  28.982  86.752  1.00 30.48           C  
+ATOM   6190  CG  TYR B 283      74.673  30.023  86.352  1.00 32.66           C  
+ATOM   6191  CD1 TYR B 283      73.732  30.476  87.265  1.00 32.56           C  
+ATOM   6192  CD2 TYR B 283      74.654  30.587  85.079  1.00 34.68           C  
+ATOM   6193  CE1 TYR B 283      72.819  31.473  86.935  1.00 32.49           C  
+ATOM   6194  CE2 TYR B 283      73.729  31.579  84.732  1.00 32.09           C  
+ATOM   6195  CZ  TYR B 283      72.819  32.027  85.669  1.00 38.05           C  
+ATOM   6196  OH  TYR B 283      71.898  33.008  85.327  1.00 33.95           O  
+ATOM   6197  N   LEU B 284      76.962  25.683  85.720  1.00 31.34           N  
+ATOM   6198  CA  LEU B 284      78.067  24.760  85.924  1.00 32.04           C  
+ATOM   6199  C   LEU B 284      79.160  25.134  84.902  1.00 36.43           C  
+ATOM   6200  O   LEU B 284      80.350  24.895  85.129  1.00 36.27           O  
+ATOM   6201  CB  LEU B 284      77.607  23.312  85.705  1.00 32.65           C  
+ATOM   6202  CG  LEU B 284      76.656  22.693  86.739  1.00 38.96           C  
+ATOM   6203  CD1 LEU B 284      76.422  21.216  86.457  1.00 39.98           C  
+ATOM   6204  CD2 LEU B 284      77.100  22.920  88.186  1.00 38.05           C  
+ATOM   6205  N   ALA B 285      78.748  25.702  83.761  1.00 30.15           N  
+ATOM   6206  CA  ALA B 285      79.670  26.128  82.713  1.00 27.63           C  
+ATOM   6207  C   ALA B 285      79.361  27.578  82.368  1.00 29.91           C  
+ATOM   6208  O   ALA B 285      78.366  28.119  82.856  1.00 31.69           O  
+ATOM   6209  CB  ALA B 285      79.479  25.250  81.482  1.00 26.85           C  
+ATOM   6210  N   TRP B 286      80.182  28.190  81.518  1.00 26.54           N  
+ATOM   6211  CA  TRP B 286      79.932  29.557  81.077  1.00 30.11           C  
+ATOM   6212  C   TRP B 286      78.633  29.600  80.252  1.00 35.60           C  
+ATOM   6213  O   TRP B 286      78.204  28.596  79.671  1.00 30.65           O  
+ATOM   6214  CB  TRP B 286      81.095  30.085  80.233  1.00 30.96           C  
+ATOM   6215  CG  TRP B 286      82.390  30.224  80.990  1.00 33.87           C  
+ATOM   6216  CD1 TRP B 286      82.584  30.828  82.202  1.00 36.82           C  
+ATOM   6217  CD2 TRP B 286      83.671  29.747  80.578  1.00 34.91           C  
+ATOM   6218  NE1 TRP B 286      83.905  30.747  82.570  1.00 35.66           N  
+ATOM   6219  CE2 TRP B 286      84.586  30.068  81.598  1.00 37.99           C  
+ATOM   6220  CE3 TRP B 286      84.131  29.067  79.445  1.00 36.75           C  
+ATOM   6221  CZ2 TRP B 286      85.931  29.748  81.504  1.00 37.87           C  
+ATOM   6222  CZ3 TRP B 286      85.469  28.763  79.351  1.00 37.23           C  
+ATOM   6223  CH2 TRP B 286      86.352  29.097  80.376  1.00 37.93           C  
+ATOM   6224  N   SER B 287      78.010  30.773  80.200  1.00 33.88           N  
+ATOM   6225  CA  SER B 287      76.744  30.952  79.497  1.00 31.26           C  
+ATOM   6226  C   SER B 287      76.690  32.371  78.955  1.00 35.14           C  
+ATOM   6227  O   SER B 287      77.605  33.153  79.174  1.00 36.26           O  
+ATOM   6228  CB  SER B 287      75.567  30.694  80.456  1.00 32.92           C  
+ATOM   6229  OG  SER B 287      75.555  31.579  81.574  1.00 35.64           O  
+ATOM   6230  N   GLY B 288      75.619  32.697  78.242  1.00 32.67           N  
+ATOM   6231  CA  GLY B 288      75.442  34.011  77.638  1.00 30.43           C  
+ATOM   6232  C   GLY B 288      75.902  35.224  78.439  1.00 36.27           C  
+ATOM   6233  O   GLY B 288      76.391  36.192  77.866  1.00 38.85           O  
+ATOM   6234  N   HIS B 289      75.712  35.229  79.747  1.00 36.49           N  
+ATOM   6235  CA  HIS B 289      76.102  36.410  80.505  1.00 40.47           C  
+ATOM   6236  C   HIS B 289      77.450  36.356  81.218  1.00 40.30           C  
+ATOM   6237  O   HIS B 289      77.805  37.292  81.939  1.00 38.86           O  
+ATOM   6238  CB  HIS B 289      75.018  36.735  81.527  1.00 45.83           C  
+ATOM   6239  CG  HIS B 289      74.082  37.813  81.084  1.00 52.97           C  
+ATOM   6240  ND1 HIS B 289      73.874  38.126  79.764  1.00 56.71           N  
+ATOM   6241  CD2 HIS B 289      73.306  38.668  81.787  1.00 56.71           C  
+ATOM   6242  CE1 HIS B 289      73.001  39.120  79.670  1.00 56.42           C  
+ATOM   6243  NE2 HIS B 289      72.644  39.466  80.884  1.00 57.11           N  
+ATOM   6244  N   SER B 290      78.177  35.261  81.014  1.00 34.15           N  
+ATOM   6245  CA  SER B 290      79.466  35.005  81.644  1.00 29.29           C  
+ATOM   6246  C   SER B 290      80.566  36.053  81.472  1.00 32.04           C  
+ATOM   6247  O   SER B 290      81.301  36.353  82.413  1.00 32.07           O  
+ATOM   6248  CB  SER B 290      79.948  33.608  81.261  1.00 24.77           C  
+ATOM   6249  OG  SER B 290      79.200  32.623  81.950  1.00 26.60           O  
+ATOM   6250  N   ALA B 291      80.666  36.623  80.277  1.00 29.23           N  
+ATOM   6251  CA  ALA B 291      81.691  37.621  79.997  1.00 29.55           C  
+ATOM   6252  C   ALA B 291      81.357  39.018  80.502  1.00 41.17           C  
+ATOM   6253  O   ALA B 291      82.265  39.827  80.701  1.00 40.01           O  
+ATOM   6254  CB  ALA B 291      82.004  37.649  78.519  1.00 29.76           C  
+ATOM   6255  N   ARG B 292      80.061  39.292  80.679  1.00 45.53           N  
+ATOM   6256  CA  ARG B 292      79.540  40.580  81.162  1.00 43.90           C  
+ATOM   6257  C   ARG B 292      79.862  40.650  82.642  1.00 42.73           C  
+ATOM   6258  O   ARG B 292      80.364  41.647  83.142  1.00 44.84           O  
+ATOM   6259  CB  ARG B 292      78.017  40.595  81.026  1.00 45.58           C  
+ATOM   6260  CG  ARG B 292      77.426  41.657  80.124  1.00 53.84           C  
+ATOM   6261  CD  ARG B 292      75.917  41.451  80.015  1.00 45.34           C  
+ATOM   6262  NE  ARG B 292      75.170  42.511  80.687  1.00 43.45           N  
+ATOM   6263  CZ  ARG B 292      75.126  43.766  80.254  1.00 50.39           C  
+ATOM   6264  NH1 ARG B 292      75.789  44.107  79.158  1.00 43.25           N  
+ATOM   6265  NH2 ARG B 292      74.431  44.683  80.915  1.00 55.83           N  
+ATOM   6266  N   VAL B 293      79.556  39.570  83.344  1.00 38.40           N  
+ATOM   6267  CA  VAL B 293      79.863  39.514  84.758  1.00 39.56           C  
+ATOM   6268  C   VAL B 293      81.380  39.633  84.856  1.00 48.15           C  
+ATOM   6269  O   VAL B 293      81.902  40.560  85.477  1.00 50.81           O  
+ATOM   6270  CB  VAL B 293      79.439  38.152  85.343  1.00 43.40           C  
+ATOM   6271  CG1 VAL B 293      80.107  37.885  86.684  1.00 44.10           C  
+ATOM   6272  CG2 VAL B 293      77.919  38.026  85.409  1.00 42.30           C  
+ATOM   6273  N   GLY B 294      82.070  38.692  84.209  1.00 44.08           N  
+ATOM   6274  CA  GLY B 294      83.532  38.615  84.179  1.00 41.32           C  
+ATOM   6275  C   GLY B 294      84.275  39.909  83.857  1.00 38.73           C  
+ATOM   6276  O   GLY B 294      85.274  40.222  84.511  1.00 34.71           O  
+ATOM   6277  N   ALA B 295      83.807  40.642  82.850  1.00 33.91           N  
+ATOM   6278  CA  ALA B 295      84.449  41.896  82.478  1.00 34.61           C  
+ATOM   6279  C   ALA B 295      84.193  42.940  83.556  1.00 51.10           C  
+ATOM   6280  O   ALA B 295      85.127  43.567  84.058  1.00 51.11           O  
+ATOM   6281  CB  ALA B 295      83.919  42.387  81.154  1.00 33.97           C  
+ATOM   6282  N   ALA B 296      82.917  43.141  83.879  1.00 53.15           N  
+ATOM   6283  CA  ALA B 296      82.523  44.110  84.896  1.00 52.15           C  
+ATOM   6284  C   ALA B 296      83.540  43.962  86.012  1.00 50.96           C  
+ATOM   6285  O   ALA B 296      84.215  44.903  86.425  1.00 48.49           O  
+ATOM   6286  CB  ALA B 296      81.127  43.785  85.418  1.00 52.86           C  
+ATOM   6287  N   ARG B 297      83.646  42.734  86.483  1.00 47.31           N  
+ATOM   6288  CA  ARG B 297      84.577  42.422  87.542  1.00 49.27           C  
+ATOM   6289  C   ARG B 297      85.983  42.891  87.205  1.00 58.11           C  
+ATOM   6290  O   ARG B 297      86.448  43.876  87.767  1.00 63.22           O  
+ATOM   6291  CB  ARG B 297      84.578  40.921  87.785  1.00 49.08           C  
+ATOM   6292  CG  ARG B 297      83.305  40.403  88.406  1.00 49.17           C  
+ATOM   6293  CD  ARG B 297      83.690  39.408  89.472  1.00 64.65           C  
+ATOM   6294  NE  ARG B 297      82.679  38.387  89.712  1.00 71.33           N  
+ATOM   6295  CZ  ARG B 297      82.961  37.115  89.931  1.00 90.21           C  
+ATOM   6296  NH1 ARG B 297      84.221  36.702  89.952  1.00 91.71           N  
+ATOM   6297  NH2 ARG B 297      81.979  36.250  90.221  1.00 75.30           N  
+ATOM   6298  N   ASP B 298      86.668  42.196  86.302  1.00 53.26           N  
+ATOM   6299  CA  ASP B 298      88.029  42.595  85.941  1.00 52.21           C  
+ATOM   6300  C   ASP B 298      88.272  44.107  86.024  1.00 49.73           C  
+ATOM   6301  O   ASP B 298      89.364  44.544  86.393  1.00 48.94           O  
+ATOM   6302  CB  ASP B 298      88.412  42.105  84.538  1.00 53.89           C  
+ATOM   6303  CG  ASP B 298      88.423  40.595  84.411  1.00 52.73           C  
+ATOM   6304  OD1 ASP B 298      88.882  39.923  85.354  1.00 54.69           O  
+ATOM   6305  OD2 ASP B 298      87.993  40.089  83.350  1.00 49.81           O  
+ATOM   6306  N   MET B 299      87.269  44.894  85.639  1.00 44.08           N  
+ATOM   6307  CA  MET B 299      87.350  46.352  85.650  1.00 44.81           C  
+ATOM   6308  C   MET B 299      87.442  46.892  87.080  1.00 54.16           C  
+ATOM   6309  O   MET B 299      88.219  47.810  87.351  1.00 56.15           O  
+ATOM   6310  CB  MET B 299      86.127  46.944  84.948  1.00 46.90           C  
+ATOM   6311  CG  MET B 299      86.271  47.094  83.450  1.00 50.31           C  
+ATOM   6312  SD  MET B 299      84.664  47.389  82.690  1.00 55.98           S  
+ATOM   6313  CE  MET B 299      84.956  48.974  81.967  1.00 52.43           C  
+ATOM   6314  N   ALA B 300      86.646  46.326  87.983  1.00 49.90           N  
+ATOM   6315  CA  ALA B 300      86.677  46.736  89.374  1.00 49.46           C  
+ATOM   6316  C   ALA B 300      88.134  46.613  89.787  1.00 59.33           C  
+ATOM   6317  O   ALA B 300      88.814  47.617  89.992  1.00 65.30           O  
+ATOM   6318  CB  ALA B 300      85.810  45.814  90.217  1.00 50.32           C  
+ATOM   6319  N   ARG B 301      88.638  45.394  89.879  1.00 54.35           N  
+ATOM   6320  CA  ARG B 301      90.035  45.204  90.261  1.00 56.08           C  
+ATOM   6321  C   ARG B 301      91.072  46.147  89.656  1.00 67.70           C  
+ATOM   6322  O   ARG B 301      91.984  46.592  90.352  1.00 71.70           O  
+ATOM   6323  CB  ARG B 301      90.490  43.829  89.812  1.00 55.75           C  
+ATOM   6324  CG  ARG B 301      90.120  42.694  90.721  1.00 69.45           C  
+ATOM   6325  CD  ARG B 301      91.003  41.510  90.400  1.00 81.45           C  
+ATOM   6326  NE  ARG B 301      90.474  40.780  89.257  1.00 89.89           N  
+ATOM   6327  CZ  ARG B 301      89.465  39.922  89.329  1.00100.00           C  
+ATOM   6328  NH1 ARG B 301      88.865  39.722  90.484  1.00 96.87           N  
+ATOM   6329  NH2 ARG B 301      89.027  39.325  88.231  1.00100.00           N  
+ATOM   6330  N   ALA B 302      91.015  46.340  88.339  1.00 65.51           N  
+ATOM   6331  CA  ALA B 302      91.985  47.172  87.618  1.00 65.10           C  
+ATOM   6332  C   ALA B 302      92.056  48.546  88.256  1.00 71.24           C  
+ATOM   6333  O   ALA B 302      93.046  49.269  88.124  1.00 72.15           O  
+ATOM   6334  CB  ALA B 302      91.590  47.297  86.145  1.00 64.81           C  
+ATOM   6335  N   GLY B 303      90.978  48.878  88.955  1.00 65.92           N  
+ATOM   6336  CA  GLY B 303      90.833  50.157  89.627  1.00 64.38           C  
+ATOM   6337  C   GLY B 303      89.916  51.022  88.774  1.00 64.26           C  
+ATOM   6338  O   GLY B 303      89.769  52.216  89.032  1.00 66.67           O  
+ATOM   6339  N   VAL B 304      89.301  50.423  87.761  1.00 55.36           N  
+ATOM   6340  CA  VAL B 304      88.397  51.190  86.914  1.00 53.93           C  
+ATOM   6341  C   VAL B 304      87.315  51.841  87.775  1.00 58.74           C  
+ATOM   6342  O   VAL B 304      86.900  51.291  88.801  1.00 56.61           O  
+ATOM   6343  CB  VAL B 304      87.754  50.341  85.803  1.00 54.59           C  
+ATOM   6344  CG1 VAL B 304      86.725  51.163  85.039  1.00 53.66           C  
+ATOM   6345  CG2 VAL B 304      88.816  49.785  84.866  1.00 53.22           C  
+ATOM   6346  N   SER B 305      86.882  53.028  87.360  1.00 56.29           N  
+ATOM   6347  CA  SER B 305      85.876  53.772  88.103  1.00 56.73           C  
+ATOM   6348  C   SER B 305      84.496  53.205  87.852  1.00 65.29           C  
+ATOM   6349  O   SER B 305      84.111  52.970  86.703  1.00 62.78           O  
+ATOM   6350  CB  SER B 305      85.908  55.264  87.750  1.00 56.73           C  
+ATOM   6351  OG  SER B 305      85.341  55.518  86.475  1.00 59.12           O  
+ATOM   6352  N   ILE B 306      83.755  53.000  88.937  1.00 64.48           N  
+ATOM   6353  CA  ILE B 306      82.403  52.478  88.838  1.00 63.10           C  
+ATOM   6354  C   ILE B 306      81.712  53.220  87.708  1.00 65.01           C  
+ATOM   6355  O   ILE B 306      81.091  52.608  86.847  1.00 64.94           O  
+ATOM   6356  CB  ILE B 306      81.592  52.726  90.110  1.00 65.87           C  
+ATOM   6357  CG1 ILE B 306      81.499  51.438  90.932  1.00 66.57           C  
+ATOM   6358  CG2 ILE B 306      80.195  53.191  89.729  1.00 66.06           C  
+ATOM   6359  CD1 ILE B 306      82.426  51.389  92.128  1.00 68.98           C  
+ATOM   6360  N   PRO B 307      81.827  54.543  87.708  1.00 60.74           N  
+ATOM   6361  CA  PRO B 307      81.202  55.340  86.658  1.00 60.45           C  
+ATOM   6362  C   PRO B 307      81.643  54.852  85.293  1.00 66.14           C  
+ATOM   6363  O   PRO B 307      80.947  55.051  84.299  1.00 65.09           O  
+ATOM   6364  CB  PRO B 307      81.796  56.729  86.878  1.00 62.28           C  
+ATOM   6365  CG  PRO B 307      82.143  56.782  88.331  1.00 66.97           C  
+ATOM   6366  CD  PRO B 307      82.273  55.371  88.842  1.00 61.50           C  
+ATOM   6367  N   GLU B 308      82.830  54.250  85.255  1.00 65.31           N  
+ATOM   6368  CA  GLU B 308      83.417  53.731  84.019  1.00 64.34           C  
+ATOM   6369  C   GLU B 308      83.007  52.284  83.784  1.00 55.22           C  
+ATOM   6370  O   GLU B 308      82.638  51.909  82.674  1.00 51.13           O  
+ATOM   6371  CB  GLU B 308      84.946  53.876  84.005  1.00 67.73           C  
+ATOM   6372  CG  GLU B 308      85.532  54.169  82.620  1.00 88.57           C  
+ATOM   6373  CD  GLU B 308      86.966  54.698  82.643  1.00100.00           C  
+ATOM   6374  OE1 GLU B 308      87.476  55.039  83.734  1.00100.00           O  
+ATOM   6375  OE2 GLU B 308      87.572  54.759  81.548  1.00 94.64           O  
+ATOM   6376  N   ILE B 309      83.068  51.485  84.842  1.00 49.43           N  
+ATOM   6377  CA  ILE B 309      82.636  50.106  84.740  1.00 48.85           C  
+ATOM   6378  C   ILE B 309      81.215  50.167  84.188  1.00 60.77           C  
+ATOM   6379  O   ILE B 309      80.785  49.293  83.441  1.00 61.43           O  
+ATOM   6380  CB  ILE B 309      82.509  49.460  86.110  1.00 49.06           C  
+ATOM   6381  CG1 ILE B 309      83.874  49.340  86.773  1.00 45.81           C  
+ATOM   6382  CG2 ILE B 309      81.823  48.109  85.988  1.00 50.12           C  
+ATOM   6383  CD1 ILE B 309      83.965  48.185  87.740  1.00 48.20           C  
+ATOM   6384  N   MET B 310      80.485  51.212  84.569  1.00 63.44           N  
+ATOM   6385  CA  MET B 310      79.103  51.398  84.145  1.00 64.84           C  
+ATOM   6386  C   MET B 310      78.855  51.711  82.661  1.00 64.42           C  
+ATOM   6387  O   MET B 310      77.958  51.122  82.054  1.00 64.43           O  
+ATOM   6388  CB  MET B 310      78.347  52.338  85.103  1.00 69.69           C  
+ATOM   6389  CG  MET B 310      78.079  51.744  86.505  1.00 76.25           C  
+ATOM   6390  SD  MET B 310      77.386  52.903  87.733  1.00 82.78           S  
+ATOM   6391  CE  MET B 310      76.609  54.107  86.639  1.00 78.81           C  
+ATOM   6392  N   GLN B 311      79.637  52.605  82.058  1.00 58.28           N  
+ATOM   6393  CA  GLN B 311      79.443  52.893  80.632  1.00 57.03           C  
+ATOM   6394  C   GLN B 311      79.779  51.650  79.812  1.00 63.64           C  
+ATOM   6395  O   GLN B 311      79.151  51.399  78.783  1.00 65.28           O  
+ATOM   6396  CB  GLN B 311      80.285  54.074  80.132  1.00 57.51           C  
+ATOM   6397  CG  GLN B 311      80.644  53.995  78.640  1.00 68.34           C  
+ATOM   6398  CD  GLN B 311      79.522  54.463  77.727  1.00100.00           C  
+ATOM   6399  OE1 GLN B 311      78.794  55.396  78.062  1.00100.00           O  
+ATOM   6400  NE2 GLN B 311      79.368  53.809  76.578  1.00100.00           N  
+ATOM   6401  N   ALA B 312      80.778  50.889  80.262  1.00 57.65           N  
+ATOM   6402  CA  ALA B 312      81.204  49.658  79.588  1.00 55.19           C  
+ATOM   6403  C   ALA B 312      80.026  48.713  79.379  1.00 57.70           C  
+ATOM   6404  O   ALA B 312      79.809  48.205  78.275  1.00 53.13           O  
+ATOM   6405  CB  ALA B 312      82.289  48.959  80.390  1.00 55.74           C  
+ATOM   6406  N   GLY B 313      79.269  48.488  80.451  1.00 57.80           N  
+ATOM   6407  CA  GLY B 313      78.093  47.618  80.421  1.00 58.29           C  
+ATOM   6408  C   GLY B 313      76.820  48.328  79.959  1.00 62.58           C  
+ATOM   6409  O   GLY B 313      75.789  47.689  79.777  1.00 62.61           O  
+ATOM   6410  N   GLY B 314      76.887  49.642  79.771  1.00 60.69           N  
+ATOM   6411  CA  GLY B 314      75.730  50.414  79.305  1.00 61.28           C  
+ATOM   6412  C   GLY B 314      74.628  50.618  80.348  1.00 66.65           C  
+ATOM   6413  O   GLY B 314      73.504  51.020  80.017  1.00 64.98           O  
+ATOM   6414  N   TRP B 315      74.969  50.369  81.606  1.00 66.19           N  
+ATOM   6415  CA  TRP B 315      74.048  50.498  82.731  1.00 69.99           C  
+ATOM   6416  C   TRP B 315      73.770  51.943  83.122  1.00 77.97           C  
+ATOM   6417  O   TRP B 315      74.711  52.688  83.384  1.00 80.61           O  
+ATOM   6418  CB  TRP B 315      74.687  49.863  83.960  1.00 70.81           C  
+ATOM   6419  CG  TRP B 315      74.756  48.375  83.972  1.00 74.33           C  
+ATOM   6420  CD1 TRP B 315      73.744  47.503  84.229  1.00 77.85           C  
+ATOM   6421  CD2 TRP B 315      75.935  47.573  83.796  1.00 75.18           C  
+ATOM   6422  NE1 TRP B 315      74.215  46.209  84.254  1.00 78.28           N  
+ATOM   6423  CE2 TRP B 315      75.557  46.225  83.971  1.00 80.02           C  
+ATOM   6424  CE3 TRP B 315      77.270  47.860  83.524  1.00 76.16           C  
+ATOM   6425  CZ2 TRP B 315      76.474  45.170  83.845  1.00 78.83           C  
+ATOM   6426  CZ3 TRP B 315      78.179  46.812  83.370  1.00 76.80           C  
+ATOM   6427  CH2 TRP B 315      77.771  45.485  83.602  1.00 77.20           C  
+ATOM   6428  N   THR B 316      72.505  52.335  83.241  1.00 71.97           N  
+ATOM   6429  CA  THR B 316      72.233  53.690  83.683  1.00 69.22           C  
+ATOM   6430  C   THR B 316      72.104  53.725  85.206  1.00 71.63           C  
+ATOM   6431  O   THR B 316      71.599  54.700  85.757  1.00 74.65           O  
+ATOM   6432  CB  THR B 316      71.019  54.318  82.979  1.00 80.36           C  
+ATOM   6433  OG1 THR B 316      69.865  53.493  83.169  1.00 85.18           O  
+ATOM   6434  CG2 THR B 316      71.301  54.457  81.499  1.00 82.22           C  
+ATOM   6435  N   ASN B 317      72.587  52.685  85.893  1.00 65.29           N  
+ATOM   6436  CA  ASN B 317      72.504  52.623  87.359  1.00 65.07           C  
+ATOM   6437  C   ASN B 317      73.637  51.828  88.053  1.00 73.19           C  
+ATOM   6438  O   ASN B 317      74.503  51.303  87.357  1.00 78.18           O  
+ATOM   6439  CB  ASN B 317      71.122  52.113  87.751  0.00 65.73           C  
+ATOM   6440  CG  ASN B 317      70.899  52.126  89.237  0.00 87.36           C  
+ATOM   6441  OD1 ASN B 317      71.000  53.164  89.890  0.00 81.58           O  
+ATOM   6442  ND2 ASN B 317      70.598  50.958  89.790  0.00 79.12           N  
+ATOM   6443  N   VAL B 318      73.661  51.730  89.387  1.00 67.85           N  
+ATOM   6444  CA  VAL B 318      74.756  51.059  90.109  1.00 68.30           C  
+ATOM   6445  C   VAL B 318      74.677  49.710  90.832  1.00 76.60           C  
+ATOM   6446  O   VAL B 318      75.687  49.233  91.336  1.00 75.55           O  
+ATOM   6447  CB  VAL B 318      75.314  52.006  91.170  1.00 73.10           C  
+ATOM   6448  CG1 VAL B 318      76.001  53.187  90.503  1.00 73.70           C  
+ATOM   6449  CG2 VAL B 318      74.200  52.473  92.092  1.00 72.78           C  
+ATOM   6450  N   ASN B 319      73.503  49.106  90.929  1.00 78.58           N  
+ATOM   6451  CA  ASN B 319      73.318  47.851  91.664  1.00 80.29           C  
+ATOM   6452  C   ASN B 319      73.848  46.522  91.081  1.00 86.98           C  
+ATOM   6453  O   ASN B 319      74.649  45.836  91.718  1.00 84.85           O  
+ATOM   6454  CB  ASN B 319      71.853  47.743  92.098  1.00 81.60           C  
+ATOM   6455  CG  ASN B 319      71.235  49.101  92.406  1.00 81.01           C  
+ATOM   6456  OD1 ASN B 319      71.771  50.143  92.025  1.00 71.10           O  
+ATOM   6457  ND2 ASN B 319      70.097  49.091  93.089  1.00 69.28           N  
+ATOM   6458  N   ILE B 320      73.379  46.139  89.893  1.00 87.37           N  
+ATOM   6459  CA  ILE B 320      73.827  44.903  89.241  1.00 87.33           C  
+ATOM   6460  C   ILE B 320      75.330  44.962  89.370  1.00 88.33           C  
+ATOM   6461  O   ILE B 320      75.985  44.092  89.946  1.00 85.57           O  
+ATOM   6462  CB  ILE B 320      73.535  44.900  87.697  1.00 90.65           C  
+ATOM   6463  CG1 ILE B 320      73.679  46.294  87.063  1.00 89.69           C  
+ATOM   6464  CG2 ILE B 320      72.190  44.274  87.383  1.00 94.17           C  
+ATOM   6465  CD1 ILE B 320      72.640  47.330  87.480  1.00 89.61           C  
+ATOM   6466  N   VAL B 321      75.835  46.057  88.819  1.00 84.36           N  
+ATOM   6467  CA  VAL B 321      77.239  46.382  88.792  1.00 83.72           C  
+ATOM   6468  C   VAL B 321      77.807  46.062  90.151  1.00 83.73           C  
+ATOM   6469  O   VAL B 321      78.811  45.362  90.272  1.00 83.23           O  
+ATOM   6470  CB  VAL B 321      77.405  47.882  88.528  1.00 88.99           C  
+ATOM   6471  CG1 VAL B 321      78.816  48.197  88.042  1.00 89.09           C  
+ATOM   6472  CG2 VAL B 321      76.343  48.375  87.548  1.00 88.46           C  
+ATOM   6473  N   MET B 322      77.153  46.595  91.173  1.00 79.25           N  
+ATOM   6474  CA  MET B 322      77.591  46.358  92.532  1.00 79.78           C  
+ATOM   6475  C   MET B 322      77.598  44.862  92.803  1.00 86.64           C  
+ATOM   6476  O   MET B 322      78.575  44.339  93.293  1.00 86.61           O  
+ATOM   6477  CB  MET B 322      76.658  47.058  93.518  1.00 82.15           C  
+ATOM   6478  CG  MET B 322      76.927  48.532  93.736  1.00 85.47           C  
+ATOM   6479  SD  MET B 322      78.519  49.083  93.138  1.00 89.12           S  
+ATOM   6480  CE  MET B 322      79.529  48.640  94.539  1.00 84.79           C  
+ATOM   6481  N   ASN B 323      76.520  44.172  92.445  1.00 83.89           N  
+ATOM   6482  CA  ASN B 323      76.376  42.738  92.693  1.00 83.18           C  
+ATOM   6483  C   ASN B 323      77.516  41.846  92.201  1.00 84.42           C  
+ATOM   6484  O   ASN B 323      78.013  41.004  92.949  1.00 83.28           O  
+ATOM   6485  CB  ASN B 323      75.017  42.198  92.209  1.00 84.28           C  
+ATOM   6486  CG  ASN B 323      74.392  41.205  93.191  1.00 92.44           C  
+ATOM   6487  OD1 ASN B 323      74.040  41.568  94.317  1.00 86.75           O  
+ATOM   6488  ND2 ASN B 323      74.247  39.952  92.769  1.00 76.31           N  
+ATOM   6489  N   TYR B 324      77.913  42.038  90.945  1.00 79.73           N  
+ATOM   6490  CA  TYR B 324      78.962  41.256  90.282  1.00 76.91           C  
+ATOM   6491  C   TYR B 324      80.430  41.162  90.780  1.00 86.46           C  
+ATOM   6492  O   TYR B 324      81.155  40.289  90.301  1.00 88.69           O  
+ATOM   6493  CB  TYR B 324      78.969  41.645  88.791  1.00 72.64           C  
+ATOM   6494  CG  TYR B 324      77.742  41.287  87.958  1.00 69.36           C  
+ATOM   6495  CD1 TYR B 324      77.519  41.900  86.725  1.00 71.54           C  
+ATOM   6496  CD2 TYR B 324      76.842  40.307  88.366  1.00 67.94           C  
+ATOM   6497  CE1 TYR B 324      76.421  41.571  85.932  1.00 72.63           C  
+ATOM   6498  CE2 TYR B 324      75.745  39.967  87.578  1.00 63.89           C  
+ATOM   6499  CZ  TYR B 324      75.534  40.607  86.371  1.00 74.40           C  
+ATOM   6500  OH  TYR B 324      74.453  40.284  85.590  1.00 72.43           O  
+ATOM   6501  N   ILE B 325      80.907  42.021  91.685  1.00 83.79           N  
+ATOM   6502  CA  ILE B 325      82.333  41.960  92.065  1.00 84.26           C  
+ATOM   6503  C   ILE B 325      82.848  41.445  93.414  1.00 90.71           C  
+ATOM   6504  O   ILE B 325      83.994  41.022  93.509  1.00 93.18           O  
+ATOM   6505  CB  ILE B 325      83.082  43.303  91.809  1.00 86.93           C  
+ATOM   6506  CG1 ILE B 325      82.914  44.260  93.002  1.00 88.16           C  
+ATOM   6507  CG2 ILE B 325      82.690  43.919  90.471  1.00 85.83           C  
+ATOM   6508  CD1 ILE B 325      83.209  45.717  92.690  1.00100.00           C  
+ATOM   6509  N   ARG B 326      82.013  41.538  94.447  1.00 87.71           N  
+ATOM   6510  CA  ARG B 326      82.270  41.251  95.876  1.00 89.02           C  
+ATOM   6511  C   ARG B 326      82.888  40.006  96.573  1.00 94.80           C  
+ATOM   6512  O   ARG B 326      83.303  39.048  95.905  1.00 94.63           O  
+ATOM   6513  CB  ARG B 326      81.026  41.698  96.633  1.00 91.88           C  
+ATOM   6514  CG  ARG B 326      80.669  43.151  96.498  1.00100.00           C  
+ATOM   6515  CD  ARG B 326      79.346  43.367  95.763  1.00 92.02           C  
+ATOM   6516  NE  ARG B 326      78.705  44.646  96.089  1.00 91.12           N  
+ATOM   6517  CZ  ARG B 326      79.355  45.786  96.266  1.00100.00           C  
+ATOM   6518  NH1 ARG B 326      80.660  45.903  96.082  1.00 92.71           N  
+ATOM   6519  NH2 ARG B 326      78.666  46.869  96.552  1.00 99.63           N  
+ATOM   6520  N   ASN B 327      82.967  40.065  97.923  1.00 93.01           N  
+ATOM   6521  CA  ASN B 327      83.504  39.030  98.865  1.00 93.84           C  
+ATOM   6522  C   ASN B 327      82.733  37.697  98.861  1.00 98.19           C  
+ATOM   6523  O   ASN B 327      83.297  36.639  98.470  1.00 99.93           O  
+ATOM   6524  CB  ASN B 327      84.005  39.475 100.303  1.00 96.25           C  
+ATOM   6525  CG  ASN B 327      83.092  40.486 101.116  1.00100.00           C  
+ATOM   6526  OD1 ASN B 327      81.904  40.700 100.821  1.00 97.23           O  
+ATOM   6527  ND2 ASN B 327      83.684  41.071 102.161  1.00 94.13           N  
+ATOM   6528  N   LEU B 328      81.461  37.770  99.203  1.00 92.68           N  
+ATOM   6529  CA  LEU B 328      80.450  36.715  99.127  1.00 97.82           C  
+ATOM   6530  C   LEU B 328      80.897  35.338  98.646  1.00100.00           C  
+ATOM   6531  O   LEU B 328      80.739  34.360  99.381  1.00 91.20           O  
+ATOM   6532  CB  LEU B 328      79.172  37.206  98.414  1.00 97.35           C  
+ATOM   6533  CG  LEU B 328      78.817  38.668  98.774  1.00100.00           C  
+ATOM   6534  CD1 LEU B 328      79.768  39.820  98.580  1.00100.00           C  
+ATOM   6535  CD2 LEU B 328      77.774  39.113  97.895  1.00100.00           C  
+ATOM   6536  N   GLY B 333      91.092  40.220 105.067  1.00 99.00           N  
+ATOM   6537  CA  GLY B 333      90.947  41.300 104.093  1.00 97.76           C  
+ATOM   6538  C   GLY B 333      91.576  42.613 104.534  1.00 98.65           C  
+ATOM   6539  O   GLY B 333      92.676  42.652 105.087  1.00 97.28           O  
+ATOM   6540  N   ALA B 334      90.846  43.686 104.259  1.00 94.54           N  
+ATOM   6541  CA  ALA B 334      91.289  45.021 104.603  1.00 93.92           C  
+ATOM   6542  C   ALA B 334      91.435  45.163 106.110  1.00 96.56           C  
+ATOM   6543  O   ALA B 334      92.376  45.808 106.574  1.00 97.62           O  
+ATOM   6544  CB  ALA B 334      90.302  46.051 104.077  1.00 94.32           C  
+ATOM   6545  N   MET B 335      90.492  44.603 106.870  1.00 87.20           N  
+ATOM   6546  CA  MET B 335      90.505  44.730 108.329  1.00 83.16           C  
+ATOM   6547  C   MET B 335      91.589  43.897 108.982  1.00 80.77           C  
+ATOM   6548  O   MET B 335      91.971  44.109 110.131  1.00 78.95           O  
+ATOM   6549  CB  MET B 335      89.130  44.455 108.949  1.00 84.47           C  
+ATOM   6550  CG  MET B 335      88.173  45.647 108.926  1.00 85.26           C  
+ATOM   6551  SD  MET B 335      88.614  47.066 109.955  1.00 86.49           S  
+ATOM   6552  CE  MET B 335      89.906  46.373 111.005  1.00 82.81           C  
+ATOM   6553  N   VAL B 336      92.130  42.992 108.182  1.00 77.40           N  
+ATOM   6554  CA  VAL B 336      93.201  42.122 108.621  1.00 79.98           C  
+ATOM   6555  C   VAL B 336      94.623  42.636 108.345  1.00 90.63           C  
+ATOM   6556  O   VAL B 336      95.550  41.842 108.216  1.00 92.19           O  
+ATOM   6557  CB  VAL B 336      93.015  40.718 108.035  1.00 84.74           C  
+ATOM   6558  CG1 VAL B 336      93.625  39.669 108.957  1.00 85.37           C  
+ATOM   6559  CG2 VAL B 336      91.537  40.440 107.817  1.00 84.32           C  
+ATOM   6560  N   ARG B 337      94.803  43.948 108.261  1.00 89.07           N  
+ATOM   6561  CA  ARG B 337      96.120  44.533 108.024  1.00 87.58           C  
+ATOM   6562  C   ARG B 337      96.215  45.672 109.019  1.00 88.17           C  
+ATOM   6563  O   ARG B 337      97.278  45.952 109.574  1.00 86.44           O  
+ATOM   6564  CB  ARG B 337      96.217  45.062 106.596  1.00 88.81           C  
+ATOM   6565  CG  ARG B 337      96.294  43.961 105.552  1.00 99.01           C  
+ATOM   6566  CD  ARG B 337      95.334  44.208 104.397  1.00100.00           C  
+ATOM   6567  NE  ARG B 337      95.139  45.633 104.127  1.00 99.60           N  
+ATOM   6568  CZ  ARG B 337      94.698  46.131 102.979  1.00100.00           C  
+ATOM   6569  NH1 ARG B 337      94.365  45.321 101.980  1.00 80.93           N  
+ATOM   6570  NH2 ARG B 337      94.557  47.442 102.831  1.00 99.14           N  
+ATOM   6571  N   LEU B 338      95.075  46.317 109.243  1.00 84.59           N  
+ATOM   6572  CA  LEU B 338      95.006  47.365 110.239  1.00 83.41           C  
+ATOM   6573  C   LEU B 338      95.377  46.486 111.416  1.00 89.52           C  
+ATOM   6574  O   LEU B 338      96.465  46.603 111.983  1.00 91.67           O  
+ATOM   6575  CB  LEU B 338      93.569  47.863 110.403  1.00 82.33           C  
+ATOM   6576  CG  LEU B 338      93.321  49.201 109.714  1.00 86.41           C  
+ATOM   6577  CD1 LEU B 338      91.836  49.477 109.588  1.00 86.61           C  
+ATOM   6578  CD2 LEU B 338      94.023  50.326 110.460  1.00 87.53           C  
+ATOM   6579  N   LEU B 339      94.501  45.539 111.727  1.00 82.75           N  
+ATOM   6580  CA  LEU B 339      94.814  44.644 112.822  1.00 80.56           C  
+ATOM   6581  C   LEU B 339      96.191  44.003 112.690  1.00 82.57           C  
+ATOM   6582  O   LEU B 339      97.048  44.217 113.542  1.00 81.21           O  
+ATOM   6583  CB  LEU B 339      93.689  43.650 113.111  1.00 79.94           C  
+ATOM   6584  CG  LEU B 339      92.348  44.300 113.483  1.00 82.70           C  
+ATOM   6585  CD1 LEU B 339      91.175  43.440 113.039  1.00 81.91           C  
+ATOM   6586  CD2 LEU B 339      92.210  44.674 114.955  1.00 81.25           C  
+ATOM   6587  N   GLU B 340      96.411  43.248 111.618  1.00 79.74           N  
+ATOM   6588  CA  GLU B 340      97.690  42.581 111.383  1.00 80.32           C  
+ATOM   6589  C   GLU B 340      98.893  43.520 111.498  1.00 86.61           C  
+ATOM   6590  O   GLU B 340      99.928  43.132 112.042  1.00 88.56           O  
+ATOM   6591  CB  GLU B 340      97.673  41.832 110.045  1.00 81.76           C  
+ATOM   6592  CG  GLU B 340      97.062  40.436 110.100  1.00 88.25           C  
+ATOM   6593  CD  GLU B 340      97.901  39.460 110.874  1.00100.00           C  
+ATOM   6594  OE1 GLU B 340      98.839  39.857 111.596  1.00100.00           O  
+ATOM   6595  OE2 GLU B 340      97.522  38.305 110.821  1.00100.00           O  
+ATOM   6596  N   ASP B 341      98.741  44.743 110.995  1.00 82.39           N  
+ATOM   6597  CA  ASP B 341      99.794  45.752 111.046  1.00 84.87           C  
+ATOM   6598  C   ASP B 341     100.880  45.618 109.983  1.00100.00           C  
+ATOM   6599  O   ASP B 341     101.541  46.596 109.629  1.00100.00           O  
+ATOM   6600  CB  ASP B 341     100.388  45.857 112.446  1.00 85.86           C  
+ATOM   6601  CG  ASP B 341      99.690  46.892 113.264  1.00 96.83           C  
+ATOM   6602  OD1 ASP B 341      98.466  47.039 113.084  1.00 98.68           O  
+ATOM   6603  OD2 ASP B 341     100.353  47.577 114.065  1.00100.00           O  
+TER    6604      ASP B 341                                                      
+HETATM 6605  O   HOH C  35      64.980  46.740  90.316  1.00 58.15           O  
+HETATM 6606  O   HOH C  36      74.306  22.893  61.049  1.00 44.26           O  
+HETATM 6607  O   HOH C  37      61.908  35.748  86.762  1.00 46.67           O  
+HETATM 6608  O   HOH C  38      71.071  30.713  61.341  1.00 41.26           O  
+HETATM 6609  O   HOH C  39      66.359  29.582  72.347  1.00 44.33           O  
+HETATM 6610  O   HOH C  40      79.414  21.489  67.567  1.00 49.41           O  
+HETATM 6611  O   HOH C  41      64.033  74.571  73.602  1.00 59.46           O  
+HETATM 6612  O   HOH C  42      77.189  19.821  67.575  1.00 47.79           O  
+HETATM 6613  O   HOH C  43      73.874  17.407  68.012  1.00 56.10           O  
+HETATM 6614  O   HOH C  44      72.558  37.886  91.064  1.00 53.30           O  
+HETATM 6615  O   HOH C  45      63.981  30.587  74.128  1.00 51.13           O  
+HETATM 6616  O   HOH C  46      68.278  38.308  82.136  1.00 45.94           O  
+HETATM 6617  O   HOH C  47      54.603  26.567  84.596  1.00 52.81           O  
+HETATM 6618  O   HOH C  48      72.701  20.298  69.451  1.00 73.18           O  
+HETATM 6619  O   HOH C  49      61.087  87.684  40.876  1.00 57.30           O  
+HETATM 6620  O   HOH C  50      69.103  40.214  80.849  1.00 51.64           O  
+HETATM 6621  O   HOH C  51      65.886  84.497  38.194  1.00 73.08           O  
+HETATM 6622  O   HOH C  52      77.531  17.506  68.106  1.00 70.15           O  
+HETATM 6623  O   HOH C  53      63.146  71.240  48.955  1.00 70.48           O  
+HETATM 6624  O   HOH C  54      71.311  90.897  43.842  1.00 74.58           O  
+HETATM 6625  O   HOH D  35      68.250  30.440  74.516  1.00 48.41           O  
+HETATM 6626  O   HOH D  36      59.987  40.705 101.128  1.00 42.67           O  
+HETATM 6627  O   HOH D  37      67.958  33.536  83.534  1.00 42.38           O  
+HETATM 6628  O   HOH D  38      68.297  15.122  64.842  1.00 51.03           O  
+HETATM 6629  O   HOH D  39      67.395  32.558  76.126  1.00 44.61           O  
+HETATM 6630  O   HOH D  40      72.640  27.183  78.097  1.00 38.82           O  
+HETATM 6631  O   HOH D  41      60.917  41.258  89.671  1.00 57.38           O  
+HETATM 6632  O   HOH D  42      58.700  39.944  87.333  1.00 41.79           O  
+HETATM 6633  O   HOH D  43      61.668  33.939  76.454  1.00 54.14           O  
+HETATM 6634  O   HOH D  44      62.640  37.297 131.422  1.00 65.61           O  
+HETATM 6635  O   HOH D  45      70.424  22.083  72.917  1.00 53.37           O  
+HETATM 6636  O   HOH D  46      65.969  22.745  80.603  1.00 58.80           O  
+HETATM 6637  O   HOH D  47      74.625  32.935 137.257  1.00 55.50           O  
+HETATM 6638  O   HOH D  48      67.841  34.363  74.775  1.00 50.53           O  
+HETATM 6639  O   HOH D  49      66.573  42.219 123.245  1.00 44.69           O  
+HETATM 6640  O   HOH D  50      62.522  53.632 125.596  1.00 52.35           O  
+HETATM 6641  O   HOH D  51      69.030  39.482 152.529  1.00 51.45           O  
+HETATM 6642  O   HOH D  52      64.633  32.169  75.522  1.00 52.25           O  
+HETATM 6643  O   HOH D  53      66.578  46.260 108.481  1.00 58.99           O  
+HETATM 6644  O   HOH D  54      68.297  52.808 117.748  1.00 54.71           O  
+HETATM 6645  O   HOH D  55      69.628  35.921  82.978  1.00 44.07           O  
+HETATM 6646  O   HOH D  56      57.661  55.352 121.294  1.00 55.56           O  
+HETATM 6647  O   HOH D  57      77.675  40.648 134.967  1.00 52.91           O  
+HETATM 6648  O   HOH D  58      70.889  42.979 130.137  1.00 43.48           O  
+HETATM 6649  O   HOH D  59      69.101  49.883 113.487  1.00 64.91           O  
+HETATM 6650  O   HOH D  60      70.211  51.569 115.994  1.00 51.60           O  
+HETATM 6651  O   HOH D  61      70.487  56.662 109.680  1.00 46.87           O  
+HETATM 6652  O   HOH D  62      70.866  47.921 111.661  1.00 54.45           O  
+HETATM 6653  O   HOH D  63      74.634  24.305  83.786  1.00 48.57           O  
+HETATM 6654  O   HOH D  64      77.820  20.422  55.941  1.00 63.25           O  
+HETATM 6655  O   HOH D  65      77.603  22.947  54.803  1.00 65.58           O  
+HETATM 6656  O   HOH D  66      67.858  47.881 109.127  1.00 71.59           O  
+HETATM 6657  O   HOH D  67      61.442  55.075 113.407  1.00 71.63           O  
+HETATM 6658  O   HOH D  68      72.612  33.676 134.301  1.00 65.25           O  
+HETATM 6659  O   HOH A 344      46.426  36.957 103.388  1.00 30.42           O  
+HETATM 6660  O   HOH A 345      80.411  53.864 130.822  1.00 63.19           O  
+HETATM 6661  O   HOH A 346      75.279  45.611 115.551  1.00 46.04           O  
+HETATM 6662  O   HOH A 347      30.510  39.647 105.547  1.00 44.27           O  
+HETATM 6663  O   HOH A 348      69.681  35.989 119.559  1.00 38.27           O  
+HETATM 6664  O   HOH A 349      68.092  44.551 122.726  1.00 37.32           O  
+HETATM 6665  O   HOH A 350      59.449  66.247 120.580  1.00 54.92           O  
+HETATM 6666  O   HOH A 351      74.049  32.999 132.496  1.00 53.00           O  
+HETATM 6667  O   HOH A 352      90.121  35.347 124.411  1.00 51.47           O  
+HETATM 6668  O   HOH A 353      81.258  35.073 138.848  1.00 53.07           O  
+HETATM 6669  O   HOH A 354      73.758  55.081 127.243  1.00 62.74           O  
+HETATM 6670  O   HOH A 355      67.353  41.361 115.577  1.00 49.54           O  
+HETATM 6671  O   HOH A 356      79.774  46.451 115.960  1.00 49.26           O  
+HETATM 6672  O   HOH A 357      39.948  59.574 115.633  1.00 52.29           O  
+HETATM 6673  O   HOH A 358      55.072  45.684 121.269  1.00 50.29           O  
+HETATM 6674  O   HOH A 359      67.892  44.531 119.550  1.00 66.01           O  
+HETATM 6675  O   HOH A 360      81.280  43.076 108.203  1.00 63.39           O  
+HETATM 6676  O   HOH A 361      55.122  52.788 120.973  1.00 47.03           O  
+HETATM 6677  O   HOH A 362      50.704  40.902 107.143  1.00 58.69           O  
+HETATM 6678  O   HOH A 363      72.893  52.312 117.024  1.00 45.82           O  
+HETATM 6679  O   HOH A 364      53.557  70.077 120.483  1.00 63.30           O  
+HETATM 6680  O   HOH A 365      68.518  38.117 119.968  1.00 46.34           O  
+HETATM 6681  O   HOH A 366      54.048  51.917 107.054  1.00 61.26           O  
+HETATM 6682  O   HOH A 367      60.890  37.280 112.233  1.00 63.35           O  
+HETATM 6683  O   HOH A 368      77.479  25.809 135.680  1.00 63.07           O  
+HETATM 6684  O   HOH A 369      55.812  49.376 108.570  1.00 46.62           O  
+HETATM 6685  O   HOH A 370      49.241  56.888 124.670  1.00 64.44           O  
+HETATM 6686  O   HOH A 371      94.647  80.999 104.123  1.00 67.58           O  
+HETATM 6687  O   HOH A 372      75.084  53.244 115.579  1.00 57.32           O  
+HETATM 6688  O   HOH A 373      53.351  43.050 122.246  1.00 57.93           O  
+HETATM 6689  O   HOH A 374      47.696  59.160 126.436  1.00 48.46           O  
+HETATM 6690  O   HOH A 375      80.484  44.703 114.741  1.00 48.58           O  
+HETATM 6691  O   HOH A 376      72.237  41.898 111.751  1.00 54.94           O  
+HETATM 6692  O   HOH A 377      86.541  71.940 103.842  1.00 55.76           O  
+HETATM 6693  O   HOH A 378      84.218  70.198 105.672  1.00 72.26           O  
+HETATM 6694  O   HOH A 379      67.496  39.780 122.275  1.00 49.34           O  
+HETATM 6695  O   HOH A 380      77.354  53.850 121.700  1.00 70.05           O  
+HETATM 6696  O   HOH A 381      75.116  33.020 120.599  1.00 49.96           O  
+HETATM 6697  O   HOH A 382      51.949  33.652 108.058  1.00 54.48           O  
+HETATM 6698  O   HOH A 383      43.986  69.188 115.677  1.00 70.26           O  
+HETATM 6699  O   HOH A 384      47.471  67.565 120.998  1.00 69.02           O  
+HETATM 6700  O   HOH A 385      55.900  58.758 108.456  1.00 63.18           O  
+HETATM 6701  O   HOH A 386      57.212  56.774 107.352  1.00 64.51           O  
+HETATM 6702  O   HOH A 387      54.293  54.984 105.751  1.00 61.06           O  
+HETATM 6703  O   HOH A 388      88.636  58.861 116.693  1.00 68.47           O  
+HETATM 6704  O   HOH A 389      82.942  61.780 105.130  1.00 78.96           O  
+HETATM 6705  O   HOH A 390      77.071  38.340 102.860  1.00 65.49           O  
+HETATM 6706  O   HOH A 391      73.032  48.824 124.768  1.00 66.35           O  
+HETATM 6707  O   HOH A 392      46.103  51.126 124.968  1.00 75.89           O  
+HETATM 6708  O   HOH A 393      40.489  53.887 122.509  1.00 67.68           O  
+HETATM 6709  O   HOH A 394      59.837  70.429 107.404  1.00 74.62           O  
+HETATM 6710  O   HOH A 395      62.019  75.087 118.051  1.00 63.44           O  
+HETATM 6711  O   HOH A 396      70.575  68.811 113.121  1.00 70.84           O  
+HETATM 6712  O   HOH A 397      68.929  70.293 115.134  1.00 69.88           O  
+HETATM 6713  O   HOH A 398      74.726  29.314 122.398  1.00 76.09           O  
+HETATM 6714  O   HOH A 399      67.616  34.195 120.969  1.00 79.41           O  
+HETATM 6715  O   HOH A 400      70.284  36.606 116.003  1.00 76.35           O  
+HETATM 6716  O   HOH A 401      80.437  58.680 127.362  1.00 79.43           O  
+HETATM 6717  O   HOH A 402      73.287  47.631 127.538  1.00 79.61           O  
+HETATM 6718  O   HOH B 344      77.187  30.513  83.579  1.00 28.42           O  
+HETATM 6719  O   HOH B 345      93.078  41.949  73.012  1.00 25.24           O  
+HETATM 6720  O   HOH B 346      96.947  25.662  70.030  1.00 32.30           O  
+HETATM 6721  O   HOH B 347      40.418  33.281  89.663  1.00 36.41           O  
+HETATM 6722  O   HOH B 348      59.864  28.201  96.419  1.00 35.38           O  
+HETATM 6723  O   HOH B 349      89.686  29.278  81.427  1.00 36.23           O  
+HETATM 6724  O   HOH B 350      78.932  39.729  76.991  1.00 34.28           O  
+HETATM 6725  O   HOH B 351      43.872  32.208  99.396  1.00 34.16           O  
+HETATM 6726  O   HOH B 352      73.351  34.865  60.343  1.00 35.60           O  
+HETATM 6727  O   HOH B 353      98.984  30.383  71.012  1.00 47.27           O  
+HETATM 6728  O   HOH B 354      84.212  24.470  61.042  1.00 42.32           O  
+HETATM 6729  O   HOH B 355      59.769  37.543  79.202  1.00 43.70           O  
+HETATM 6730  O   HOH B 356      88.709  34.708  65.337  1.00 36.13           O  
+HETATM 6731  O   HOH B 357      75.211  25.044  61.058  1.00 32.32           O  
+HETATM 6732  O   HOH B 358      76.024  39.189  64.527  1.00 40.77           O  
+HETATM 6733  O   HOH B 359      65.003  33.932  92.980  1.00 37.39           O  
+HETATM 6734  O   HOH B 360      65.575  34.124  72.445  1.00 53.33           O  
+HETATM 6735  O   HOH B 361      57.448  29.287  84.866  1.00 37.12           O  
+HETATM 6736  O   HOH B 362      96.250  34.708  74.780  1.00 46.71           O  
+HETATM 6737  O   HOH B 363      74.117  37.881  77.559  1.00 42.72           O  
+HETATM 6738  O   HOH B 364      68.064  25.185  84.027  1.00 55.76           O  
+HETATM 6739  O   HOH B 365      43.489  29.742 100.856  1.00 42.00           O  
+HETATM 6740  O   HOH B 366      69.389  35.539  67.486  1.00 42.78           O  
+HETATM 6741  O   HOH B 367      90.868  30.600  65.519  1.00 37.59           O  
+HETATM 6742  O   HOH B 368      73.665  36.790  64.122  1.00 39.25           O  
+HETATM 6743  O   HOH B 369      60.672  38.167  88.077  1.00 50.57           O  
+HETATM 6744  O   HOH B 370      85.196  26.410  86.301  1.00 52.00           O  
+HETATM 6745  O   HOH B 371      95.036  44.388  71.846  1.00 49.04           O  
+HETATM 6746  O   HOH B 372      72.281  34.939  83.569  1.00 49.04           O  
+HETATM 6747  O   HOH B 373      54.045  29.814 102.646  1.00 44.72           O  
+HETATM 6748  O   HOH B 374      91.429  32.945  65.313  1.00 37.43           O  
+HETATM 6749  O   HOH B 375      81.713  22.124  81.406  1.00 34.51           O  
+HETATM 6750  O   HOH B 376      55.063  30.888  75.232  1.00 44.23           O  
+HETATM 6751  O   HOH B 377      89.577  35.230  86.373  1.00 47.59           O  
+HETATM 6752  O   HOH B 378      87.261  18.322  77.517  1.00 59.54           O  
+HETATM 6753  O   HOH B 379      86.536  22.987  59.517  1.00 34.80           O  
+HETATM 6754  O   HOH B 380      69.243  31.588  85.479  1.00 38.77           O  
+HETATM 6755  O   HOH B 381      37.556  23.484  94.153  1.00 32.11           O  
+HETATM 6756  O   HOH B 382      74.284  46.658  65.749  1.00 43.85           O  
+HETATM 6757  O   HOH B 383      46.647  24.425  94.930  1.00 54.98           O  
+HETATM 6758  O   HOH B 384      73.217  32.265  60.581  1.00 39.08           O  
+HETATM 6759  O   HOH B 385      93.115  23.607  62.578  1.00 39.27           O  
+HETATM 6760  O   HOH B 386      84.935  24.394  54.459  1.00 50.83           O  
+HETATM 6761  O   HOH B 387      75.692  36.398  58.639  1.00 46.15           O  
+HETATM 6762  O   HOH B 388      69.405  42.218  74.711  1.00 38.11           O  
+HETATM 6763  O   HOH B 389      42.338  44.185  99.488  1.00 51.14           O  
+HETATM 6764  O   HOH B 390      52.060  44.456  65.716  1.00 59.38           O  
+HETATM 6765  O   HOH B 391      78.206  37.965  78.510  1.00 45.15           O  
+HETATM 6766  O   HOH B 392      47.675  26.794  97.285  1.00 45.87           O  
+HETATM 6767  O   HOH B 393      38.422  39.804  89.665  1.00 64.18           O  
+HETATM 6768  O   HOH B 394      38.798  36.591  95.512  1.00 37.99           O  
+HETATM 6769  O   HOH B 395      45.539  47.422  76.288  1.00 52.98           O  
+HETATM 6770  O   HOH B 396      69.230  29.804  88.440  1.00 43.40           O  
+HETATM 6771  O   HOH B 397      49.767  24.753  86.625  1.00 55.15           O  
+HETATM 6772  O   HOH B 398      74.940  20.408  79.209  1.00 50.61           O  
+HETATM 6773  O   HOH B 399      80.192  52.202  63.965  1.00 46.25           O  
+HETATM 6774  O   HOH B 400      76.903  26.176  55.143  1.00 56.11           O  
+HETATM 6775  O   HOH B 401      86.778  24.913  58.238  1.00 48.62           O  
+HETATM 6776  O   HOH B 402      84.323  48.185  74.246  1.00 52.87           O  
+HETATM 6777  O   HOH B 403      90.924  42.820  80.791  1.00 61.89           O  
+HETATM 6778  O   HOH B 404      62.340  26.372  97.366  1.00 77.16           O  
+HETATM 6779  O   HOH B 405      72.743  26.091  56.431  1.00 64.53           O  
+HETATM 6780  O   HOH B 406      81.558  38.342  94.008  1.00 57.44           O  
+HETATM 6781  O   HOH B 407      64.214  38.327 103.491  1.00 56.13           O  
+HETATM 6782  O   HOH B 408      64.818  25.733  82.829  1.00 70.25           O  
+HETATM 6783  O   HOH B 409      34.959  28.962  90.668  1.00 42.26           O  
+HETATM 6784  O   HOH B 410      69.575  29.111  59.493  1.00 56.50           O  
+HETATM 6785  O   HOH B 411      40.654  27.384  83.174  1.00 49.43           O  
+HETATM 6786  O   HOH B 412      79.825  21.967  79.495  1.00 53.83           O  
+HETATM 6787  O   HOH B 413      54.223  43.015  89.314  1.00 65.43           O  
+HETATM 6788  O   HOH B 414      68.558  38.604  68.627  1.00 52.22           O  
+HETATM 6789  O   HOH B 415      84.185  39.114  54.238  1.00 63.02           O  
+HETATM 6790  O   HOH B 416      40.974  42.093  88.696  1.00 60.47           O  
+HETATM 6791  O   HOH B 417      54.173  31.385  73.109  1.00 67.56           O  
+HETATM 6792  O   HOH B 418      53.964  44.747  99.005  1.00 46.21           O  
+HETATM 6793  O   HOH B 419      94.664  35.600  68.864  1.00 64.70           O  
+HETATM 6794  O   HOH B 420      44.452  48.219  86.819  1.00 57.59           O  
+HETATM 6795  O   HOH B 421      78.415  28.871  88.824  1.00 51.39           O  
+HETATM 6796  O   HOH B 422      77.449  46.782  76.830  1.00 56.86           O  
+HETATM 6797  O   HOH B 423      52.729  42.224  94.634  1.00 55.33           O  
+HETATM 6798  O   HOH B 424      54.122  42.356  97.513  1.00 58.63           O  
+HETATM 6799  O   HOH B 425      61.494  30.604  72.229  1.00 57.63           O  
+HETATM 6800  O   HOH B 426      54.345  26.001  87.088  1.00 55.71           O  
+HETATM 6801  O   HOH B 427      68.183  43.035  72.863  1.00 64.69           O  
+HETATM 6802  O   HOH B 428      56.332  35.798  71.468  1.00 44.60           O  
+HETATM 6803  O   HOH B 429      55.070  28.671  83.183  1.00 59.20           O  
+HETATM 6804  O   HOH B 430      72.196  31.162  57.677  1.00 71.96           O  
+HETATM 6805  O   HOH B 431      75.564  27.668  78.557  1.00 60.93           O  
+HETATM 6806  O   HOH B 432      37.312  39.563  94.467  1.00 54.61           O  
+HETATM 6807  O   HOH B 433      92.495  33.253  57.372  1.00 60.48           O  
+HETATM 6808  O   HOH B 434      75.044  24.499  80.013  1.00 47.85           O  
+HETATM 6809  O   HOH B 435      82.060  23.654  61.164  1.00 51.65           O  
+HETATM 6810  O   HOH B 436      85.884  34.159  89.683  1.00 75.72           O  
+HETATM 6811  O   HOH B 437      80.974  22.701  84.556  1.00 65.30           O  
+HETATM 6812  O   HOH B 438      82.303  33.175  89.019  1.00 61.77           O  
+HETATM 6813  O   HOH B 439      43.004  50.591  74.303  1.00 55.62           O  
+HETATM 6814  O   HOH B 440      74.520  25.955  76.313  1.00 50.36           O  
+HETATM 6815  O   HOH B 441      67.160  31.178  70.966  1.00 39.14           O  
+HETATM 6816  O   HOH B 442      54.180  34.162  71.434  1.00 53.95           O  
+HETATM 6817  O   HOH B 443      56.896  37.387  69.683  1.00 60.72           O  
+HETATM 6818  O   HOH B 444      70.377  26.013  89.645  1.00 53.78           O  
+HETATM 6819  O   HOH B 445      71.901  49.889  76.447  1.00 62.70           O  
+HETATM 6820  O   HOH B 446      85.020  19.446  62.025  1.00 60.41           O  
+HETATM 6821  O   HOH B 447      69.523  33.316  55.964  1.00 67.32           O  
+HETATM 6822  O   HOH B 448      51.382  25.570 100.005  1.00 69.25           O  
+HETATM 6823  O   HOH B 449      49.963  23.863  97.453  1.00 50.73           O  
+HETATM 6824  O   HOH B 450      68.477  27.884  88.907  1.00 54.40           O  
+HETATM 6825  O   HOH B 451      85.323  25.710  69.900  1.00 59.90           O  
+HETATM 6826  O   HOH B 452      86.573  23.994  70.553  1.00 64.54           O  
+HETATM 6827  O   HOH B 453      61.513  41.476  70.177  1.00 78.65           O  
+HETATM 6828  O   HOH B 454      44.823  21.335  84.238  1.00 79.95           O  
+HETATM 6829  O   HOH B 455      46.950  25.147  80.385  1.00 65.79           O  
+HETATM 6830  O   HOH B 456      45.665  27.259  78.125  1.00 67.58           O  
+HETATM 6831  O   HOH B 457      38.760  28.851  84.141  1.00 70.71           O  
+HETATM 6832  O   HOH B 458      39.878  21.427  94.601  1.00 72.62           O  
+HETATM 6833  O   HOH B 459      37.974  38.256  97.174  1.00 63.59           O  
+HETATM 6834  O   HOH B 460      77.168  31.129  89.598  1.00 65.82           O  
+HETATM 6835  O   HOH B 461      82.807  47.721  76.963  1.00 63.71           O  
+HETATM 6836  O   HOH B 462      76.241  26.096  81.754  1.00 69.53           O  
+HETATM 6837  O   HOH B 463      93.818  43.030 101.872  1.00 75.86           O  
+HETATM 6838  O   HOH B 464      73.030  23.192  76.758  1.00 70.59           O  
+HETATM 6839  O   HOH B 465      89.576  19.250  78.441  1.00 71.09           O  
+HETATM 6840  O   HOH B 466      42.120  40.628  90.049  1.00 79.87           O  
+HETATM 6841  O   HOH B 467      70.448  45.793  68.688  1.00 75.97           O  
+MASTER      467    0    0   36    5    0    0    6 6837    4    0   60          
+END                                                                             

--- a/moldesign/_tests/test_protein_primary_structure.py
+++ b/moldesign/_tests/test_protein_primary_structure.py
@@ -33,7 +33,6 @@ def protease_cif():
     return mdt.read(get_data_path('3aid.cif'))
 
 
-@pytest.mark.xfail(reason="Known biopython bugs, should be fixed by 0.7.4")
 def test_3aid_cif_chains(protease_cif):
     mol = protease_cif
     assert len(mol.chains) == 5
@@ -45,7 +44,6 @@ def test_3aid_cif_chains(protease_cif):
     assert mol.chains['D'].type == mol.chains['D'].type == 'water'
 
 
-@pytest.mark.xfail(reason='Known bug with biopython mmCIF parser, should be fixed before 0.7.4')
 def test_3aid_cif_separate_waters(protease_cif):
     mol = protease_cif
     assert mol.chains['D'].num_residues == 5
@@ -115,8 +113,6 @@ def test_residue_lookup_by_name_and_index(fixture, request):
 @pytest.mark.parametrize('fixture', fixture_types['protein'])
 def test_atom_lookup_by_name_and_index(fixture, request):
     mol = request.getfuncargvalue(fixture)
-    if mol.name.split('.')[-1] == 'cif':
-        pytest.xfail(reason='Known bug with biopython mmCIF parser, should be fixed before 0.7.4')
 
     for residue in mol.residues:
         for iatom, atom in enumerate(residue.atoms):
@@ -209,9 +205,6 @@ def test_chains_iterate_in_order(fixture, request):
 def test_residues_iterate_in_order(fixture, request):
     mol = request.getfuncargvalue(fixture)
 
-    if mol.name.split('.')[-1] == 'cif':
-        pytest.xfail(reason='Known bug with OpenBabel mmCIF parser, should be fixed before 0.7.4')
-
     _iter_index_order_tester(mol.residues)
 
     for chain in mol.chains:
@@ -221,9 +214,6 @@ def test_residues_iterate_in_order(fixture, request):
 @pytest.mark.parametrize('fixture', fixture_types['protein'])
 def test_atoms_iterate_in_order(fixture, request):
     mol = request.getfuncargvalue(fixture)
-
-    if mol.name.split('.')[-1] == 'cif':
-        pytest.xfail(reason='Known bug with OpenBabel mmCIF parser, should be fixed before 0.7.4')
 
     _iter_index_order_tester(mol.atoms)
 

--- a/moldesign/fileio.py
+++ b/moldesign/fileio.py
@@ -198,7 +198,7 @@ def read_pdb(f, assign_ccd_bonds=True):
     """
     assemblies = pdb.get_pdb_assemblies(f)
     f.seek(0)
-    mol = biopython_interface.parse_pdb(f)
+    mol = mdt.interfaces.parmed_interface.parse_pdb(f)
     mol.properties.bioassemblies = assemblies
     f.seek(0)
     conect_graph = pdb.get_conect_records(f)
@@ -237,7 +237,7 @@ def read_mmcif(f):
     Returns:
         moldesign.Molecule: the parsed molecular structure
     """
-    mol = openbabel_interface.read_stream(f, 'cif')
+    mol = mdt.interfaces.parmed_interface.parse_mmcif(f)
     f.seek(0)
     assemblies = biopython_interface.get_mmcif_assemblies(f)
     if assemblies:

--- a/moldesign/geom/periodic.py
+++ b/moldesign/geom/periodic.py
@@ -1,0 +1,20 @@
+# Copyright 2016 Autodesk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import moldesign as mdt
+
+# Need functions to:
+# 1) move all positions into unit cell
+# 2) unbreak bonds that wrap around the unit cell
+# 3) Break / unbreak a component
+# 4) Fast trajectory geometry analysis that takes periodicity into account

--- a/moldesign/interfaces/__init__.py
+++ b/moldesign/interfaces/__init__.py
@@ -1,11 +1,16 @@
-# Unlike other subpackages, this one doesn't make anything available at the top level
 from . import ambertools
 from . import biopython_interface
 from . import nbo_interface
 from . import openbabel
 from . import openmm
 from . import opsin_interface
+from . import parmed_interface
 from . import pdbfixer_interface
 from . import pyscf_interface
 from . import symmol_interface
 
+from .biopython_interface import *
+from .openbabel import *
+from .openmm import *
+from .parmed_interface import *
+from .pyscf_interface import *

--- a/moldesign/interfaces/biopython_interface.py
+++ b/moldesign/interfaces/biopython_interface.py
@@ -24,6 +24,12 @@ from moldesign import units as u
 from moldesign.helpers.pdb import BioAssembly
 
 
+def exports(o):
+    __all__.append(o.__name__)
+    return o
+__all__ = []
+
+
 def parse_mmcif(f):
     """Parse an mmCIF file (using the Biopython parser) and return a molecule
 
@@ -70,7 +76,7 @@ def _parse_file(f, parser_type):
     mol = biopy_to_mol(struc)
     return mol
 
-
+@exports
 def biopy_to_mol(struc):
     """Convert a biopython PDB structure to an MDT molecule.
 
@@ -130,7 +136,7 @@ def get_mmcif_assemblies(fileobj=None, mmcdata=None):
         Mapping[str, BioAssembly]: dict mapping assembly ids to BioAssembly instances
     """
     if mmcdata is None:
-        mmcdata = _getmmcdata(fileobj)
+        mmcdata = get_mmcif_data(fileobj)
 
     if '_pdbx_struct_assembly.id' not in mmcdata:
         return {}  # no assemblies present
@@ -185,7 +191,7 @@ def _make_transform_dict(tmat, transform_ids):
     return transforms
 
 
-def _getmmcdata(fileobj):
+def get_mmcif_data(fileobj):
     mmcdata = Bio.PDB.MMCIF2Dict.MMCIF2Dict(fileobj)
     fileobj.seek(0)  # rewind for future access
     return mmcdata

--- a/moldesign/interfaces/openmm.py
+++ b/moldesign/interfaces/openmm.py
@@ -22,6 +22,13 @@ from moldesign.utils import from_filepath
 from moldesign import units as u
 from moldesign import compute
 
+
+def exports(o):
+    __all__.append(o.__name__)
+    return o
+__all__ = []
+
+
 try:
     imp.find_module('simtk')
 except (ImportError, OSError) as exc:
@@ -136,6 +143,7 @@ PINT_NAMES = {'mole': u.avogadro,
               'elementary charge': u.q_e}
 
 
+@exports
 def simtk2pint(quantity, flat=False):
     """
     Converts a quantity from the simtk unit system to a quantity from the pint unit system
@@ -163,6 +171,7 @@ def simtk2pint(quantity, flat=False):
     return u.default.convert(mag)
 
 
+@exports
 def pint2simtk(quantity):
     """ Converts a quantity from the pint to simtk unit system.
     Note SimTK appears limited, esp for energy units. May need to have pint convert
@@ -209,6 +218,10 @@ else:
     amber_to_mol = _amber_to_mol
 
 
+exports(amber_to_mol)
+
+
+@exports
 def topology_to_mol(topo, name=None, positions=None, velocities=None, assign_bond_orders=True):
     """ Convert an OpenMM topology object into an MDT molecule.
 
@@ -292,6 +305,7 @@ def topology_to_mol(topo, name=None, positions=None, velocities=None, assign_bon
     return newmol
 
 
+@exports
 def mol_to_topology(mol):
     """ Create an openmm topology object from an MDT molecule
 
@@ -319,6 +333,7 @@ def mol_to_topology(mol):
     return top
 
 
+@exports
 def mol_to_modeller(mol):
     from simtk.openmm import app
     return app.Modeller(mol_to_topology(mol), pint2simtk(mol.positions))

--- a/moldesign/interfaces/parmed_interface.py
+++ b/moldesign/interfaces/parmed_interface.py
@@ -21,9 +21,21 @@ from moldesign import units as u
 def exports(o):
     __all__.append(o.__name__)
     return o
-
-
 __all__ = []
+
+
+def parse_mmcif(f):
+    """Parse an mmCIF file (using the Biopython parser) and return a molecule
+
+    Args:
+        f (file): file-like object containing the mmCIF file
+
+    Returns:
+        moldesign.Molecule: parsed molecule
+    """
+    parmedmol = parmed.read_CIF(f)
+    mol = parmed_to_mdt(parmedmol)
+    return mol
 
 
 @exports
@@ -65,7 +77,9 @@ def parmed_to_mdt(pmdmol):
     for pbnd in pmdmol.bonds:
         atoms[pbnd.atom1].bond_to(atoms[pbnd.atom2], int(pbnd.order))
 
-    return mdt.Molecule(atoms.values(), name=pmdmol.title)
+    mol = mdt.Molecule(atoms.values())
+    mol.description = pmdmol.title
+    return mol
 
 
 def _parmed_to_ff(topo, atom_map):

--- a/moldesign/interfaces/parmed_interface.py
+++ b/moldesign/interfaces/parmed_interface.py
@@ -1,0 +1,101 @@
+# Copyright 2016 Autodesk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import collections
+import parmed
+
+import moldesign as mdt
+from moldesign import units as u
+
+
+def exports(o):
+    __all__.append(o.__name__)
+    return o
+
+
+__all__ = []
+
+
+@exports
+def parmed_to_mdt(pmdmol):
+    """ Convert parmed object to MDT object
+
+    Args:
+        pmdmol (parmed.Structure): parmed structure to convert
+
+    Returns:
+        mdt.Molecule: converted molecule
+    """
+    atoms = collections.OrderedDict()
+    residues = {}
+    chains = {}
+    for patm in pmdmol.atoms:
+        if patm.residue.chain not in chains:
+            chains[patm.residue.chain] = mdt.Chain(pdbname=patm.residue.chain)
+        chain = chains[patm.residue.chain]
+
+        if patm.residue not in residues:
+            residues[patm.residue] = mdt.Residue(resname=patm.residue.name,
+                                                 pdbindex=patm.residue.number)
+            residues[patm.residue].chain = chain
+            chain.add(residues[patm.residue])
+        residue = residues[patm.residue]
+
+        atom = mdt.Atom(name=patm.name,
+                        atnum=patm.atomic_number,
+                        pdbindex=patm.number,
+                        mass=patm.mass * u.dalton)
+        atom.position = [patm.xx, patm.xy, patm.xz]*u.angstrom
+
+        atom.residue = residue
+        residue.add(atom)
+        atom.chain = chain
+        atoms[patm] = atom
+
+    for pbnd in pmdmol.bonds:
+        atoms[pbnd.atom1].bond_to(atoms[pbnd.atom2], int(pbnd.order))
+
+    return mdt.Molecule(atoms.values(), name=pmdmol.title)
+
+
+def _parmed_to_ff(topo, atom_map):
+    """ Create an MDT FFParameters object from a ParmEd topology
+
+    Args:
+        topo (parmed.Structure): ParmEd structure (with FF terms)
+        atom_map (Mapping[parmed.Atom, moldesign.Atom]): mapping between MDT and ParmEd atoms
+
+    Returns:
+        moldesign.forcefields.FFParameters: parameters in MDT format
+    """
+    bonds = [mdt.forcefields.HarmonicBondTerm(atom_map[bond.a1],
+                                              atom_map[bond.a2],
+                                              bond.type.k*u.kcalpermol/u.angstrom ** 2,
+                                              bond.type.req*u.angstrom)
+             for bond in topo.bonds]
+
+    angles = [mdt.forcefields.HarmonicAngleTerm(atom_map[angle.a1],
+                                                atom_map[angle.a2],
+                                                atom_map[angle.a3],
+                                                angle.type.k*u.kcalpermol/u.radian ** 2,
+                                                angle.type.theta_eq*u.degrees)
+              for angle in topo.angles]
+
+    dihedrals = [mdt.forcefields.PeriodicTorsionTerm(atom_map[dihedral.a1],
+                                                     atom_map[dihedral.a2],
+                                                     atom_map[dihedral.a3],
+                                                     atom_map[dihedral.a4],
+                                                     dihedral.type.per,
+                                                     dihedral.type.phi_k*u.kcalpermol,
+                                                     dihedral.type.phase*u.degrees)
+                 for dihedral in topo.dihedrals]

--- a/moldesign/interfaces/pyscf_interface.py
+++ b/moldesign/interfaces/pyscf_interface.py
@@ -22,6 +22,12 @@ from moldesign.utils import if_not_none, redirect_stderr
 from moldesign import orbitals
 
 
+def exports(o):
+    __all__.append(o.__name__)
+    return o
+__all__ = []
+
+
 try:
     imp.find_module('pyscf')
 except (ImportError, OSError) as exc:
@@ -31,6 +37,7 @@ else:
     force_remote = False
 
 
+@exports
 def mol_to_pyscf(mol, basis, symmetry=None, charge=0, positions=None):
     """Convert an MDT molecule to a PySCF "Mole" object"""
     from pyscf import gto

--- a/moldesign/molecules/atoms.py
+++ b/moldesign/molecules/atoms.py
@@ -214,8 +214,11 @@ class AtomReprMixin(object):
         lines.append('**Formal charge**: %s' % self.formal_charge)
 
         if self.molecule is not None:
+            lines.append('\n')
             if self.molecule.is_biomolecule:
-                lines.append("\n\n**Residue**: %s (index %d)" % (self.residue.name, self.residue.index))
+                if self.pdbindex is not None:
+                    lines.append('**PDB serial #**: %s'%self.pdbindex)
+                lines.append("**Residue**: %s (index %d)" % (self.residue.name, self.residue.index))
                 lines.append("**Chain**: %s" % self.chain.name)
             lines.append("**Molecule**: %s" % self.molecule.name)
             for ibond, (nbr, order) in enumerate(self.bond_graph.iteritems()):

--- a/moldesign/molecules/residue.py
+++ b/moldesign/molecules/residue.py
@@ -339,7 +339,7 @@ class Residue(Entity):
 
         lines.append('**<p>Chain:** %s' % self.chain.name)
 
-        lines.append('**Sequence number**: %d' % self.pdbindex)
+        lines.append('**PDB sequence #**: %d' % self.pdbindex)
 
         terminus = None
         if self.type == 'dna':

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ matplotlib
 nbmolviz >= 0.6.5
 notebook >= 4.2
 numpy
+parmed >= 2.0.0
 pint >= 0.7
 pyccc >= 0.6.4
 pytest


### PR DESCRIPTION
This adds integrations for the [ParmEd package](https://github.com/ParmEd/ParmEd), which provides the best mmCIF/PDB parsers that I've been able to find so far - and therefore fixes most of our failing test cases.

It introduces yet another python package dependency, but it's easy enough to install that we can just stick with pip/conda

ParmEd's real power comes in giving us a portable representation of Forcefield objects, but that will come in a future PR.