### PR TITLE
Fix gaff parameterization

### DIFF
--- a/moldesign/_tests/test_forcefield.py
+++ b/moldesign/_tests/test_forcefield.py
@@ -1,0 +1,126 @@
+import pytest
+
+import moldesign as mdt
+
+
+@pytest.fixture(scope='function')
+def mol_from_xyz():
+    return mdt.read("""43
+    c1.pdb
+    C         -1.21700        1.04300        2.45300
+    C         -0.14200        0.18700        2.19500
+    C         -0.31600       -0.99500        1.46200
+    C         -1.59800       -1.33100        1.02200
+    C         -2.68200       -0.48500        1.28100
+    C         -2.50400        0.70500        1.98200
+    O         -3.53000        1.57400        2.25000
+    O         -1.13200        2.21500        3.14700
+    C          0.14200        2.61500        3.63500
+    C          0.86700       -1.90600        1.12900
+    C          1.10600       -1.99700       -0.40500
+    O          2.06900       -1.52700        1.78600
+    O          1.81300       -0.81200       -0.83600
+    C          1.98100       -3.18300       -0.81100
+    O          2.18000       -3.27400       -2.21400
+    C          1.18300        0.32500       -1.28900
+    C          0.13100        0.33800       -2.23300
+    C         -0.38800        1.56800       -2.65400
+    C          0.15900        2.77500       -2.20100
+    C          1.23000        2.75900       -1.31000
+    C          1.72800        1.53500       -0.85900
+    O         -0.31100       -0.88000       -2.70600
+    C         -1.43500       -0.90100       -3.58200
+    H          0.84400        0.42500        2.57000
+    H         -1.77600       -2.25500        0.47700
+    H         -3.67600       -0.75700        0.93200
+    H         -4.35900        1.18400        1.93700
+    H         -0.03000        3.54300        4.18500
+    H          0.84500        2.80900        2.81200
+    H          0.56300        1.86400        4.31600
+    H          0.63600       -2.91500        1.49500
+    H          0.14200       -2.06200       -0.91500
+    H          2.51900       -0.89500        1.20400
+    H          1.52900       -4.10700       -0.41600
+    H          2.97500       -3.07900       -0.36800
+    H          1.34400       -3.10100       -2.67400
+    H         -1.20600        1.60000       -3.36300
+    H         -0.25300        3.71600       -2.56000
+    H          1.68000        3.68900       -0.97300
+    H          2.55900        1.49100       -0.16100
+    H         -1.60900       -1.95000       -3.81500
+    H         -1.22800       -0.35800       -4.51600
+    H         -2.32500       -0.48000       -3.09700
+    """, format='xyz')
+
+
+@pytest.fixture(scope='function')
+def mol_from_sdf():
+    return mdt.read("""
+ OpenBabel02271712493D
+
+ 11 10  0  0  0  0  0  0  0  0999 V2000
+    0.9114   -0.0615    0.0032 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.4168    1.3750    0.0264 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.9114    2.1503   -1.1831 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.5568   -0.5828   -0.8916 H   0  0  0  0  0  0  0  0  0  0  0  0
+    0.5460   -0.6043    0.8807 H   0  0  0  0  0  0  0  0  0  0  0  0
+    2.0053   -0.0987    0.0111 H   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.6785    1.3847    0.0446 H   0  0  0  0  0  0  0  0  0  0  0  0
+    0.7625    1.8663    0.9425 H   0  0  0  0  0  0  0  0  0  0  0  0
+    0.5568    1.6932   -2.1123 H   0  0  0  0  0  0  0  0  0  0  0  0
+    0.5460    3.1815   -1.1499 H   0  0  0  0  0  0  0  0  0  0  0  0
+    2.0053    2.1774   -1.2097 H   0  0  0  0  0  0  0  0  0  0  0  0
+  2  1  1  0  0  0  0
+  3  2  1  0  0  0  0
+  4  1  1  0  0  0  0
+  5  1  1  0  0  0  0
+  6  1  1  0  0  0  0
+  7  2  1  0  0  0  0
+  8  2  1  0  0  0  0
+  9  3  1  0  0  0  0
+ 10  3  1  0  0  0  0
+ 11  3  1  0  0  0  0
+M  END
+$$$$
+""", format='sdf')
+
+
+@pytest.fixture(scope='function')
+def mol_from_pdb():
+    mol = mdt.from_pdb('3aid')
+    return mdt.Molecule(mol.chains['A'].residues['ARQ401'])
+
+
+@pytest.fixture(scope='function')
+def mol_from_smiles():
+    return mdt.from_smiles('CC')
+
+
+@pytest.mark.parametrize('objkey',
+                         'mol_from_smiles mol_from_pdb mol_from_xyz mol_from_sdf'.split())
+def test_parameterization_from_formats(objkey, request):
+    mol = request.getfuncargvalue(objkey)
+    assert not mol.ff
+    params = mdt.parameterize(mol, charges='gasteiger')
+    _test_succesful_parameterization(mol, params)
+
+
+@pytest.mark.parametrize('chargemodel',
+                         'esp gasteiger zero am1-bcc'.split())
+def test_charge_models(mol_from_smiles, chargemodel):
+    mol = mol_from_smiles
+
+    if chargemodel == 'esp':
+        pytest.xfail("ESP not yet implemented")
+    assert not mol.ff
+    params = mdt.parameterize(mol, charges=chargemodel)
+    _test_succesful_parameterization(mol, params)
+
+
+def _test_succesful_parameterization(mol, params):
+    assert params is not None
+    assert mol.ff
+    mol.set_energy_model(mdt.models.ForceField)
+    mol.calculate()
+    assert 'potential_energy' in mol.properties
+    assert 'forces' in mol.properties

--- a/moldesign/_tests/test_io.py
+++ b/moldesign/_tests/test_io.py
@@ -47,19 +47,12 @@ ATOMDATA = {  # (symbol, valence, mass)
     8: ('O', 2, 15.995 * u.amu)}
 
 
-@pytest.mark.parametrize('key', 'iupac smiles inchi'.split())
+@pytest.mark.parametrize('key', 'iupac smiles inchi xyz sdf'.split())
 def test_auto_unique_atom_names(key, request):
     mol = request.getfuncargvalue('bipyridine_'+key)
 
     atomnames = set(atom.name for atom in mol.atoms)
     assert len(atomnames) == mol.num_atoms
-
-
-@pytest.mark.parametrize('key', 'xyz sdf'.split())
-def test_atom_names_preserved_from_input_file(key, request):
-    mol = request.getfuncargvalue('bipyridine_'+key)
-    for atom in mol.atoms:
-        assert atom.name == atom.symbol
 
 
 def test_atom_names_preserved_from_input_file_mol2(bipyridine_mol2):

--- a/moldesign/fileio.py
+++ b/moldesign/fileio.py
@@ -84,6 +84,7 @@ def read(f, format=None):
     if filename is not None and mol.name not in (None, 'untitled'):
         mol.name = filename
 
+    mdt.helpers.atom_name_check(mol)
     return mol
 
 

--- a/moldesign/helpers/helpers.py
+++ b/moldesign/helpers/helpers.py
@@ -171,3 +171,28 @@ def _cmap_to_rgb(mplmap, values):
     # strip alpha field and rescale to [0,255] RGB integers
     rgb = [map(int, c[:3]*256.0) for c in rgba]
     return rgb
+
+
+def atom_name_check(mol):
+    """ Makes sure atom names are unique in each residue.
+
+    If atoms names aren't unqiue:
+      - if the names are just the names of the elements, rename them
+      - else print a warning
+    """
+    badres = []
+    for residue in mol.residues:
+        names = set(atom.name for atom in residue.atoms)
+        if len(names) != residue.num_atoms:
+            # atom names aren't unique, check if we can change them
+            for atom in residue.atoms:
+                if atom.name.lower() != atom.symbol.lower():
+                    badres.append(residue)
+            else:  # rename the atoms
+                atomnums = {}
+                for atom in residue.atoms:
+                    atom.name = atom.symbol + str(atomnums.setdefault(atom.symbol, 0))
+                    atomnums[atom.symbol] += 1
+
+    if badres:
+        print 'WARNING: residues do not have uniquely named atoms: %s' % badres

--- a/moldesign/helpers/helpers.py
+++ b/moldesign/helpers/helpers.py
@@ -173,7 +173,7 @@ def _cmap_to_rgb(mplmap, values):
     return rgb
 
 
-def atom_name_check(mol):
+def atom_name_check(mol, force=False):
     """ Makes sure atom names are unique in each residue.
 
     If atoms names aren't unqiue:
@@ -188,6 +188,8 @@ def atom_name_check(mol):
             for atom in residue.atoms:
                 if atom.name.lower() != atom.symbol.lower():
                     badres.append(residue)
+                    if not force:
+                        break
             else:  # rename the atoms
                 atomnums = {}
                 for atom in residue.atoms:

--- a/moldesign/interfaces/ambertools.py
+++ b/moldesign/interfaces/ambertools.py
@@ -106,7 +106,7 @@ def calc_gasteiger_charges(mol, **kwargs):
 
 def _antechamber_calc_charges(mol, ambname, chargename, kwargs):
     charge = utils.if_not_none(mol.charge, 0)
-    command = 'antechamber -fi pdb -i mol.pdb -fo mol2 -o out.mol2 -c %s -an n'%ambname
+    command = 'antechamber -fi mol2 -i mol.mol2 -fo mol2 -o out.mol2 -c %s -an n'%ambname
     if charge != 0:
         command += ' -nc %d' % charge.value_in(u.q_e)
 
@@ -132,8 +132,8 @@ def _antechamber_calc_charges(mol, ambname, chargename, kwargs):
 
     job = pyccc.Job(image=mdt.compute.get_image_path(IMAGE),
                     command=command,
-                    name="%s, %s"%(chargename, mol.name),
-                    inputs={'mol.pdb': mol.write(format='pdb')},
+                    name="%s, %s" % (chargename, mol.name),
+                    inputs={'mol.mol2': mol.write(format='mol2')},
                     when_finished=finish_job)
     return compute.run_job(job, _return_result=True, **kwargs)
 
@@ -419,7 +419,7 @@ def _parse_tleap_errors(job, molin):
     msg = []
     unknown_res = set()  # so we can print only one error per unkonwn residue
     lineiter = iter(job.stdout.split('\n'))
-    offset = utils.if_not_none(molin.residues[0].pdbindex, 0)
+    offset = utils.if_not_none(molin.residues[0].pdbindex, 1)
     reslookup = {str(i+offset): r for i,r in enumerate(molin.residues)}
 
     def _atom_from_re(s):

--- a/moldesign/interfaces/ambertools.py
+++ b/moldesign/interfaces/ambertools.py
@@ -354,11 +354,16 @@ def parameterize(mol, charges='esp', ffname='gaff2', **kwargs):
         ExtraAmberParameters: Parameters for the molecule; this object can be used to create
             forcefield parameters for other systems that contain this molecule
     """
+    # Check that there's only 1 residue, give it a name
     assert mol.num_residues == 1
     if mol.residues[0].resname is None:
         mol.residues[0].resname = 'UNL'
         print 'Assigned residue name "UNL" to %s' % mol
     resname = mol.residues[0].resname
+
+    # check that atoms have unique names
+    if len(set(atom.name for atom in mol.atoms)) != mol.num_atoms:
+        raise ValueError('This molecule does not have uniquely named atoms, cannot assign FF')
 
     if charges == 'am1-bcc' and 'am1-bcc' not in mol.properties:
         calc_am1_bcc_charges(mol)

--- a/moldesign/interfaces/openbabel.py
+++ b/moldesign/interfaces/openbabel.py
@@ -35,7 +35,6 @@ from moldesign import units as u
 from moldesign.utils import exports
 
 
-
 def read_file(filename, name=None, format=None):
     """ Read a molecule from a file
 
@@ -259,7 +258,6 @@ def mol_to_pybel(mdtmol):
 
 @exports
 def pybel_to_mol(pbmol,
-                 atom_names=True,
                  reorder_atoms_by_residue=False,
                  primary_structure=True,
                  **kwargs):
@@ -270,7 +268,6 @@ def pybel_to_mol(pbmol,
 
     Args:
         pbmol (pybel.Molecule): molecule to translate
-        atom_names (bool): use pybel's atom names (default True)
         reorder_atoms_by_residue (bool): change atom order so that all atoms in a residue are stored
             contiguously
         primary_structure (bool): translate primary structure data as well as atomic data
@@ -287,10 +284,7 @@ def pybel_to_mol(pbmol,
 
     for pybatom in pbmol.atoms:
         obres = pybatom.OBAtom.GetResidue()
-        if atom_names:
-            name = obres.GetAtomID(pybatom.OBAtom).strip()
-        else:
-            name = None
+        name = obres.GetAtomID(pybatom.OBAtom).strip()
 
         if pybatom.atomicnum == 67:
             print ("WARNING: openbabel parsed atom serial %d (name:%s) as Holmium; "
@@ -405,8 +399,6 @@ def _string_to_3d_mol(s, fmt, name):
     pbmol.make3D()
     mol = pybel_to_mol(pbmol,
                        name=name,
-                       atom_names=False,
                        primary_structure=False)
-    for atom in mol.atoms:
-        atom.name = atom.elem+str(atom.index)
+    mdt.helpers.atom_name_check(mol)
     return mol


### PR DESCRIPTION
Two fixes for #122:
 - automatically assign unique atom names if names are just generic element names, and
 - Use a `mol2` file for antechamber so that we're sending bond information as well