### PR TITLE
Fix Orbitals Not Showing Up

### DIFF
--- a/moldesign/widgets/orbitals.py
+++ b/moldesign/widgets/orbitals.py
@@ -48,7 +48,7 @@ class OrbitalUIPane(Selector, ipy.Box):
         self.type_dropdown.value = initial_orb
         self.type_dropdown.observe(self.new_orb_type, 'value')
 
-        self.orblist = ipy.Select(options={None: None},
+        self.orblist = ipy.Dropdown(options={None: None},
                                   width=str(kwargs['width'])+'px',
                                   height=str(int(kwargs['height']) - 75)+'px')
 
@@ -69,7 +69,6 @@ class OrbitalUIPane(Selector, ipy.Box):
         super(OrbitalUIPane, self).__init__(children, **kwargs)
         self.new_orb_type()
         self.orblist.observe(self.new_orbital_selection, 'value')
-
 
     def new_orbital_selection(self, *args):
         self.fire_selection_event({'orbname': (self.type_dropdown.value, self.orblist.value)})


### PR DESCRIPTION
Issue: https://github.com/Autodesk/notebook-molecular-visualization/issues/38

This seems to be caused by a bug in the v6 beta releases on ipywidgets (I tried both b1 and b2).  I submitted an issue: https://github.com/ipython/ipywidgets/issues/876.  But the workaround in the meantime is to use a Dropdown instead.