### PR TITLE
Interface cleanup

### DIFF
--- a/moldesign/interfaces/__init__.py
+++ b/moldesign/interfaces/__init__.py
@@ -1,11 +1,16 @@
-# Unlike other subpackages, this one doesn't make anything available at the top level
 from . import ambertools
 from . import biopython_interface
 from . import nbo_interface
 from . import openbabel
 from . import openmm
 from . import opsin_interface
+from . import parmed_interface
 from . import pdbfixer_interface
 from . import pyscf_interface
 from . import symmol_interface
 
+from .biopython_interface import *
+from .openbabel import *
+from .openmm import *
+from .parmed_interface import *
+from .pyscf_interface import *

--- a/moldesign/interfaces/__init__.py
+++ b/moldesign/interfaces/__init__.py
@@ -4,7 +4,6 @@ from . import nbo_interface
 from . import openbabel
 from . import openmm
 from . import opsin_interface
-from . import parmed_interface
 from . import pdbfixer_interface
 from . import pyscf_interface
 from . import symmol_interface
@@ -12,5 +11,4 @@ from . import symmol_interface
 from .biopython_interface import *
 from .openbabel import *
 from .openmm import *
-from .parmed_interface import *
 from .pyscf_interface import *

--- a/moldesign/interfaces/biopython_interface.py
+++ b/moldesign/interfaces/biopython_interface.py
@@ -76,6 +76,7 @@ def _parse_file(f, parser_type):
     mol = biopy_to_mol(struc)
     return mol
 
+
 @exports
 def biopy_to_mol(struc):
     """Convert a biopython PDB structure to an MDT molecule.

--- a/moldesign/interfaces/biopython_interface.py
+++ b/moldesign/interfaces/biopython_interface.py
@@ -24,6 +24,12 @@ from moldesign import units as u
 from moldesign.helpers.pdb import BioAssembly
 
 
+def exports(o):
+    __all__.append(o.__name__)
+    return o
+__all__ = []
+
+
 def parse_mmcif(f):
     """Parse an mmCIF file (using the Biopython parser) and return a molecule
 
@@ -70,7 +76,7 @@ def _parse_file(f, parser_type):
     mol = biopy_to_mol(struc)
     return mol
 
-
+@exports
 def biopy_to_mol(struc):
     """Convert a biopython PDB structure to an MDT molecule.
 
@@ -130,7 +136,7 @@ def get_mmcif_assemblies(fileobj=None, mmcdata=None):
         Mapping[str, BioAssembly]: dict mapping assembly ids to BioAssembly instances
     """
     if mmcdata is None:
-        mmcdata = _getmmcdata(fileobj)
+        mmcdata = get_mmcif_data(fileobj)
 
     if '_pdbx_struct_assembly.id' not in mmcdata:
         return {}  # no assemblies present
@@ -185,7 +191,7 @@ def _make_transform_dict(tmat, transform_ids):
     return transforms
 
 
-def _getmmcdata(fileobj):
+def get_mmcif_data(fileobj):
     mmcdata = Bio.PDB.MMCIF2Dict.MMCIF2Dict(fileobj)
     fileobj.seek(0)  # rewind for future access
     return mmcdata

--- a/moldesign/interfaces/openbabel.py
+++ b/moldesign/interfaces/openbabel.py
@@ -35,6 +35,13 @@ import moldesign.molecules.atoms
 from moldesign import units as u
 
 
+def exports(o):
+    __all__.append(o.__name__)
+    return o
+
+__all__ = []
+
+
 def read_file(filename, name=None, format=None):
     """ Read a molecule from a file
 
@@ -174,7 +181,7 @@ def add_hydrogen(mol, ph=None):
     mdt.helpers.assign_unique_hydrogen_names(newmol)
     return newmol
 
-
+@exports
 def mol_to_pybel(mdtmol):
     """ Translate a moldesign molecule object into a pybel molecule object.
 
@@ -232,6 +239,7 @@ def mol_to_pybel(mdtmol):
     return pbmol
 
 
+@exports
 def pybel_to_mol(pbmol,
                  atom_names=True,
                  reorder_atoms_by_residue=False,

--- a/moldesign/interfaces/openmm.py
+++ b/moldesign/interfaces/openmm.py
@@ -22,6 +22,13 @@ from moldesign.utils import from_filepath
 from moldesign import units as u
 from moldesign import compute
 
+
+def exports(o):
+    __all__.append(o.__name__)
+    return o
+__all__ = []
+
+
 try:
     imp.find_module('simtk')
 except (ImportError, OSError) as exc:
@@ -136,6 +143,7 @@ PINT_NAMES = {'mole': u.avogadro,
               'elementary charge': u.q_e}
 
 
+@exports
 def simtk2pint(quantity, flat=False):
     """
     Converts a quantity from the simtk unit system to a quantity from the pint unit system
@@ -163,6 +171,7 @@ def simtk2pint(quantity, flat=False):
     return u.default.convert(mag)
 
 
+@exports
 def pint2simtk(quantity):
     """ Converts a quantity from the pint to simtk unit system.
     Note SimTK appears limited, esp for energy units. May need to have pint convert
@@ -209,6 +218,10 @@ else:
     amber_to_mol = _amber_to_mol
 
 
+exports(amber_to_mol)
+
+
+@exports
 def topology_to_mol(topo, name=None, positions=None, velocities=None, assign_bond_orders=True):
     """ Convert an OpenMM topology object into an MDT molecule.
 
@@ -292,6 +305,7 @@ def topology_to_mol(topo, name=None, positions=None, velocities=None, assign_bon
     return newmol
 
 
+@exports
 def mol_to_topology(mol):
     """ Create an openmm topology object from an MDT molecule
 
@@ -319,6 +333,7 @@ def mol_to_topology(mol):
     return top
 
 
+@exports
 def mol_to_modeller(mol):
     from simtk.openmm import app
     return app.Modeller(mol_to_topology(mol), pint2simtk(mol.positions))

--- a/moldesign/interfaces/opsin_interface.py
+++ b/moldesign/interfaces/opsin_interface.py
@@ -18,6 +18,7 @@ from moldesign import utils
 
 IMAGE = 'opsin'
 
+
 @utils.kwargs_from(mdt.compute.run_job)
 def name_to_smiles(name,
                    **kwargs):

--- a/moldesign/interfaces/pyscf_interface.py
+++ b/moldesign/interfaces/pyscf_interface.py
@@ -22,6 +22,12 @@ from moldesign.utils import if_not_none, redirect_stderr
 from moldesign import orbitals
 
 
+def exports(o):
+    __all__.append(o.__name__)
+    return o
+__all__ = []
+
+
 try:
     imp.find_module('pyscf')
 except (ImportError, OSError) as exc:
@@ -31,6 +37,7 @@ else:
     force_remote = False
 
 
+@exports
 def mol_to_pyscf(mol, basis, symmetry=None, charge=0, positions=None):
     """Convert an MDT molecule to a PySCF "Mole" object"""
     from pyscf import gto


### PR DESCRIPTION
This is code cleanup, doing 2 things:

 - Exposes python object converters `mol_to_pybel`, `biopython_to_mol`, etc. in the `moldesign.interfaces` namespace (instead of making you hunt for them in subpackages)
 - Cleans up the opsin interface so that it uses the same patterns as all the others (so that I can point to it as a template)

@justinmc, this is ready for review. The next two PRs (to fix our builds) will depend on this one