### PR TITLE
Parmed integration

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ dependencies:
  - markdown2
  - matplotlib
  - numpy
+ - parmed >= 2.0.0
  - pint >= 0.7
  - pytest
  - pyyaml

--- a/moldesign/_tests/test_protein_primary_structure.py
+++ b/moldesign/_tests/test_protein_primary_structure.py
@@ -33,7 +33,6 @@ def protease_cif():
     return mdt.read(get_data_path('3aid.cif'))
 
 
-@pytest.mark.xfail(reason="Known biopython bugs, should be fixed by 0.7.4")
 def test_3aid_cif_chains(protease_cif):
     mol = protease_cif
     assert len(mol.chains) == 5
@@ -45,7 +44,6 @@ def test_3aid_cif_chains(protease_cif):
     assert mol.chains['D'].type == mol.chains['D'].type == 'water'
 
 
-@pytest.mark.xfail(reason='Known bug with biopython mmCIF parser, should be fixed before 0.7.4')
 def test_3aid_cif_separate_waters(protease_cif):
     mol = protease_cif
     assert mol.chains['D'].num_residues == 5
@@ -115,8 +113,6 @@ def test_residue_lookup_by_name_and_index(fixture, request):
 @pytest.mark.parametrize('fixture', fixture_types['protein'])
 def test_atom_lookup_by_name_and_index(fixture, request):
     mol = request.getfuncargvalue(fixture)
-    if mol.name.split('.')[-1] == 'cif':
-        pytest.xfail(reason='Known bug with biopython mmCIF parser, should be fixed before 0.7.4')
 
     for residue in mol.residues:
         for iatom, atom in enumerate(residue.atoms):
@@ -209,9 +205,6 @@ def test_chains_iterate_in_order(fixture, request):
 def test_residues_iterate_in_order(fixture, request):
     mol = request.getfuncargvalue(fixture)
 
-    if mol.name.split('.')[-1] == 'cif':
-        pytest.xfail(reason='Known bug with OpenBabel mmCIF parser, should be fixed before 0.7.4')
-
     _iter_index_order_tester(mol.residues)
 
     for chain in mol.chains:
@@ -221,9 +214,6 @@ def test_residues_iterate_in_order(fixture, request):
 @pytest.mark.parametrize('fixture', fixture_types['protein'])
 def test_atoms_iterate_in_order(fixture, request):
     mol = request.getfuncargvalue(fixture)
-
-    if mol.name.split('.')[-1] == 'cif':
-        pytest.xfail(reason='Known bug with OpenBabel mmCIF parser, should be fixed before 0.7.4')
 
     _iter_index_order_tester(mol.atoms)
 

--- a/moldesign/fileio.py
+++ b/moldesign/fileio.py
@@ -198,7 +198,7 @@ def read_pdb(f, assign_ccd_bonds=True):
     """
     assemblies = pdb.get_pdb_assemblies(f)
     f.seek(0)
-    mol = biopython_interface.parse_pdb(f)
+    mol = mdt.interfaces.parmed_interface.parse_pdb(f)
     mol.properties.bioassemblies = assemblies
     f.seek(0)
     conect_graph = pdb.get_conect_records(f)
@@ -237,7 +237,7 @@ def read_mmcif(f):
     Returns:
         moldesign.Molecule: the parsed molecular structure
     """
-    mol = openbabel_interface.read_stream(f, 'cif')
+    mol = mdt.interfaces.parmed_interface.parse_mmcif(f)
     f.seek(0)
     assemblies = biopython_interface.get_mmcif_assemblies(f)
     if assemblies:

--- a/moldesign/interfaces/__init__.py
+++ b/moldesign/interfaces/__init__.py
@@ -4,6 +4,7 @@ from . import nbo_interface
 from . import openbabel
 from . import openmm
 from . import opsin_interface
+from . import parmed_interface
 from . import pdbfixer_interface
 from . import pyscf_interface
 from . import symmol_interface
@@ -12,3 +13,4 @@ from .biopython_interface import *
 from .openbabel import *
 from .openmm import *
 from .pyscf_interface import *
+from .parmed_interface import *

--- a/moldesign/interfaces/parmed_interface.py
+++ b/moldesign/interfaces/parmed_interface.py
@@ -27,7 +27,7 @@ __all__ = []
 
 
 def parse_mmcif(f, reassign_chains=True):
-    """Parse an mmCIF file (using the Biopython parser) and return a molecule
+    """Parse an mmCIF file (using the parmEd parser) and return a molecule
 
     Args:
         f (file): file-like object containing the mmCIF file
@@ -46,7 +46,7 @@ def parse_mmcif(f, reassign_chains=True):
 
 
 def parse_pdb(f):
-    """Parse an mmCIF file (using the Biopython parser) and return a molecule
+    """Parse an mmCIF file (using the parmEd parser) and return a molecule
 
     Args:
         f (file): file-like object containing the mmCIF file

--- a/moldesign/interfaces/parmed_interface.py
+++ b/moldesign/interfaces/parmed_interface.py
@@ -21,9 +21,21 @@ from moldesign import units as u
 def exports(o):
     __all__.append(o.__name__)
     return o
-
-
 __all__ = []
+
+
+def parse_mmcif(f):
+    """Parse an mmCIF file (using the Biopython parser) and return a molecule
+
+    Args:
+        f (file): file-like object containing the mmCIF file
+
+    Returns:
+        moldesign.Molecule: parsed molecule
+    """
+    parmedmol = parmed.read_CIF(f)
+    mol = parmed_to_mdt(parmedmol)
+    return mol
 
 
 @exports
@@ -65,7 +77,9 @@ def parmed_to_mdt(pmdmol):
     for pbnd in pmdmol.bonds:
         atoms[pbnd.atom1].bond_to(atoms[pbnd.atom2], int(pbnd.order))
 
-    return mdt.Molecule(atoms.values(), name=pmdmol.title)
+    mol = mdt.Molecule(atoms.values())
+    mol.description = pmdmol.title
+    return mol
 
 
 def _parmed_to_ff(topo, atom_map):

--- a/moldesign/interfaces/parmed_interface.py
+++ b/moldesign/interfaces/parmed_interface.py
@@ -1,0 +1,101 @@
+# Copyright 2016 Autodesk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import collections
+import parmed
+
+import moldesign as mdt
+from moldesign import units as u
+
+
+def exports(o):
+    __all__.append(o.__name__)
+    return o
+
+
+__all__ = []
+
+
+@exports
+def parmed_to_mdt(pmdmol):
+    """ Convert parmed object to MDT object
+
+    Args:
+        pmdmol (parmed.Structure): parmed structure to convert
+
+    Returns:
+        mdt.Molecule: converted molecule
+    """
+    atoms = collections.OrderedDict()
+    residues = {}
+    chains = {}
+    for patm in pmdmol.atoms:
+        if patm.residue.chain not in chains:
+            chains[patm.residue.chain] = mdt.Chain(pdbname=patm.residue.chain)
+        chain = chains[patm.residue.chain]
+
+        if patm.residue not in residues:
+            residues[patm.residue] = mdt.Residue(resname=patm.residue.name,
+                                                 pdbindex=patm.residue.number)
+            residues[patm.residue].chain = chain
+            chain.add(residues[patm.residue])
+        residue = residues[patm.residue]
+
+        atom = mdt.Atom(name=patm.name,
+                        atnum=patm.atomic_number,
+                        pdbindex=patm.number,
+                        mass=patm.mass * u.dalton)
+        atom.position = [patm.xx, patm.xy, patm.xz]*u.angstrom
+
+        atom.residue = residue
+        residue.add(atom)
+        atom.chain = chain
+        atoms[patm] = atom
+
+    for pbnd in pmdmol.bonds:
+        atoms[pbnd.atom1].bond_to(atoms[pbnd.atom2], int(pbnd.order))
+
+    return mdt.Molecule(atoms.values(), name=pmdmol.title)
+
+
+def _parmed_to_ff(topo, atom_map):
+    """ Create an MDT FFParameters object from a ParmEd topology
+
+    Args:
+        topo (parmed.Structure): ParmEd structure (with FF terms)
+        atom_map (Mapping[parmed.Atom, moldesign.Atom]): mapping between MDT and ParmEd atoms
+
+    Returns:
+        moldesign.forcefields.FFParameters: parameters in MDT format
+    """
+    bonds = [mdt.forcefields.HarmonicBondTerm(atom_map[bond.a1],
+                                              atom_map[bond.a2],
+                                              bond.type.k*u.kcalpermol/u.angstrom ** 2,
+                                              bond.type.req*u.angstrom)
+             for bond in topo.bonds]
+
+    angles = [mdt.forcefields.HarmonicAngleTerm(atom_map[angle.a1],
+                                                atom_map[angle.a2],
+                                                atom_map[angle.a3],
+                                                angle.type.k*u.kcalpermol/u.radian ** 2,
+                                                angle.type.theta_eq*u.degrees)
+              for angle in topo.angles]
+
+    dihedrals = [mdt.forcefields.PeriodicTorsionTerm(atom_map[dihedral.a1],
+                                                     atom_map[dihedral.a2],
+                                                     atom_map[dihedral.a3],
+                                                     atom_map[dihedral.a4],
+                                                     dihedral.type.per,
+                                                     dihedral.type.phi_k*u.kcalpermol,
+                                                     dihedral.type.phase*u.degrees)
+                 for dihedral in topo.dihedrals]

--- a/moldesign/molecules/atoms.py
+++ b/moldesign/molecules/atoms.py
@@ -214,8 +214,11 @@ class AtomReprMixin(object):
         lines.append('**Formal charge**: %s' % self.formal_charge)
 
         if self.molecule is not None:
+            lines.append('\n')
             if self.molecule.is_biomolecule:
-                lines.append("\n\n**Residue**: %s (index %d)" % (self.residue.name, self.residue.index))
+                if self.pdbindex is not None:
+                    lines.append('**PDB serial #**: %s'%self.pdbindex)
+                lines.append("**Residue**: %s (index %d)" % (self.residue.name, self.residue.index))
                 lines.append("**Chain**: %s" % self.chain.name)
             lines.append("**Molecule**: %s" % self.molecule.name)
             for ibond, (nbr, order) in enumerate(self.bond_graph.iteritems()):

--- a/moldesign/molecules/residue.py
+++ b/moldesign/molecules/residue.py
@@ -339,7 +339,7 @@ class Residue(Entity):
 
         lines.append('**<p>Chain:** %s' % self.chain.name)
 
-        lines.append('**Sequence number**: %d' % self.pdbindex)
+        lines.append('**PDB sequence #**: %d' % self.pdbindex)
 
         terminus = None
         if self.type == 'dna':

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ matplotlib
 nbmolviz >= 0.6.5
 notebook >= 4.2
 numpy
+parmed >= 2.0.0
 pint >= 0.7
 pyccc >= 0.6.4
 pytest


### PR DESCRIPTION
This adds integrations for the ParmEd package, which provides the best python mmCIF/PDB parsers that I've been able to find so far - and provides fixes most of our failing test cases. Note that this is branched on #115, so that should get merged first.

It introduces yet another python package dependency, but it's easy enough to install that we can just stick with pip/conda.

ParmEd's real power comes in giving us a piece that we've been missing for a while - abstracted, introspectable force field objects. Those will be integrated in an upcoming PR.